### PR TITLE
Fix timing issue with subscribe in chat2

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -66,6 +66,11 @@ proc dialPeer(c: Chat, address: string) {.async.} =
   discard await c.node.switch.dial(remotePeer, WakuRelayCodec)
   c.connected = true
 
+proc connectToNodes(c: Chat, nodes: openArray[string]) =
+  echo "Connecting to nodes"
+  for nodeId in nodes:
+    discard dialPeer(c, nodeId)
+
 proc publish(c: Chat, line: string) =
   let payload = cast[seq[byte]](line)
   let message = WakuMessage(payload: payload, contentTopic: DefaultContentTopic)
@@ -158,6 +163,11 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   # waitFor vs await
   await node.start()
 
+  var chat = Chat(node: node, transp: transp, subscribed: true, connected: false, started: true)
+
+  if conf.staticnodes.len > 0:
+    connectToNodes(chat, conf.staticnodes)
+
   let peerInfo = node.peerInfo
   let listenStr = $peerInfo.addrs[0] & "/p2p/" & $peerInfo.peerId
   echo &"Listening on\n {listenStr}"
@@ -171,9 +181,10 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     let payload = cast[string](message.payload)
     echo &"{payload}"
     info "Hit subscribe handler", topic=topic, payload=payload, contentTopic=message.contentTopic
-  await node.subscribe(topic, handler)
 
-  var chat = Chat(node: node, transp: transp, subscribed: true, connected: false, started: true)
+  # XXX Timing issue with subscribe, need to wait a bit to ensure GRAFT message is sent
+  await sleepAsync(5.seconds)
+  await node.subscribe(topic, handler)
 
   await chat.readWriteLoop()
   runForever()

--- a/waku.nimble
+++ b/waku.nimble
@@ -80,4 +80,5 @@ task chat2, "Build example Waku v2 chat usage":
   let name = "chat2"
   # NOTE For debugging, set debug level. For chat usage we want minimal log
   # output to STDOUT. Can be fixed by redirecting logs to file (e.g.)
-  buildBinary name, "examples/v2/", "-d:chronicles_log_level=WARN"
+  #buildBinary name, "examples/v2/", "-d:chronicles_log_level=WARN"
+  buildBinary name, "examples/v2/", "-d:chronicles_log_level=DEBUG"

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -97,6 +97,8 @@ proc init*(T: type WakuNode, nodeKey: crypto.PrivateKey,
     filters: initTable[string, Filter]()
   )
 
+  # TODO This is _not_ safe. Subscribe should happen in start and after things settled down.
+  # Otherwise GRAFT message isn't sent to a node.
   for topic in topics:
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
       debug "Hit handler", topic=topic, data=data


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-waku/issues/221
Fixes #215 

The problem is the timing of subscribe and connection of nodes. In theory it shouldn't matter I suppose, but in practice it does. Additionally, there seems to be a need for a sleep before subscribe being called. Otherwise, a GRAFT message isn't sent. This means the number of peers in the relevant mesh is zero. For two nodes this isn't visible because of `floodPublish` setting.

It is unclear when or how this was introduced, but it didn't seem to impact wakunode2 because we call `rpc_subscribe` after the node "has settled".

This also means the default subscribe mechanism appears to be faulty in here https://github.com/status-im/nim-waku/commit/03895ffaf559c9c3f8f3cc360dd9af746a3d9ed8 - issue needed to fix this.

It'd be useful to fix FloodSub https://github.com/status-im/nim-waku/issues/161 since this would make it easier to see the exact problem.

It'd also be useful to cut out a testing issue and pr https://github.com/status-im/nim-waku/issues/158#issuecomment-707500402 to ensure we capture this again

Finally, it'd be great if this timing issue wasn't a concern and one could call subscribe at any time. I've not looked into the rebalance mesh semantics enough to know if this is a bug or something that could easily be addressed. Perhaps @dryajov or @sinkingsugar knows the answer here?

## Changelog

- Support static node in chat2
- Ensure nodes are connected before subscribing
- Sleep to allow settling down before subscribing
- Default chat2 log to DEBUG

# Testing done

Spin up three chat2 nodes, A, B, C with B and C specifying A as staticnode. Notice how subscribe action takes a few second and the resulting grafting etc. Send a message from node B, and notice how A picks it up and forwards it to C as expected. Also notice that sendPeer len for A is 1 as opposed to 0, which it was before.

For wakunode2, the default behaviour was not changed. Using `rpc_subscribe` after the node has settled still works.