### PR TITLE
WIP: Enhancement/use node for rpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,10 @@ wakusim2: | build deps wakunode2
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim wakusim2 $(NIM_PARAMS) waku.nims
 
+scripts2: | build deps wakunode2
+	echo -e $(BUILD_MSG) "build/$@" && \
+		$(ENV_SCRIPT) nim scripts2 $(NIM_PARAMS) waku.nims
+
 protocol2:
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim protocol2 $(NIM_PARAMS) waku.nims

--- a/docs/tutorial/nangang.md
+++ b/docs/tutorial/nangang.md
@@ -1,0 +1,36 @@
+# Nangang Test
+
+Nangang is the first internal testnet. See
+https://github.com/vacp2p/research/issues/43 for more.
+
+## How to
+
+Build:
+
+```
+make wakunode2
+make scripts2
+```
+
+Run two nodes and connect them:
+
+```
+# Starts listening on 60000 with RPC server on 8545.
+# Note the "listening on address" in logs.
+./build/wakunode2 --ports-shift:0`
+
+# Run another node with staticnode argument
+./build/wakunode2 --ports-shift:1 --staticnode:/ip4/0.0.0.0/tcp/60000/p2p/16Uiu2HAmF4tuht6fmna6uDqoSMgFqhUrdaVR6VQRyGr6sCpfS2jp
+```
+
+You should see your nodes connecting.
+
+Do basic RPC calls:
+
+```
+/build/rpc_subscribe 8545
+/build/rpc_subscribe 8546
+/build/rpc_publish 8545 # enter your message in STDIN
+```
+
+You should see other node receive something.

--- a/waku.nimble
+++ b/waku.nimble
@@ -64,6 +64,10 @@ task wakusim2, "Build Experimental Waku simulation tools":
   buildBinary "quicksim2", "waku/node/v2/", "-d:chronicles_log_level=DEBUG"
   buildBinary "start_network2", "waku/node/v2/", "-d:chronicles_log_level=TRACE"
 
+task scripts2, "Build Waku v2 scripts":
+  buildBinary "rpc_publish", "waku/node/v2/rpc/", "-d:chronicles_log_level=DEBUG"
+  buildBinary "rpc_subscribe", "waku/node/v2/rpc/", "-d:chronicles_log_level=DEBUG"
+
 task wakuexample2, "Build example Waku usage":
   let name = "basic2"
   buildBinary name, "examples/v2/", "-d:chronicles_log_level=DEBUG"

--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -1,8 +1,11 @@
 import
   os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
+  stew/shims/net as stewNet, stew/byteutils,
   libp2p/protobuf/minprotobuf,
   eth/common as eth_common, eth/keys,
   system,
+  strformat,
+  ../waku_types,
   options
 
 from strutils import rsplit
@@ -18,14 +21,25 @@ if paramCount() < 1:
 let rpcPort = Port(parseInt(paramStr(1)))
 
 echo "Please enter your message:"
-let message = readLine(stdin)
-echo "Message is:", message
+let raw_input = readLine(stdin)
+let input = fmt"{raw_input}"
+echo "Input is:", input
 
-var node = newRpcHttpClient()
-waitfor node.connect("localhost", rpcPort)
+var client = newRpcHttpClient()
+waitfor client.connect("localhost", rpcPort)
 
 # Subscribe ourselves to topic
 #var res = node.wakuSubscribe("waku")
 
+let
+  pubSubTopic = "waku"
+  contentTopic = "foobar"
+  contentFilter = ContentFilter(topics: @[contentTopic])
+  message = WakuMessage(payload: input.toBytes(),
+                        contentTopic: contentTopic)
+
 # TODO When RPC uses Node, create WakuMessage and pass instead
-var res2 = waitfor node.wakuPublish("waku", cast[seq[byte]]("hello world"))
+#var res2 = waitfor node.wakuPublish("waku", cast[seq[byte]]("hello world"))
+#
+var res2 = waitfor client.wakuPublish2(pubSubTopic, message)
+#node.publish(pubSubTopic, message)

--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -25,4 +25,5 @@ waitfor node.connect("localhost", Port(8545))
 
 #var res = node.wakuSubscribe("waku")
 
-var res2 = waitfor node.wakuPublish("waku", message(0).buffer)
+# TODO When RPC uses Node, create WakuMessage and pass instead
+var res2 = waitfor node.wakuPublish("waku", cast[seq[byte]]("hello world"))

--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -2,6 +2,7 @@ import
   os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
   libp2p/protobuf/minprotobuf,
   eth/common as eth_common, eth/keys,
+  system,
   options
 
 from strutils import rsplit
@@ -10,19 +11,20 @@ template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 const sigWakuPath = sourceDir / "wakucallsigs.nim"
 createRpcSigs(RpcHttpClient, sigWakuPath)
 
-proc message(i: int): ProtoBuffer =
-  let value = "hello " & $(i)
+if paramCount() < 1:
+  echo "Please provide rpcPort as argument."
+  quit(1)
 
-  var result = initProtoBuffer()
-  result.write(initProtoField(1, value))
-  result.finish()
+let rpcPort = Port(parseInt(paramStr(1)))
 
-proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-  debug "Hit handler", topic=topic, data=data
+echo "Please enter your message:"
+let message = readLine(stdin)
+echo "Message is:", message
 
 var node = newRpcHttpClient()
-waitfor node.connect("localhost", Port(8545))
+waitfor node.connect("localhost", rpcPort)
 
+# Subscribe ourselves to topic
 #var res = node.wakuSubscribe("waku")
 
 # TODO When RPC uses Node, create WakuMessage and pass instead

--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -1,0 +1,28 @@
+import
+  os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
+  libp2p/protobuf/minprotobuf,
+  eth/common as eth_common, eth/keys,
+  options
+
+from strutils import rsplit
+template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+const sigWakuPath = sourceDir / "wakucallsigs.nim"
+createRpcSigs(RpcHttpClient, sigWakuPath)
+
+proc message(i: int): ProtoBuffer =
+  let value = "hello " & $(i)
+
+  var result = initProtoBuffer()
+  result.write(initProtoField(1, value))
+  result.finish()
+
+proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+  debug "Hit handler", topic=topic, data=data
+
+var node = newRpcHttpClient()
+waitfor node.connect("localhost", Port(8545))
+
+#var res = node.wakuSubscribe("waku")
+
+var res2 = waitfor node.wakuPublish("waku", message(0).buffer)

--- a/waku/node/v2/rpc/rpc_subscribe.nim
+++ b/waku/node/v2/rpc/rpc_subscribe.nim
@@ -2,6 +2,7 @@ import
   os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
   libp2p/protobuf/minprotobuf,
   eth/common as eth_common, eth/keys,
+  system,
   options
 
 from strutils import rsplit
@@ -10,18 +11,14 @@ template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 const sigWakuPath = sourceDir / "wakucallsigs.nim"
 createRpcSigs(RpcHttpClient, sigWakuPath)
 
-proc message(i: int): ProtoBuffer =
-  let value = "hello " & $(i)
+if paramCount() < 1:
+  echo "Please provide rpcPort as argument."
+  quit(1)
 
-  var result = initProtoBuffer()
-  result.write(initProtoField(1, value))
-  result.finish()
-
-proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-  debug "Hit handler", topic=topic, data=data
+let rpcPort = Port(parseInt(paramStr(1)))
 
 var node = newRpcHttpClient()
-waitfor node.connect("localhost", Port(8545))
+waitfor node.connect("localhost", rpcPort)
 
 # Subscribe to waku topic
 var res = node.wakuSubscribe("waku")

--- a/waku/node/v2/rpc/rpc_subscribe.nim
+++ b/waku/node/v2/rpc/rpc_subscribe.nim
@@ -1,0 +1,27 @@
+import
+  os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
+  libp2p/protobuf/minprotobuf,
+  eth/common as eth_common, eth/keys,
+  options
+
+from strutils import rsplit
+template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+const sigWakuPath = sourceDir / "wakucallsigs.nim"
+createRpcSigs(RpcHttpClient, sigWakuPath)
+
+proc message(i: int): ProtoBuffer =
+  let value = "hello " & $(i)
+
+  var result = initProtoBuffer()
+  result.write(initProtoField(1, value))
+  result.finish()
+
+proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+  debug "Hit handler", topic=topic, data=data
+
+var node = newRpcHttpClient()
+waitfor node.connect("localhost", Port(8545))
+
+# Subscribe to waku topic
+var res = node.wakuSubscribe("waku")

--- a/waku/node/v2/rpc/wakucallsigs.nim
+++ b/waku/node/v2/rpc/wakucallsigs.nim
@@ -1,6 +1,7 @@
 # Alpha - Currently implemented in v2
 proc waku_version(): string
 proc waku_publish(topic: string, message: seq[byte]): bool
+proc waku_publish2(topic: string, message: WakuMessage): bool
 proc waku_subscribe(topic: string): bool
 #proc waku_subscribe(topic: string, handler: Topichandler): bool
 

--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -33,6 +33,14 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
     #if not result:
     #  raise newException(ValueError, "Message could not be posted")
 
+  rpcsrv.rpc("waku_publish2") do(topic: string, message: WakuMessage) -> bool:
+    # XXX also future return type
+    debug "waku_publish2", topic=topic, message=message
+    discard node.publish(topic, message)
+    return true
+    #if not result:
+    #  raise newException(ValueError, "Message could not be posted")
+
   # TODO: Handler / Identifier logic
   rpcsrv.rpc("waku_subscribe") do(topic: string) -> bool:
     let wakuRelay = cast[WakuRelay](node.switch.pubSub.get())

--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -27,6 +27,7 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
     let wakuRelay = cast[WakuRelay](node.switch.pubSub.get())
     # XXX also future return type
     # TODO: Shouldn't we really be doing WakuNode publish here?
+    debug "waku_publish", topic=topic, payload=payload
     discard wakuRelay.publish(topic, payload)
     return true
     #if not result:

--- a/waku/protocol/v2/waku_relay.nim
+++ b/waku/protocol/v2/waku_relay.nim
@@ -50,24 +50,24 @@ method initPubSub*(w: WakuRelay) =
   w.init()
 
 method subscribe*(w: WakuRelay,
-                  topic: string,
+                  pubSubTopic: string,
                   handler: TopicHandler) {.async.} =
-  debug "subscribe", topic=topic
+  debug "subscribe", pubSubTopic=pubSubTopic
   if w.gossipEnabled:
-    await procCall GossipSub(w).subscribe(topic, handler)
+    await procCall GossipSub(w).subscribe(pubSubTopic, handler)
   else:
-    await procCall FloodSub(w).subscribe(topic, handler)
+    await procCall FloodSub(w).subscribe(pubSubTopic, handler)
 
 method publish*(w: WakuRelay,
-                topic: string,
+                pubSubTopic: string,
                 message: seq[byte]
                ): Future[int] {.async.} =
-  debug "publish", topic=topic
+  debug "publish", pubSubTopic=pubSubTopic, message=message
 
   if w.gossipEnabled:
-    return await procCall GossipSub(w).publish(topic, message)
+    return await procCall GossipSub(w).publish(pubSubTopic, message)
   else:
-    return await procCall FloodSub(w).publish(topic, message)
+    return await procCall FloodSub(w).publish(pubSubTopic, message)
 
 method unsubscribe*(w: WakuRelay,
                     topics: seq[TopicPair]) {.async.} =


### PR DESCRIPTION
Having some issues with replacing WakuRelay with WakuNode in RPC call. Not quite sure I understand the error here.

The node reference is accurate, but for some reason it thinks I want WakuRelay. It might be because the reference doesn't contain the publish method, or I am missing something in my mental model of how this is supposed to work.

All experimental changes in last commit https://github.com/status-im/nim-waku/pull/142/commits/60c5f5a563d91ad6a834f55b428a5ba635226fcf compared to other PR
 
Error:

```
 WIP: Attempt at replacing WakuRelay with Wakunode

/home/oskarth/git/status-im/nim-waku/waku/node/v2/rpc/wakurpc.nim(39, 17) Error: type mismatch: got <WakuNode, string, WakuMessage>
but expected one of:
method publish(w: WakuRelay; pubSubTopic: string; message: seq[byte]): Future[int]
  first type mismatch at position: 1
  required type for w: WakuRelay
  but expression 'node' is of type: WakuNode

expression: publish(node, topic, message)
stack trace: (most recent call last)
```

## Aside on scoping/shadow issue (resolved)
As an aside, I'm seeing some weird scoping/shadowing issues when using RPC. E.g. in https://github.com/status-im/nim-waku/pull/142/commits/5c24b6aea543eba84e3d2a452e96bea7a30f0adc:

 Fix publish topic and payload script

Also change parameter name in waku relay due to weird shadowing of log
topic:

DBG 2020-09-09 12:07:54+08:00 waku_publish                               tid=8795 file=wakurpc.nim:30 topic=waku payload=@[]
DBG 2020-09-09 12:07:54+08:00 publish                                    tid=8795 file=waku_relay.nim:65 topic=WakuRelay

Above should show topic=waku but it gets topic=WakuRelay from log scope
for some reason.

Resolved by changing parameter name.

Expected would be that the most local variable, i.e. parameter, wins, or I get a compiler error. logScope macro magic?