### PR TITLE
feature/add-filter

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -159,7 +159,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   # waitFor vs await
   await node.start()
 
-  if conf.filternode == "":
+  if conf.filternode != "":
     await node.mountRelay(conf.topics.split(" "))
   else:
     await node.mountRelay(@[])
@@ -194,9 +194,9 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     proc filterHandler(msg: WakuMessage) {.gcsafe.} =
       let payload = cast[string](msg.payload)
       echo &"{payload}"
-      info "Hit store handler"
+      info "Hit filter handler"
 
-    await node.query(
+    await node.subscribe(
       FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topic: DefaultTopic),
       filterHandler
     )

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -195,7 +195,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
       info "Hit store handler"
 
     await node.query(
-      FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topics: DefaultTopic),
+      FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topic: DefaultTopic),
       storeHandler
     )
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -198,7 +198,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
 
     await node.query(
       FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topic: DefaultTopic),
-      storeHandler
+      filterHandler
     )
 
   # Subscribe to a topic

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -161,6 +161,8 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
 
   if conf.filternode == "":
     await node.mountRelay(conf.topics.split(" "))
+  else:
+    await node.mountRelay(@[])
 
   var chat = Chat(node: node, transp: transp, subscribed: true, connected: false, started: true)
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -158,7 +158,9 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
 
   # waitFor vs await
   await node.start()
-  await node.mountRelay(conf.topics.split(" "))
+
+  if conf.filternode == "":
+    await node.mountRelay(conf.topics.split(" "))
 
   var chat = Chat(node: node, transp: transp, subscribed: true, connected: false, started: true)
 
@@ -192,7 +194,10 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
       echo &"{payload}"
       info "Hit store handler"
 
-    await node.query(FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topics: DefaultTopic), storeHandler)
+    await node.query(
+      FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topics: DefaultTopic),
+      storeHandler
+    )
 
   # Subscribe to a topic
   # TODO To get end to end sender would require more information in payload

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -19,7 +19,7 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                muxers/muxer,             # define an interface for stream multiplexing, allowing peers to offer many protocols over a single connection
                muxers/mplex/mplex]       # define some contants and message types for stream multiplexing
 import   ../../waku/node/v2/[config, wakunode2, waku_types],
-         ../../waku/protocol/v2/[waku_relay, waku_store],
+         ../../waku/protocol/v2/[waku_relay, waku_store, waku_filter],
          ../../waku/node/common
 
 const Help = """

--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -35,7 +35,6 @@ type
 
   QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
 
-
   Index* = object
     ## This type contains the  description of an index used in the pagination of waku messages
     digest*: MDigest[256]


### PR DESCRIPTION
Adds the filter protocol to the chat2 example. This was tested locally. If a filternode is set, the relay does not subscribe to any topics.