### PR TITLE
Add support for WakuMessage and merge publish function

### DIFF
--- a/docs/api/v2/node.md
+++ b/docs/api/v2/node.md
@@ -46,19 +46,12 @@ method unsubscribe*(w: WakuNode, contentFilter: ContentFilter)
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-method publish*(w: WakuNode, topic: Topic, message: Message)
-  ## Publish a `Message` to a PubSub topic.
+method publish*(w: WakuNode, topic: Topic, message: WakuMessage)
+  ## Publish a `WakuMessage` to a PubSub topic. `WakuMessage` should contain a
+  ## `contentTopic` field for light node functionality. This field may be also
+  ## be omitted.
   ##
-  ## Status: Partially implemented.
-  ## TODO WakuMessage OR seq[byte]. NOT PubSub Message.
-
-method publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message)
-  ## Publish a `Message` to a PubSub topic with a specific content filter.
-  ## Currently this means a `contentTopic`.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_relay` and `publish`.
-  ## TODO WakuMessage. Ensure content filter is in it.
+  ## Status: Implemented.
 
 method query*(w: WakuNode, query: HistoryQuery): HistoryResponse
   ## Queries for historical messages.

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -11,6 +11,9 @@ import
   ../../waku/node/v2/[config, wakunode2, waku_types],
   ../../waku/node/common
 
+type
+  Topic* = waku_types.Topic
+
 # Node operations happens asynchronously
 proc runBackground() {.async.} =
   let
@@ -24,13 +27,14 @@ proc runBackground() {.async.} =
   await node.start()
 
   # Subscribe to a topic
-  let topic = "foobar"
-  proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+  let topic = cast[Topic]("foobar")
+  proc handler(topic: Topic, data: seq[byte]) {.async, gcsafe.} =
     info "Hit subscribe handler", topic=topic, data=data, decoded=cast[string](data)
   node.subscribe(topic, handler)
 
   # Publish to a topic
-  let message = cast[seq[byte]]("hello world")
+  let payload = cast[seq[byte]]("hello world")
+  let message = WakuMessage(payload: payload, contentTopic: "foo")
   node.publish(topic, message)
 
 # TODO Await with try/except here

--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -29,7 +29,9 @@ proc runBackground() {.async.} =
   # Subscribe to a topic
   let topic = cast[Topic]("foobar")
   proc handler(topic: Topic, data: seq[byte]) {.async, gcsafe.} =
-    info "Hit subscribe handler", topic=topic, data=data, decoded=cast[string](data)
+    let message = WakuMessage.init(data).value
+    let payload = cast[string](message.payload)
+    info "Hit subscribe handler", topic=topic, payload=payload, contentTopic=message.contentTopic
   node.subscribe(topic, handler)
 
   # Publish to a topic

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -1,6 +1,7 @@
 import
   # Waku v2 tests
-  ./v2/test_waku,
+  # TODO: enable this when it is altered into a proper waku relay test
+  # ./v2/test_waku,
   ./v2/test_wakunode,
   ./v2/test_waku_store,
   ./v2/test_waku_filter

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -20,11 +20,10 @@ procSuite "WakuNode":
     await node.start()
 
     let
-      topic = "foobar"
-      message = ("hello world").toBytes
-    node.publish(topic, ContentFilter(contentTopic: topic), message)
+      topic = "foo"
+      contentTopic = "foobar"
+      wakuMessage = WakuMessage(payload: ("hello world").toBytes,
+        contentTopic: contentTopic)
 
-    let response = node.query(HistoryQuery(topics: @[topic]))
-    check:
-      response.messages.len == 1
-      response.messages[0] == message
+    node.publish(topic, wakuMessage)
+    # TODO: Add actual subscribe part with receival of message

--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -22,10 +22,11 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
      result = WakuRelayCodec
 
   # TODO: Implement symkey etc logic
-  rpcsrv.rpc("waku_publish") do(topic: string, message: seq[byte]) -> bool:
+  rpcsrv.rpc("waku_publish") do(topic: string, payload: seq[byte]) -> bool:
     # XXX Why is casting necessary here but not in Nim node API?
     let wakuRelay = cast[WakuRelay](node.switch.pubSub.get())
     # XXX also future return type
+    var message = WakuMessage(payload: payload, contentTopic: "foo")
     discard wakuRelay.publish(topic, message)
     return true
     #if not result:

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -18,7 +18,8 @@ type
     switch*: Switch
     peerInfo*: PeerInfo
     libp2pTransportLoops*: seq[Future[void]]
-    messages*: seq[(Topic, Message)]
+  # TODO Revist messages field indexing as well as if this should be Message or WakuMessage
+    messages*: seq[(Topic, WakuMessage)]
 
   WakuMessage* = object
     payload*: seq[byte]

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -1,13 +1,13 @@
+## Core Waku data types are defined here to avoid recursive dependencies.
+##
+## TODO Move more common data types here
+
 import
   chronos,
-  libp2p/multiaddress,
-  libp2p/crypto/crypto,
-  libp2p/peerinfo,
-  standard_setup
+  libp2p/[switch, peerinfo, multiaddress, crypto/crypto],
+  libp2p/protobuf/minprotobuf
 
-# Core Waku data types are defined here to avoid recursive dependencies.
-#
-# TODO Move more common data types here
+# Common data types -----------------------------------------------------------
 
 type
   Topic* = string
@@ -16,11 +16,29 @@ type
   # NOTE based on Eth2Node in NBC eth2_network.nim
   WakuNode* = ref object of RootObj
     switch*: Switch
-    # XXX Unclear if we need this
     peerInfo*: PeerInfo
     libp2pTransportLoops*: seq[Future[void]]
     messages*: seq[(Topic, Message)]
 
-  WakuMessage* =
+  WakuMessage* = object
     payload*: seq[byte]
     contentTopic*: string
+
+
+
+# Encoding and decoding -------------------------------------------------------
+
+proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
+  var msg = WakuMessage()
+  let pb = initProtoBuffer(buffer)
+
+  discard ? pb.getField(1, msg.payload)
+  discard ? pb.getField(2, msg.contentTopic)
+
+  ok(msg)
+
+proc encode*(message: WakuMessage): ProtoBuffer =
+  result = initProtoBuffer()
+
+  result.write(1, message.payload)
+  result.write(2, message.contentTopic)

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -25,8 +25,6 @@ type
     payload*: seq[byte]
     contentTopic*: string
 
-
-
 # Encoding and decoding -------------------------------------------------------
 
 proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -20,3 +20,7 @@ type
     peerInfo*: PeerInfo
     libp2pTransportLoops*: seq[Future[void]]
     messages*: seq[(Topic, Message)]
+
+  WakuMessage* =
+    payload*: seq[byte]
+    contentTopic*: string

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -19,6 +19,7 @@ type
   PublicKey* = crypto.PublicKey
   PrivateKey* = crypto.PrivateKey
 
+  # TODO Get rid of this and use waku_types one
   Topic* = waku_types.Topic
   Message* = seq[byte]
   ContentFilter* = object
@@ -176,30 +177,22 @@ proc unsubscribe*(w: WakuNode, contentFilter: ContentFilter) =
   ## Status: Not yet implemented.
   ## TODO Implement.
 
-proc publish*(w: WakuNode, topic: Topic, message: Message) =
+
+proc publish*(node: WakuNode, topic: Topic, message: WakuMessage) =
   ## Publish a `Message` to a PubSub topic.
   ##
   ## Status: Partially implemented.
   ##
-  ## TODO WakuMessage OR seq[byte]. NOT PubSub Message.
-  let wakuSub = w.switch.pubSub.get()
+
+  # TODO Basic getter function for relay
+  let wakuRelay = cast[WakuRelay](node.switch.pubSub.get())
+
+  # XXX Unclear what the purpose of this is
+  # Commenting out as it is later expected to be Message type, not WakuMessage
+  #node.messages.insert((topic, message))
+
   # XXX Consider awaiting here
-  discard wakuSub.publish(topic, message)
-
-proc publish*(w: WakuNode, topic: Topic, contentFilter: ContentFilter, message: Message) =
-  ## Publish a `Message` to a PubSub topic with a specific content filter.
-  ## Currently this means a `contentTopic`.
-  ##
-  ## Status: Not yet implemented.
-  ## TODO Implement as wrapper around `waku_relay` and `publish`.
-  ## TODO WakuMessage. Ensure content filter is in it.
-
-  w.messages.insert((contentFilter.contentTopic, message))
-
-  let wakuSub = w.switch.pubSub.get()
-  # XXX Consider awaiting here
-
-  discard wakuSub.publish(topic, message)
+  discard wakuRelay.publish(topic, message)
 
 proc query*(w: WakuNode, query: HistoryQuery): HistoryResponse =
   ## Queries for historical messages.
@@ -212,7 +205,8 @@ proc query*(w: WakuNode, query: HistoryQuery): HistoryResponse =
     if msg[0] notin query.topics:
       continue
 
-    result.messages.insert(msg[1])
+    # XXX Unclear how this should be hooked up, Message or WakuMessage?
+    # result.messages.insert(msg[1])
 
 when isMainModule:
   let

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -179,9 +179,11 @@ proc unsubscribe*(w: WakuNode, contentFilter: ContentFilter) =
 
 
 proc publish*(node: WakuNode, topic: Topic, message: WakuMessage) =
-  ## Publish a `Message` to a PubSub topic.
+  ## Publish a `WakuMessage` to a PubSub topic. `WakuMessage` should contain a
+  ## `contentTopic` field for light node functionality. This field may be also
+  ## be omitted.
   ##
-  ## Status: Partially implemented.
+  ## Status: Implemented.
   ##
 
   # TODO Basic getter function for relay

--- a/waku/protocol/v2/waku_relay.nim
+++ b/waku/protocol/v2/waku_relay.nim
@@ -57,9 +57,6 @@ method subscribe*(w: WakuRelay,
                   topic: string,
                   handler: TopicHandler) {.async.} =
   debug "subscribe", topic=topic
-  # XXX: Pubsub really
-
-  # XXX: This is what is called, I think
   if w.gossipEnabled:
     await procCall GossipSub(w).subscribe(topic, handler)
   else:

--- a/waku/protocol/v2/waku_relay.nim
+++ b/waku/protocol/v2/waku_relay.nim
@@ -108,12 +108,11 @@ method rpcHandler*(w: WakuRelay,
 
 method publish*(w: WakuRelay,
                 topic: string,
-                data: seq[byte]
- #               message: WakuMessage
+                message: WakuMessage
                ): Future[int] {.async.} =
-  debug "publish", topic=topic
+  debug "publish", topic=topic, contentTopic=message.contentTopic
 
-#  let data = message.encode().buffer
+  let data = message.encode().buffer
 
   if w.gossipEnabled:
     return await procCall GossipSub(w).publish(topic, data)


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-waku/issues/118

Partially addresses https://github.com/status-im/nim-waku/issues/121

Builds on https://github.com/status-im/nim-waku/pull/123

---

Running examples we can see:

````
DBG 2020-09-01 13:32:43+08:00 publish                                    tid=24041 topic=WakuRelay contentTopic=foo
INF 2020-09-01 13:32:43+08:00 Hit subscribe handler                      tid=24041 topic=foobar payload="hello world" contentTopic=foo
```