### PR TITLE
fix/message-notifier-async

### DIFF
--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -21,7 +21,7 @@ procSuite "Waku Filter":
       proto = WakuFilter.init()
       subscription = proto.subscription()
 
-    var subscriptions = initTable[string, MessageNotificationSubscription]()
+    var subscriptions = newTable[string, MessageNotificationSubscription]()
     subscriptions["test"] = subscription
 
     let

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -21,7 +21,7 @@ procSuite "Waku Store":
       proto = WakuStore.init()
       subscription = proto.subscription()
 
-    var subscriptions = initTable[string, MessageNotificationSubscription]()
+    var subscriptions = newTable[string, MessageNotificationSubscription]()
     subscriptions["test"] = subscription
 
     let
@@ -29,8 +29,8 @@ procSuite "Waku Store":
       msg = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic")
       msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic2")
 
-    subscriptions.notify("foo", msg)
-    subscriptions.notify("foo", msg2)
+    await subscriptions.notify("foo", msg)
+    await subscriptions.notify("foo", msg2)
 
     let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
     let remoteSecKey = PrivateKey.random(ECDSA, rng[]).get()

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -30,8 +30,6 @@ procSuite "Waku Store":
       msg = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic")
       msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic2")
 
-    var serverFut: Future[void]
-
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
 

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -33,9 +33,9 @@ type
     payload*: seq[byte]
     contentTopic*: string
 
-  MessageNotificationHandler* = proc(topic: string, msg: WakuMessage) {.gcsafe, closure.}
+  MessageNotificationHandler* = proc(topic: string, msg: WakuMessage): Future[void] {.gcsafe, closure.}
 
-  MessageNotificationSubscriptions* = Table[string, MessageNotificationSubscription]
+  MessageNotificationSubscriptions* = TableRef[string, MessageNotificationSubscription]
 
   MessageNotificationSubscription* = object
     topics*: seq[string] # @TODO TOPIC

--- a/waku/protocol/v2/message_notifier.nim
+++ b/waku/protocol/v2/message_notifier.nim
@@ -1,5 +1,7 @@
 import
   std/tables,
+  chronos,
+  sequtils,
   ./../../node/v2/waku_types
 
 # The Message Notification system is a method to notify various protocols
@@ -7,7 +9,7 @@ import
 #
 # Protocols can subscribe to messages of specific topics, then when one is received
 # The notification handler function will be called.
-proc subscribe*(subscriptions: var MessageNotificationSubscriptions, name: string, subscription: MessageNotificationSubscription) =
+proc subscribe*(subscriptions: MessageNotificationSubscriptions, name: string, subscription: MessageNotificationSubscription) =
   subscriptions.add(name, subscription)
 
 proc init*(T: type MessageNotificationSubscription, topics: seq[string], handler: MessageNotificationHandler): T =
@@ -23,10 +25,14 @@ proc containsMatch(lhs: seq[string], rhs: seq[string]): bool =
 
   return false
 
-proc notify*(subscriptions: var MessageNotificationSubscriptions, topic: string, msg: WakuMessage) {.gcsafe.} =
+proc notify*(subscriptions: MessageNotificationSubscriptions, topic: string, msg: WakuMessage) {.async, gcsafe.} =
+  var futures = newSeq[Future[void]]()
+
   for subscription in subscriptions.mvalues:
     # @TODO WILL NEED TO CHECK SUBTOPICS IN FUTURE FOR WAKU TOPICS NOT LIBP2P ONES
     if subscription.topics.len > 0 and topic notin subscription.topics:
       continue
 
-    subscription.handler(topic, msg)
+    futures.add(subscription.handler(topic, msg))
+
+  await allFutures(futures)

--- a/waku/protocol/v2/message_notifier.nim
+++ b/waku/protocol/v2/message_notifier.nim
@@ -1,7 +1,6 @@
 import
   std/tables,
   chronos,
-  sequtils,
   ./../../node/v2/waku_types
 
 # The Message Notification system is a method to notify various protocols

--- a/waku/protocol/v2/waku_store.nim
+++ b/waku/protocol/v2/waku_store.nim
@@ -97,7 +97,7 @@ proc subscription*(proto: WakuStore): MessageNotificationSubscription =
   ## This is used to pipe messages into the storage, therefore
   ## the filter should be used by the component that receives
   ## new messages.
-  proc handle(topic: string, msg: WakuMessage) =
+  proc handle(topic: string, msg: WakuMessage) {.async.} =
     proto.messages.add(msg)
 
   MessageNotificationSubscription.init(@[], handle)


### PR DESCRIPTION
This PR makes the Message protocol asynchronous as suggested by @dryajov, additionally it drastically simplifies the store test by using 2 switches. In a later step this will aslo need to be done to the filter protocol once the problem within libp2p is determined that is currently causing it to close connections.