### PR TITLE
Minimal changes of splitting API and CLI code to make import in wakurpc work

### DIFF
--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -4,7 +4,7 @@ import
   nimcrypto/[sysrand, hmac, sha2],
   eth/[common, rlp, keys, p2p],
   ../../../protocol/v2/waku_relay,
-  ../waku_types
+  ../waku_types, ../wakunode2
 
 # Instead of using rlpx waku_protocol here, lets do mock waku2_protocol
 # This should wrap GossipSub, not use EthereumNode here
@@ -47,4 +47,3 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
     return true
     #if not result:
     #  raise newException(ValueError, "Message could not be posted")
-

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -1,19 +1,19 @@
 import
-  std/[strutils, options, tables],
-  chronos, confutils, json_rpc/rpcserver, metrics, stew/shims/net as stewNet,
+  std/[options, tables],
+  chronos, chronicles, stew/shims/net as stewNet,
   # TODO: Why do we need eth keys?
   eth/keys,
-  # eth/[keys, p2p], eth/net/nat, eth/p2p/[discovery, enode],
   libp2p/multiaddress,
   libp2p/crypto/crypto,
   libp2p/protocols/protocol,
   # NOTE For TopicHandler, solve with exports?
   libp2p/protocols/pubsub/pubsub,
   libp2p/peerinfo,
-  rpc/wakurpc,
-  standard_setup,
-  ../../protocol/v2/[waku_relay, waku_store, waku_filter], ../common,
-  ./waku_types, ./config, ./standard_setup, ./rpc/wakurpc
+  ../../protocol/v2/[waku_relay, waku_store, waku_filter],
+  ./waku_types, ./standard_setup
+
+# Default clientId
+const clientId* = "Nimbus Waku v2 node"
 
 # key and crypto modules different
 type
@@ -30,8 +30,6 @@ type
 
   HistoryResponse* = object
     messages*: seq[Message]
-
-const clientId* = "Nimbus Waku v2 node"
 
 # NOTE Any difference here in Waku vs Eth2?
 # E.g. Devp2p/Libp2p support, etc.
@@ -51,55 +49,6 @@ proc initAddress(T: type MultiAddress, str: string): T =
 
 template tcpEndPoint(address, port): auto =
   MultiAddress.init(address, tcpProtocol, port)
-
-proc dialPeer(n: WakuNode, address: string) {.async.} =
-  info "dialPeer", address = address
-  # XXX: This turns ipfs into p2p, not quite sure why
-  let multiAddr = MultiAddress.initAddress(address)
-  info "multiAddr", ma = multiAddr
-  let parts = address.split("/")
-  let remotePeer = PeerInfo.init(parts[^1], [multiAddr])
-
-  info "Dialing peer", multiAddr
-  # NOTE This is dialing on WakuRelay protocol specifically
-  # TODO Keep track of conn and connected state somewhere (WakuRelay?)
-  #p.conn = await p.switch.dial(remotePeer, WakuRelayCodec)
-  #p.connected = true
-  discard n.switch.dial(remotePeer, WakuRelayCodec)
-  info "Post switch dial"
-
-proc connectToNodes(n: WakuNode, nodes: openArray[string]) =
-  for nodeId in nodes:
-    info "connectToNodes", node = nodeId
-    # XXX: This seems...brittle
-    discard dialPeer(n, nodeId)
-    # Waku 1
-    #    let whisperENode = ENode.fromString(nodeId).expect("correct node")
-    #    traceAsyncErrors node.peerPool.connectToNode(newNode(whisperENode))
-
-proc startRpc(node: WakuNode, rpcIp: ValidIpAddress, rpcPort: Port) =
-  let
-    ta = initTAddress(rpcIp, rpcPort)
-    rpcServer = newRpcHttpServer([ta])
-  setupWakuRPC(node, rpcServer)
-  rpcServer.start()
-  info "RPC Server started", ta
-
-proc startMetricsServer(serverIp: ValidIpAddress, serverPort: Port) =
-    info "Starting metrics HTTP server", serverIp, serverPort
-    metrics.startHttpServer($serverIp, serverPort)
-
-proc startMetricsLog() =
-  proc logMetrics(udata: pointer) {.closure, gcsafe.} =
-    {.gcsafe.}:
-      # TODO: libp2p_pubsub_peers is not public, so we need to make this either
-      # public in libp2p or do our own peer counting after all.
-      let
-        totalMessages = total_messages.value
-
-    info "Node metrics", totalMessages
-    discard setTimer(Moment.fromNow(2.seconds), logMetrics)
-  discard setTimer(Moment.fromNow(2.seconds), logMetrics)
 
 ## Public API
 ##
@@ -217,6 +166,60 @@ proc query*(w: WakuNode, query: HistoryQuery): HistoryResponse =
     # result.messages.insert(msg[1])
 
 when isMainModule:
+  import
+    std/strutils,
+    confutils, json_rpc/rpcserver, metrics,
+    ./config, ./rpc/wakurpc, ../common
+
+  proc dialPeer(n: WakuNode, address: string) {.async.} =
+    info "dialPeer", address = address
+    # XXX: This turns ipfs into p2p, not quite sure why
+    let multiAddr = MultiAddress.initAddress(address)
+    info "multiAddr", ma = multiAddr
+    let parts = address.split("/")
+    let remotePeer = PeerInfo.init(parts[^1], [multiAddr])
+
+    info "Dialing peer", multiAddr
+    # NOTE This is dialing on WakuRelay protocol specifically
+    # TODO Keep track of conn and connected state somewhere (WakuRelay?)
+    #p.conn = await p.switch.dial(remotePeer, WakuRelayCodec)
+    #p.connected = true
+    discard n.switch.dial(remotePeer, WakuRelayCodec)
+    info "Post switch dial"
+
+  proc connectToNodes(n: WakuNode, nodes: openArray[string]) =
+    for nodeId in nodes:
+      info "connectToNodes", node = nodeId
+      # XXX: This seems...brittle
+      discard dialPeer(n, nodeId)
+      # Waku 1
+      #    let whisperENode = ENode.fromString(nodeId).expect("correct node")
+      #    traceAsyncErrors node.peerPool.connectToNode(newNode(whisperENode))
+
+  proc startRpc(node: WakuNode, rpcIp: ValidIpAddress, rpcPort: Port) =
+    let
+      ta = initTAddress(rpcIp, rpcPort)
+      rpcServer = newRpcHttpServer([ta])
+    setupWakuRPC(node, rpcServer)
+    rpcServer.start()
+    info "RPC Server started", ta
+
+  proc startMetricsServer(serverIp: ValidIpAddress, serverPort: Port) =
+      info "Starting metrics HTTP server", serverIp, serverPort
+      metrics.startHttpServer($serverIp, serverPort)
+
+  proc startMetricsLog() =
+    proc logMetrics(udata: pointer) {.closure, gcsafe.} =
+      {.gcsafe.}:
+        # TODO: libp2p_pubsub_peers is not public, so we need to make this either
+        # public in libp2p or do our own peer counting after all.
+        let
+          totalMessages = total_messages.value
+
+      info "Node metrics", totalMessages
+      discard setTimer(Moment.fromNow(2.seconds), logMetrics)
+    discard setTimer(Moment.fromNow(2.seconds), logMetrics)
+
   let
     conf = WakuNodeConf.load()
     (extIp, extTcpPort, extUdpPort) = setupNat(conf.nat, clientId,


### PR DESCRIPTION
This will allow import of wakunode2 in wakurpc so that https://github.com/status-im/nim-waku/issues/143 can be done.

Fixes https://github.com/status-im/nim-waku/issues/149, but could decide to further split it in two files. Basically it is just a matter then of moving everything under `when isMainModule:` to a new file (and adding the additional imports)