### PR TITLE
Node API: Implement publish

### DIFF
--- a/docs/api/v2/node.md
+++ b/docs/api/v2/node.md
@@ -16,8 +16,7 @@ five method are:
 proc init*(conf: WakuNodeConf): Future[WakuNode]
   ## Creates and starts a Waku node.
   ##
-  ## Status: Partially implemented.
-  ## TODO Take conf as a parameter and return a started WakuNode
+  ## Status: Implemented.
 
 method subscribe*(w: WakuNode, topic: Topic, handler: TopicHandler)
   ## Subscribes to a PubSub topic. Triggers handler when receiving messages on

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -15,15 +15,18 @@ import ../../waku/node/v2/wakunode2
 # Loads the config in `waku/node/v2/config.nim`
 let conf = WakuNodeConf.load()
 
-# Create and start the node
-#proc runBackground(conf: WakuNodeConf) {.async.} =
-#  init(conf)
-#  runForever()
+# Node operations happens asynchronously
+proc runBackground(conf: WakuNodeConf) {.async.} =
+  # Create and start the node
+  let node = await init(conf)
 
-discard init(conf)
+  # Subscribe to a topic
+  let topic = "foobar"
+  proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    info "Hit subscribe handler", topic=topic, data=data
+  node.subscribe(topic, handler)
 
-echo("Do stuff after with node")
-
+discard runBackground(conf)
 runForever()
 
 # TODO Lets start with Nim Node API first

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -3,6 +3,7 @@
 
 import confutils, chronicles, chronos, os
 
+import stew/shims/net as stewNet
 import libp2p/crypto/crypto
 import libp2p/crypto/secp
 import eth/keys
@@ -14,16 +15,18 @@ import ../../waku/node/v2/wakunode2
 # Loads the config in `waku/node/v2/config.nim`
 let conf = WakuNodeConf.load()
 
-# Start the node
-# Running this should give you output like this:
-# INF Listening on tid=5719 full=/ip4/127.0.0.1/tcp/60000/p2p/16Uiu2HAmNiAqr1cwhyntotP9fiSDyBvfKtB4ZiaDsrkipSCoKCB4
-# TODO Run this in background
-# See https://github.com/status-im/nim-waku/pull/59
-proc runBackground(conf: WakuNodeConf) {.async.} =
-  run(conf)
-  runForever()
+# Create and start the node
+#proc runBackground(conf: WakuNodeConf) {.async.} =
+#  init(conf)
+#  runForever()
 
-discard runBackground(conf)
+discard init(conf)
+
+echo("Do stuff after with node")
+
+runForever()
+
+# TODO Lets start with Nim Node API first
 
 # To do more operations on this node, we can do this in two ways:
 # - We can use the Nim Node API, which is currently not exposed
@@ -35,17 +38,17 @@ discard runBackground(conf)
 # Here's how to do it with JSON RPC
 
 # Get RPC call signatures in Nim
-from strutils import rsplit
-template sourceDir: string = currentSourcePath.parentDir().parentDir().rsplit(DirSep, 1)[0]
-const sigWakuPath = sourceDir / "waku" / "node" / "v2" / "rpc" / "wakucallsigs.nim"
+#from strutils import rsplit
+#template sourceDir: string = currentSourcePath.parentDir().parentDir().rsplit(DirSep, 1)[0]
+#const sigWakuPath = sourceDir / "waku" / "node" / "v2" / "rpc" / "wakucallsigs.nim"
 
-createRpcSigs(RpcHttpClient, sigWakuPath)
+#createRpcSigs(RpcHttpClient, sigWakuPath)
 
 # Create RPC Client and connect to it
-var node = newRpcHttpClient()
-waitfor node.connect("localhost", Port(8547))
+#var node = newRpcHttpClient()
+#waitfor node.connect("localhost", Port(8547))
 
 # TODO Do something with res
-var res = waitFor node.wakuSubscribe("apptopic")
+#var res = waitFor node.wakuSubscribe("apptopic")
 
 # TODO Use publish as well

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -23,8 +23,12 @@ proc runBackground(conf: WakuNodeConf) {.async.} =
   # Subscribe to a topic
   let topic = "foobar"
   proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-    info "Hit subscribe handler", topic=topic, data=data
+    info "Hit subscribe handler", topic=topic, data=data, decoded=cast[string](data)
   node.subscribe(topic, handler)
+
+  # Publish to a topic
+  let message = cast[seq[byte]]("hello world")
+  node.publish(topic, message)
 
 discard runBackground(conf)
 runForever()

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -286,12 +286,13 @@ method unsubscribe*(w: WakuNode, contentFilter: ContentFilter) =
   ## TODO Implement.
 
 method publish*(w: WakuNode, topic: Topic, message: Message) =
-  echo "NYI"
   ## Publish a `Message` to a PubSub topic.
   ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_protocol`, and ensure Message is
-  ## passed, not `data` field.
+  ## Status: Partially implemented.
+  ## TODO: Esure Message is passed, not seq[byte] `data` field.
+  let wakuSub = w.switch.pubSub.get()
+  # XXX Consider awaiting here
+  discard wakuSub.publish(topic, message)
 
 method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message) =
   echo "NYI"

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -218,19 +218,8 @@ proc start*(node: WakuNode, conf: WakuNodeConf) {.async.} =
         addTimer(Moment.fromNow(2.seconds), logMetrics)
       addTimer(Moment.fromNow(2.seconds), logMetrics)
 
-# TODO Get rid of this
-# runForever()
-
-#proc run(conf: WakuNodeConf) {.async, gcsafe.} =
-
 ## Public API
 ##
-
-# TODO Take conf as a parameter and return a started WakuNode
-#proc init*() {.async.} =
-#  let conf = WakuNodeConf.load()
-#  let network = await createWakuNode(conf)
-#  waitFor network.start(conf)
 
 method init*(conf: WakuNodeConf): Future[WakuNode] {.async.} =
   ## Creates and starts a Waku node.

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -227,18 +227,14 @@ proc start*(node: WakuNode, conf: WakuNodeConf) {.async.} =
 ##
 
 # TODO Take conf as a parameter and return a started WakuNode
-proc init*() {.async.} =
-  let conf = WakuNodeConf.load()
-  let network = await createWakuNode(conf)
-  waitFor network.start(conf)
-  runForever()
+#proc init*() {.async.} =
+#  let conf = WakuNodeConf.load()
+#  let network = await createWakuNode(conf)
+#  waitFor network.start(conf)
 
-# TODO Replace init above
-method init2*(conf: WakuNodeConf): Future[WakuNode] {.async.} =
+method init*(conf: WakuNodeConf): Future[WakuNode] {.async.} =
   ## Creates and starts a Waku node.
   ##
-  ## Status: Partially implemented.
-  ## TODO Take conf as a parameter and return a started WakuNode
   let node = await createWakuNode(conf)
   await node.start(conf)
   return node
@@ -316,4 +312,6 @@ method query*(w: WakuNode, query: HistoryQuery): HistoryResponse =
   ## TODO Implement as wrapper around `waku_protocol` and send `RPCMsg`.
 
 when isMainModule:
-  discard init()
+  let conf = WakuNodeConf.load()
+  discard init(conf)
+  runForever()


### PR DESCRIPTION
Addresses https://github.com/status-im/nim-waku/issues/86

However, this is still using Message as seq[byte] / data field. This needs to be addressed at protocol level; separate issue to come.

Running examples we can see that basic loopback publish/subscribe works.

```
INF 2020-07-28 13:15:21+08:00 Listening on                               tid=10712 full=/ip4/0.0.0.0/tcp/60000/p2p/16Uiu2HAmDaf6KPnZD6GpriEow4tbFNu8AN51baJSLGdNkSxcC2ux
DBG 2020-07-28 13:15:21+08:00 subscribe                                  tid=10712 topic=WakuSub
DBG 2020-07-28 13:15:21+08:00 publish                                    tid=10712 topic=WakuSub
INF 2020-07-28 13:15:21+08:00 Hit subscribe handler                      tid=10712 topic=foobar data="@[104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]" decoded="hello world"
```