### PR TITLE
Refactor Makefile and remove old task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ protocol2:
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim protocol2 $(NIM_PARAMS) waku.nims
 
-wakutest2:
+test2:
 	echo -e $(BUILD_MSG) "build/$@" && \
-		$(ENV_SCRIPT) nim wakutest2 $(NIM_PARAMS) waku.nims
+		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) waku.nims
 
 wakuexample2:
 	echo -e $(BUILD_MSG) "build/$@" && \

--- a/waku.nimble
+++ b/waku.nimble
@@ -53,11 +53,6 @@ task wakusim, "Build Waku simulation tools":
 task protocol2, "Build the experimental Waku protocol":
   buildBinary "waku_protocol2", "waku/protocol/v2/", "-d:chronicles_log_level=TRACE"
 
-task wakutest2, "Build Experimental Waku tests":
-  let name = "v2/test_waku"
-  buildBinary name, "tests/", "-d:chronicles_log_level=DEBUG"
-  exec "build/" & name
-
 task wakunode2, "Build Experimental Waku cli":
   buildBinary "wakunode2", "waku/node/v2/", "-d:chronicles_log_level=TRACE"
 


### PR DESCRIPTION
`make test2` runs Waku v2 tests now. `make test` still runs all tests for CI.