### PR TITLE
parametrize Dockerfile to make wakunode2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM alpine:3.11 AS nim-build
 
 ARG NIM_PARAMS
+ARG MAKE_TARGET=wakunode
 
 # Get build tools and required header files
 RUN apk add --no-cache bash build-base pcre-dev linux-headers git
@@ -14,7 +15,7 @@ ADD . .
 RUN git submodule update --init --recursive
 
 # Build the node binary
-RUN make -j$(nproc) wakunode NIM_PARAMS="${NIM_PARAMS}"
+RUN make -j$(nproc) ${MAKE_TARGET} NIM_PARAMS="${NIM_PARAMS}"
 
 # ACTUAL IMAGE -------------------------------------------------------
 FROM alpine:3.11
@@ -31,8 +32,8 @@ RUN apk add --no-cache libgcc pcre-dev
 # Fix for 'Error loading shared library libpcre.so.3: No such file or directory'
 RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 
-COPY --from=nim-build /app/build/wakunode /usr/bin/wakunode
+COPY --from=nim-build /app/build/${MAKE_TARGET} /usr/bin/${MAKE_TARGET}
 
-ENTRYPOINT ["/usr/bin/wakunode"]
+ENTRYPOINT ["/usr/bin/${MAKE_TARGET}"]
 # By default just show help if called without arguments
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ SHELL := bash # the shell used internally by Make
 # used inside the included makefiles
 BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 
-# Docker image name
-DOCKER_IMAGE_TAG ?= latest
-DOCKER_IMAGE_NAME ?= statusteam/nim-waku:$(DOCKER_IMAGE_TAG)
 # -d:insecure - Necessary to enable Prometheus HTTP endpoint for metrics
 # -d:chronicles_colors:none - Necessary to disable colors in logs for Docker
 DOCKER_IMAGE_NIM_PARAMS ?= -d:chronicles_colors:none -d:insecure
@@ -24,8 +21,9 @@ DOCKER_IMAGE_NIM_PARAMS ?= -d:chronicles_colors:none -d:insecure
 	all \
 	deps \
 	update \
-	wakunode \
 	wakusim \
+	wakunode \
+	wakunode2 \
 	wakuexample \
 	test \
 	clean \
@@ -111,8 +109,12 @@ libbacktrace:
 	+ $(MAKE) -C vendor/nim-libbacktrace --no-print-directory BUILD_CXX_LIB=0
 
 # build a docker image for the fleet
+docker-image: MAKE_TARGET ?= wakunode
+docker-image: DOCKER_IMAGE_TAG ?= $(MAKE_TARGET)
+docker-image: DOCKER_IMAGE_NAME ?= statusteam/nim-waku:$(DOCKER_IMAGE_TAG)
 docker-image:
 	docker build \
+		--build-arg="MAKE_TARGET=$(MAKE_TARGET)" \
 		--build-arg="NIM_PARAMS=$(DOCKER_IMAGE_NIM_PARAMS)" \
 		--tag $(DOCKER_IMAGE_NAME) .
 


### PR DESCRIPTION
To deploy Waku node v2 I added `MAKE_TARGET` argument to the `Dockerfile` to allow for building of separately tagged images.

Related to: https://github.com/status-im/nim-waku/issues/144