### PR TITLE
enhancement/v2-test-make

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -54,7 +54,7 @@ task protocol2, "Build the experimental Waku protocol":
   buildBinary "waku_protocol2", "waku/protocol/v2/", "-d:chronicles_log_level=TRACE"
 
 task wakutest2, "Build Experimental Waku tests":
-  let name = "v2/test_waku"
+  let name = "v2/all_tests_v2"
   buildBinary name, "tests/", "-d:chronicles_log_level=DEBUG"
   exec "build/" & name
 


### PR DESCRIPTION
@oskarth Is this what you meant? I think it probably makes sense to clean up the nimble file a bit along with the make file beyond this.

Why do we have, `test`, `test2`, `wakutest2`. Seems a bit confusing.