### PR TITLE
Remove filter parts from relay as this is obsolete (moved to WakuNode)

### DIFF
--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -129,9 +129,6 @@ proc start*(node: WakuNode) {.async.} =
   let storeProto = WakuStore.init()
   node.switch.mount(storeProto)
 
-  let wakuRelay = cast[WakuRelay](node.switch.pubSub.get())
-  wakuRelay.addFilter("store", storeProto.filter())
-
   # TODO Get this from WakuNode obj
   let peerInfo = node.peerInfo
   let id = peerInfo.peerId.pretty

--- a/waku/protocol/v2/waku_relay.nim
+++ b/waku/protocol/v2/waku_relay.nim
@@ -4,13 +4,11 @@
 ## Instead, it should likely be on top of GossipSub with a similar interface.
 
 import
-  std/[strutils, tables],
+  std/strutils,
   chronos, chronicles, metrics,
-  libp2p/protocols/pubsub/[pubsub, pubsubpeer, floodsub, gossipsub],
+  libp2p/protocols/pubsub/[pubsub, floodsub, gossipsub],
   libp2p/protocols/pubsub/rpc/messages,
-  libp2p/stream/connection,
-  ../../node/v2/waku_types,
-  ./filter
+  libp2p/stream/connection
 
 declarePublicGauge total_messages, "number of messages received"
 
@@ -93,6 +91,3 @@ method stop*(w: WakuRelay) {.async.} =
     await procCall GossipSub(w).stop()
   else:
     await procCall FloodSub(w).stop()
-
-proc addFilter*(w: WakuRelay, name: string, filter: Filter) =
-  w.filters.subscribe(name, filter)


### PR DESCRIPTION
CI got broken because of two PR merges without rebasing first the second. 

Fixes this as does https://github.com/status-im/nim-waku/pull/131, but by just removing filters from WakuRelay completely.