### PR TITLE
fixes a bug related to contentTopic type mismatch

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -5,4 +5,5 @@ import
   ./v2/test_wakunode,
   ./v2/test_waku_store,
   ./v2/test_waku_filter,
-  ./v2/test_rpc_waku
+  ./v2/test_rpc_waku,
+  ./v2/test_waku_pagination

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -1,3 +1,4 @@
+{.used.}
 import
   std/unittest,
   ../../waku/node/v2/waku_types,

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -16,9 +16,9 @@ procSuite "pagination":
 
   test "computeIndex: identical WakuMessages test":
     let
-      wm = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic2")
+      wm = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(1))
       index1 = wm.computeIndex()
-      wm2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: "topic2")
+      wm2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(1))
       index2 = wm2.computeIndex()
 
     check:


### PR DESCRIPTION
This PR fixes a bug in `test_waku_pagination.nim` and also adds `test_waku_pagination` to waku v2 tests.