### PR TITLE
JSON RPC: Use WakuNode instead of WakuRelay

### DIFF
--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -20,8 +20,9 @@ if paramCount() < 1:
 let rpcPort = Port(parseInt(paramStr(1)))
 
 echo "Please enter your message:"
-let message = readLine(stdin)
-echo "Message is:", message
+let raw_input = readLine(stdin)
+let input = fmt"{raw_input}"
+echo "Input is:", input
 
 var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
@@ -31,7 +32,8 @@ waitfor node.connect("localhost", rpcPort)
 
 let pubSubTopic = "waku"
 let contentTopic = "foobar"
-var wakuMessage = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
+var wakuMessage = WakuMessage(payload: input.toBytes(), contentTopic: contentTopic)
+# XXX This should be WakuMessage type, but need to setup JSON-RPC mapping for that to work
 var raw_bytes = wakuMessage.encode().buffer
 var res = waitfor node.wakuPublish2(pubSubTopic, raw_bytes)
 echo "Waku publish response: ", res

--- a/waku/node/v2/rpc/rpc_publish.nim
+++ b/waku/node/v2/rpc/rpc_publish.nim
@@ -1,9 +1,11 @@
 import
   os, strutils, strformat, chronicles, json_rpc/[rpcclient, rpcserver], nimcrypto/sysrand,
+  stew/byteutils,
   libp2p/protobuf/minprotobuf,
   eth/common as eth_common, eth/keys,
   system,
-  options
+  options,
+  ../waku_types
 
 from strutils import rsplit
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
@@ -27,5 +29,9 @@ waitfor node.connect("localhost", rpcPort)
 # Subscribe ourselves to topic
 #var res = node.wakuSubscribe("waku")
 
-# TODO When RPC uses Node, create WakuMessage and pass instead
-var res2 = waitfor node.wakuPublish("waku", cast[seq[byte]]("hello world"))
+let pubSubTopic = "waku"
+let contentTopic = "foobar"
+var wakuMessage = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
+var raw_bytes = wakuMessage.encode().buffer
+var res = waitfor node.wakuPublish2(pubSubTopic, raw_bytes)
+echo "Waku publish response: ", res

--- a/waku/node/v2/rpc/wakucallsigs.nim
+++ b/waku/node/v2/rpc/wakucallsigs.nim
@@ -1,6 +1,9 @@
 # Alpha - Currently implemented in v2
 proc waku_version(): string
+# TODO Deprecate old waku_publish, requires adjust simulation code etc
 proc waku_publish(topic: string, message: seq[byte]): bool
+# TODO This should be properly done with rpc types, etc.
+proc waku_publish2(topic: string, message: seq[byte]): bool
 proc waku_subscribe(topic: string): bool
 #proc waku_subscribe(topic: string, handler: Topichandler): bool
 

--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -58,7 +58,8 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
       else:
         warn "waku_subscribe decode error", msg=msg
 
-      info "Hit subscribe handler", topic=topic, msg=msg[], payload=msg[].payload
+      var readable_str = cast[string](msg[].payload)
+      info "Hit subscribe handler", topic=topic, msg=msg[], payload=readable_str
 
     node.subscribe(topic, handler)
     return true

--- a/waku/node/v2/rpc/wakurpc.nim
+++ b/waku/node/v2/rpc/wakurpc.nim
@@ -33,6 +33,19 @@ proc setupWakuRPC*(node: WakuNode, rpcsrv: RpcServer) =
     #if not result:
     #  raise newException(ValueError, "Message could not be posted")
 
+  rpcsrv.rpc("waku_publish2") do(topic: string, payload: seq[byte]) -> bool:
+    let msg = WakuMessage.init(payload)
+    if msg.isOk():
+      debug "waku_publish", msg=msg
+    else:
+      warn "waku_publish decode error"
+
+    debug "waku_publish", topic=topic, payload=payload, msg=msg[]
+    node.publish(topic, msg[])
+    return true
+    #if not result:
+    #  raise newException(ValueError, "Message could not be posted")
+
   # TODO: Handler / Identifier logic
   rpcsrv.rpc("waku_subscribe") do(topic: string) -> bool:
     debug "waku_subscribe", topic=topic


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-waku/issues/143

This means it is using WakuMessage and going through Node API.

![image](https://user-images.githubusercontent.com/1552237/92882403-7bc8d680-f442-11ea-939d-4b94d1692b94.png)

Can be cleaned up further with JSON type encoding and replacing old usage in simulation etc, but this is good enough for testnet!