### PR TITLE
Simplify Node API

### DIFF
--- a/docs/api/v2/node.md
+++ b/docs/api/v2/node.md
@@ -2,9 +2,9 @@
 
 ## Nim API
 
-The Nim Waku API consist of five functions. Some of them have different arity
+The Nim Waku API consist of five methods. Some of them have different arity
 depending on what privacy/bandwidth trade-off the consumer wants to make. These
-five functions are:
+five method are:
 
 1. **Init** - create and start a node.
 2. **Subscribe** - to a topic or a specific content filter.
@@ -19,7 +19,7 @@ proc init*(conf: WakuNodeConf): Future[WakuNode]
   ## Status: Partially implemented.
   ## TODO Take conf as a parameter and return a started WakuNode
 
-proc subscribe*(topic: Topic, handler: TopicHandler)
+method subscribe*(w: WakuNode, topic: Topic, handler: TopicHandler)
   ## Subscribes to a PubSub topic. Triggers handler when receiving messages on
   ## this topic. TopicHandler is a method that takes a topic and a `Message`.
   ##
@@ -27,7 +27,7 @@ proc subscribe*(topic: Topic, handler: TopicHandler)
   ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
   ## passed, not `data` field.
 
-proc subscribe*(contentFilter: ContentFilter, handler: ContentFilterHandler)
+method subscribe*(w: WakuNode, contentFilter: ContentFilter, handler: ContentFilterHandler)
   ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
   ## this content filter. ContentFilter is a method that takes some content
   ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
@@ -37,26 +37,26 @@ proc subscribe*(contentFilter: ContentFilter, handler: ContentFilterHandler)
   ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
   ## ensure Message is passed, not `data` field.
 
-proc unsubscribe*(topic: Topic)
+method unsubscribe*(w: WakuNode, topic: Topic)
   ## Unsubscribe from a topic.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-proc unsubscribe*(contentFilter: ContentFilter)
+method unsubscribe*(w: WakuNode, contentFilter: ContentFilter)
   ## Unsubscribe from a content filter.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-proc publish*(topic: Topic, message: Message)
+method publish*(w: WakuNode, topic: Topic, message: Message)
   ## Publish a `Message` to a PubSub topic.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
   ## passed, not `data` field.
 
-proc publish*(topic: Topic, contentFilter: ContentFilter, message: Message)
+method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message)
   ## Publish a `Message` to a PubSub topic with a specific content filter.
   ## Currently this means a `contentTopic`.
   ##
@@ -65,7 +65,7 @@ proc publish*(topic: Topic, contentFilter: ContentFilter, message: Message)
   ## Message is passed, not `data` field. Also ensure content filter is in
   ## Message.
 
-proc query*(query: HistoryQuery): HistoryResponse
+method query*(w: WakuNode, query: HistoryQuery): HistoryResponse
   ## Queries for historical messages.
   ##
   ## Status: Not yet implemented.

--- a/docs/api/v2/node.md
+++ b/docs/api/v2/node.md
@@ -29,22 +29,38 @@ For now it is assumed that we will require a seperate request-response protocol
 for this, next to the GossipSub domain.
 
 ```Nim
+## Implemented
+##----------------------------------------------------------
 type
-  WakuOptions = object
-    # If there are more capabilities than just light node, we can create a
-    # capabilities field.
-    lightNode: bool
-    topics: seq[WakuTopic]
-    bloomfilter: Bloom # TODO: No longer needed with Gossip?
-    limits: Limits
+  WakuNode* = ref object of RootObj
+  switch*: Switch
+  peerInfo*: PeerInfo
+  libp2pTransportLoops*: seq[Future[void]]
 
-proc init(w: WakuNode, conf: WakuConfig)
-## Initialize the WakuNode.
+proc createWakuNode*(conf: WakuNodeConf): Future[WakuNode] {.async, gcsafe.} =
+## Creates the WakuNode.
+
+proc start*(node: WakuNode, conf: WakuNodeConf) {.async.} =
+## Starts an already created WakuNode.
 ##
 ## When not a light node, this will set up the node to be part of the gossipsub
 ## network with a subscription to the general Waku Topic.
 ## When a light node, this will connect to full node peer(s) with provided
-## `topics` or `bloomfilter` for the full node to filter messages on.
+## `contentFilter` for the full node to filter on. Currently this means
+## `contentTopic`, but this could potentially be `bloomFilter` and other filters
+## as well.
+
+## Not yet implemented / under consideration
+##----------------------------------------------------------
+
+type
+  WakuOptions = object
+  # If there are more capabilities than just light node, we can create a
+  # capabilities field.
+    lightNode: bool
+    topics: seq[WakuTopic]
+    bloomfilter: Bloom # TODO: No longer needed with Gossip?
+    limits: Limits
 
 proc publish(w: WakuNode, topic: WakuTopic, data: seq[byte]): bool
 ## Publish a message with specified `WakuTopic`.

--- a/docs/api/v2/node.md
+++ b/docs/api/v2/node.md
@@ -2,117 +2,76 @@
 
 ## Nim API
 
-### WakuSub API
+The Nim Waku API consist of five functions. Some of them have different arity
+depending on what privacy/bandwidth trade-off the consumer wants to make. These
+five functions are:
 
-This is an internal API to be used by the Waku API. It is practically a small
-layer above GossipSub. And possibly a request/response libp2p protocol.
-
-```Nim
-# TODO: Some init call to set things up?
-method publish*(w: WakuSub, topic: string, data: seq[byte]) {.async.}
-method subscribe*(w: WakuSub, topic: string, handler: TopicHandler) {.async.}
-method unsubscribe*(w: WakuSub, topics: seq[TopicPair]) {.async.}
-
-# TODO: Calls for non GossipSub communication.
-```
-
-### Waku API
-
-This API is very dependend on how the protocol should work for functionality
-such as light nodes (no relaying) and nodes that do not want to get messages
-from all `WakuTopic`s.
-
-See also issue:
-https://github.com/vacp2p/specs/issues/156
-
-For now it is assumed that we will require a seperate request-response protocol
-for this, next to the GossipSub domain.
+1. **Init** - create and start a node.
+2. **Subscribe** - to a topic or a specific content filter.
+3. **Unsubscribe** - to a topic or a specific content filter.
+4. **Publish** - to a topic, or a topic and a specific content filter.
+5. **Query** - for historical messages.
 
 ```Nim
-## Implemented
-##----------------------------------------------------------
-type
-  WakuNode* = ref object of RootObj
-  switch*: Switch
-  peerInfo*: PeerInfo
-  libp2pTransportLoops*: seq[Future[void]]
+proc init*(conf: WakuNodeConf): Future[WakuNode]
+  ## Creates and starts a Waku node.
+  ##
+  ## Status: Partially implemented.
+  ## TODO Take conf as a parameter and return a started WakuNode
 
-proc createWakuNode*(conf: WakuNodeConf): Future[WakuNode] {.async, gcsafe.} =
-## Creates the WakuNode.
+proc subscribe*(topic: Topic, handler: TopicHandler)
+  ## Subscribes to a PubSub topic. Triggers handler when receiving messages on
+  ## this topic. TopicHandler is a method that takes a topic and a `Message`.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+  ## passed, not `data` field.
 
-proc start*(node: WakuNode, conf: WakuNodeConf) {.async.} =
-## Starts an already created WakuNode.
-##
-## When not a light node, this will set up the node to be part of the gossipsub
-## network with a subscription to the general Waku Topic.
-## When a light node, this will connect to full node peer(s) with provided
-## `contentFilter` for the full node to filter on. Currently this means
-## `contentTopic`, but this could potentially be `bloomFilter` and other filters
-## as well.
+proc subscribe*(contentFilter: ContentFilter, handler: ContentFilterHandler)
+  ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
+  ## this content filter. ContentFilter is a method that takes some content
+  ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
+  ## has to match the `ContentTopic`.
 
-## Not yet implemented / under consideration
-##----------------------------------------------------------
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
+  ## ensure Message is passed, not `data` field.
 
-type
-  WakuOptions = object
-  # If there are more capabilities than just light node, we can create a
-  # capabilities field.
-    lightNode: bool
-    topics: seq[WakuTopic]
-    bloomfilter: Bloom # TODO: No longer needed with Gossip?
-    limits: Limits
+proc unsubscribe*(topic: Topic)
+  ## Unsubscribe from a topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
 
-proc publish(w: WakuNode, topic: WakuTopic, data: seq[byte]): bool
-## Publish a message with specified `WakuTopic`.
-##
-## Both full node and light node can use the GossipSub network to publish.
+proc unsubscribe*(contentFilter: ContentFilter)
+  ## Unsubscribe from a content filter.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
 
-proc subscribe(w: WakuNode, topics: seq[WakuTopic], handler: WakuHandler): Identifier
-## Subscribe to the provided `topics`, handler will be called on receival of
-## messages on those topics.
-##
-## In case of a full node, this will be through the GossipSub network (see,
-## subscription in `init`)
-## In case of the light node, this will likely be through a separate request
-## response network where the full node filters out the messages.
+proc publish*(topic: Topic, message: Message)
+  ## Publish a `Message` to a PubSub topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+  ## passed, not `data` field.
 
-proc unsubscribe(id: Identifier): bool
-## Unsubscribe handler for topics.
+proc publish*(topic: Topic, contentFilter: ContentFilter, message: Message)
+  ## Publish a `Message` to a PubSub topic with a specific content filter.
+  ## Currently this means a `contentTopic`.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
+  ## Message is passed, not `data` field. Also ensure content filter is in
+  ## Message.
 
-# Can get rid of the identifiers in subscribe and unsubscribe and track topics +
-# handler like in WakuSub, if that is more convenient.
-
-proc setLightNode(isLightNode: bool)
-## Change light node setting. This might trigger change in subscriptions from
-## the gossip domain to the request response domain and vice versa.
-
-proc setTopicInterest(topics: seq[string])
-## Change the topic interests.
-# TODO: Only valid if light node?
-
-proc setBloomFilter(topics: seq[string])
-## Change the topic interests.
-# TODO: Still required if we have gossip?
+proc query*(query: HistoryQuery): HistoryResponse
+  ## Queries for historical messages.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
 ```
 
 ## JSON RPC
 
-**TODO: Data should be RPC Messages / bytes**
-**TODO: Enable topic handler**
-
-Call signatures:
-
-```Nim
-proc waku_version(): string
-proc waku_info(): WakuInfo
-proc waku_publish(topic: string, message: string): bool
-proc waku_subscribe(topics: seq[string]): Identifier
-proc waku_unsubscribe(id: Identifier): bool
-
-# TODO: Do we still want to be able to pull for data also?
-# E.g. a getTopicsMessages(topics: seq[string])?
-
-proc waku_setLightNode(isLightNode: bool)
-proc waku_setTopicInterest(topics: seq[string])
-proc waku_setBloomFilter(topics: seq[string])
-```
+### TODO To specify

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -233,63 +233,87 @@ proc init*() {.async.} =
   waitFor network.start(conf)
   runForever()
 
-##proc init*(conf: WakuNodeConf): Future[WakuNode]
+# TODO Replace init above
+method init2*(conf: WakuNodeConf): Future[WakuNode] {.async.} =
   ## Creates and starts a Waku node.
   ##
   ## Status: Partially implemented.
   ## TODO Take conf as a parameter and return a started WakuNode
+  let node = await createWakuNode(conf)
+  await node.start(conf)
+  return node
 
-##method subscribe*(w: WakuNode, topic: Topic, handler: TopicHandler) =
-## Subscribes to a PubSub topic. Triggers handler when receiving messages on
-## this topic. TopicHandler is a method that takes a topic and a `Message`.
-##
-## Status: Not yet implemented.
-## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
-## passed, not `data` field.
+type Topic* = string
+type Message* = seq[byte]
+type ContentFilter* = object
+    contentTopic*: string
+type TopicHandler* = proc(topic: Topic, message: Message)
+type ContentFilterHandler* = proc(contentFilter: ContentFilter, message: Message)
 
-##method subscribe*(w: WakuNode, contentFilter: ContentFilter, handler: ContentFilterHandler)
-## Subscribes to a ContentFilter. Triggers handler when receiving messages on
-## this content filter. ContentFilter is a method that takes some content
-## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
-## has to match the `ContentTopic`.
+type HistoryQuery = object
+    xxx*: seq[byte]
 
-## Status: Not yet implemented.
-## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
-## ensure Message is passed, not `data` field.
+type HistoryResponse = object
+    xxx*: seq[byte]
 
-##method unsubscribe*(w: WakuNode, topic: Topic)
-## Unsubscribe from a topic.
-##
-## Status: Not yet implemented.
-## TODO Implement.
+method subscribe*(w: WakuNode, topic: Topic, handler: TopicHandler) =
+  echo "NYI"
+  ## Subscribes to a PubSub topic. Triggers handler when receiving messages on
+  ## this topic. TopicHandler is a method that takes a topic and a `Message`.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+  ## passed, not `data` field.
 
-##method unsubscribe*(w: WakuNode, contentFilter: ContentFilter)
-## Unsubscribe from a content filter.
-##
-## Status: Not yet implemented.
-## TODO Implement.
+method subscribe*(w: WakuNode, contentFilter: ContentFilter, handler: ContentFilterHandler) =
+  echo "NYI"
+  ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
+  ## this content filter. ContentFilter is a method that takes some content
+  ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
+  ## has to match the `ContentTopic`.
 
-##method publish*(w: WakuNode, topic: Topic, message: Message)
-## Publish a `Message` to a PubSub topic.
-##
-## Status: Not yet implemented.
-## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
-## passed, not `data` field.
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
+  ## ensure Message is passed, not `data` field.
 
-##method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message)
-## Publish a `Message` to a PubSub topic with a specific content filter.
-## Currently this means a `contentTopic`.
-##
-## Status: Not yet implemented.
-## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
-## Message is passed, not `data` field. Also ensure content filter is in
-## Message.
+method unsubscribe*(w: WakuNode, topic: Topic) =
+  echo "NYI"
+  ## Unsubscribe from a topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
 
-##method query*(w: WakuNode, query: HistoryQuery): HistoryResponse
-## Queries for historical messages.
-##
-## Status: Not yet implemented.
-## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
+method unsubscribe*(w: WakuNode, contentFilter: ContentFilter) =
+  echo "NYI"
+  ## Unsubscribe from a content filter.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
+
+method publish*(w: WakuNode, topic: Topic, message: Message) =
+  echo "NYI"
+  ## Publish a `Message` to a PubSub topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+  ## passed, not `data` field.
+
+method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message) =
+  echo "NYI"
+  ## Publish a `Message` to a PubSub topic with a specific content filter.
+  ## Currently this means a `contentTopic`.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
+  ## Message is passed, not `data` field. Also ensure content filter is in
+  ## Message.
+
+method query*(w: WakuNode, query: HistoryQuery): HistoryResponse =
+  echo "NYI"
+  ## Queries for historical messages.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
 
 when isMainModule:
   discard init()

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -248,48 +248,48 @@ proc init*() {.async.} =
 ## passed, not `data` field.
 
 ##method subscribe*(w: WakuNode, contentFilter: ContentFilter, handler: ContentFilterHandler)
-  ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
-  ## this content filter. ContentFilter is a method that takes some content
-  ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
-  ## has to match the `ContentTopic`.
+## Subscribes to a ContentFilter. Triggers handler when receiving messages on
+## this content filter. ContentFilter is a method that takes some content
+## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
+## has to match the `ContentTopic`.
 
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
-  ## ensure Message is passed, not `data` field.
+## Status: Not yet implemented.
+## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
+## ensure Message is passed, not `data` field.
 
 ##method unsubscribe*(w: WakuNode, topic: Topic)
-  ## Unsubscribe from a topic.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement.
+## Unsubscribe from a topic.
+##
+## Status: Not yet implemented.
+## TODO Implement.
 
 ##method unsubscribe*(w: WakuNode, contentFilter: ContentFilter)
-  ## Unsubscribe from a content filter.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement.
+## Unsubscribe from a content filter.
+##
+## Status: Not yet implemented.
+## TODO Implement.
 
 ##method publish*(w: WakuNode, topic: Topic, message: Message)
-  ## Publish a `Message` to a PubSub topic.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
-  ## passed, not `data` field.
+## Publish a `Message` to a PubSub topic.
+##
+## Status: Not yet implemented.
+## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+## passed, not `data` field.
 
 ##method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message)
-  ## Publish a `Message` to a PubSub topic with a specific content filter.
-  ## Currently this means a `contentTopic`.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
-  ## Message is passed, not `data` field. Also ensure content filter is in
-  ## Message.
+## Publish a `Message` to a PubSub topic with a specific content filter.
+## Currently this means a `contentTopic`.
+##
+## Status: Not yet implemented.
+## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
+## Message is passed, not `data` field. Also ensure content filter is in
+## Message.
 
 ##method query*(w: WakuNode, query: HistoryQuery): HistoryResponse
-  ## Queries for historical messages.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
+## Queries for historical messages.
+##
+## Status: Not yet implemented.
+## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
 
 when isMainModule:
   discard init()

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -223,11 +223,73 @@ proc start*(node: WakuNode, conf: WakuNodeConf) {.async.} =
 
 #proc run(conf: WakuNodeConf) {.async, gcsafe.} =
 
+## Public API
+##
+
+# TODO Take conf as a parameter and return a started WakuNode
 proc init*() {.async.} =
   let conf = WakuNodeConf.load()
   let network = await createWakuNode(conf)
   waitFor network.start(conf)
   runForever()
+
+##proc init*(conf: WakuNodeConf): Future[WakuNode]
+  ## Creates and starts a Waku node.
+  ##
+  ## Status: Partially implemented.
+  ## TODO Take conf as a parameter and return a started WakuNode
+
+##proc subscribe*(topic: Topic, handler: TopicHandler) =
+## Subscribes to a PubSub topic. Triggers handler when receiving messages on
+## this topic. TopicHandler is a method that takes a topic and a `Message`.
+##
+## Status: Not yet implemented.
+## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+## passed, not `data` field.
+
+##proc subscribe*(contentFilter: ContentFilter, handler: ContentFilterHandler)
+  ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
+  ## this content filter. ContentFilter is a method that takes some content
+  ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
+  ## has to match the `ContentTopic`.
+
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
+  ## ensure Message is passed, not `data` field.
+
+##proc unsubscribe*(topic: Topic)
+  ## Unsubscribe from a topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
+
+##proc unsubscribe*(contentFilter: ContentFilter)
+  ## Unsubscribe from a content filter.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement.
+
+##proc publish*(topic: Topic, message: Message)
+  ## Publish a `Message` to a PubSub topic.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
+  ## passed, not `data` field.
+
+##proc publish*(topic: Topic, contentFilter: ContentFilter, message: Message)
+  ## Publish a `Message` to a PubSub topic with a specific content filter.
+  ## Currently this means a `contentTopic`.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and `publish`, and ensure
+  ## Message is passed, not `data` field. Also ensure content filter is in
+  ## Message.
+
+##proc query*(query: HistoryQuery): HistoryResponse
+  ## Queries for historical messages.
+  ##
+  ## Status: Not yet implemented.
+  ## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
 
 when isMainModule:
   discard init()

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -239,7 +239,7 @@ proc init*() {.async.} =
   ## Status: Partially implemented.
   ## TODO Take conf as a parameter and return a started WakuNode
 
-##proc subscribe*(topic: Topic, handler: TopicHandler) =
+##method subscribe*(w: WakuNode, topic: Topic, handler: TopicHandler) =
 ## Subscribes to a PubSub topic. Triggers handler when receiving messages on
 ## this topic. TopicHandler is a method that takes a topic and a `Message`.
 ##
@@ -247,7 +247,7 @@ proc init*() {.async.} =
 ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
 ## passed, not `data` field.
 
-##proc subscribe*(contentFilter: ContentFilter, handler: ContentFilterHandler)
+##method subscribe*(w: WakuNode, contentFilter: ContentFilter, handler: ContentFilterHandler)
   ## Subscribes to a ContentFilter. Triggers handler when receiving messages on
   ## this content filter. ContentFilter is a method that takes some content
   ## filter, specifically with `ContentTopic`, and a `Message`. The `Message`
@@ -257,26 +257,26 @@ proc init*() {.async.} =
   ## TODO Implement as wrapper around `waku_protocol` and `subscribe` above, and
   ## ensure Message is passed, not `data` field.
 
-##proc unsubscribe*(topic: Topic)
+##method unsubscribe*(w: WakuNode, topic: Topic)
   ## Unsubscribe from a topic.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-##proc unsubscribe*(contentFilter: ContentFilter)
+##method unsubscribe*(w: WakuNode, contentFilter: ContentFilter)
   ## Unsubscribe from a content filter.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-##proc publish*(topic: Topic, message: Message)
+##method publish*(w: WakuNode, topic: Topic, message: Message)
   ## Publish a `Message` to a PubSub topic.
   ##
   ## Status: Not yet implemented.
   ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
   ## passed, not `data` field.
 
-##proc publish*(topic: Topic, contentFilter: ContentFilter, message: Message)
+##method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message)
   ## Publish a `Message` to a PubSub topic with a specific content filter.
   ## Currently this means a `contentTopic`.
   ##
@@ -285,7 +285,7 @@ proc init*() {.async.} =
   ## Message is passed, not `data` field. Also ensure content filter is in
   ## Message.
 
-##proc query*(query: HistoryQuery): HistoryResponse
+##method query*(w: WakuNode, query: HistoryQuery): HistoryResponse
   ## Queries for historical messages.
   ##
   ## Status: Not yet implemented.


### PR DESCRIPTION
This simplifies the Node API into five main functions. Depending on the desired privacy/resource constraints, a node will choose how they use it.

Addresses https://github.com/status-im/nim-waku/issues/61

Also stubbed these out in `wakunode` module.

Removed JSONRPC so we can nail this first, then create a mirror based on it.
