### PR TITLE
Minimal accounting

### DIFF
--- a/waku/node/v2/waku_types.nim
+++ b/waku/node/v2/waku_types.nim
@@ -169,6 +169,9 @@ type
     date*: uint32
     amount*: uint32
 
+  AccountUpdateFunc* = proc(peerId: PeerId, amount: int) {.gcsafe.}
+
+
 # Encoding and decoding -------------------------------------------------------
 # TODO Move out to to waku_message module
 # Possibly same with util functions

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -21,8 +21,7 @@ logScope:
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
 
-# TODO Default to false
-const SWAPAccountingEnabled* = true
+const SWAPAccountingEnabled* = false
 
 # key and crypto modules different
 type

--- a/waku/node/v2/wakunode2.nim
+++ b/waku/node/v2/wakunode2.nim
@@ -10,7 +10,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   libp2p/peerinfo,
   libp2p/standard_setup,
-  ../../protocol/v2/[waku_relay, waku_store, waku_filter, message_notifier],
+  ../../protocol/v2/[waku_relay, waku_store, waku_filter, waku_swap, message_notifier],
   ./waku_types, ./message_store
 
 export waku_types
@@ -199,9 +199,6 @@ proc unsubscribe*(node: WakuNode, request: FilterRequest) {.async, gcsafe.} =
   await node.wakuFilter.unsubscribe(request)
   node.filters.removeContentFilters(request.contentFilters)
 
-# TODO Move to better place, i.e. separate module
-proc accountFor(peerId: PeerId, n: int) {.gcsafe.} =
-  info "Accounting for", peerId, n
 
 proc publish*(node: WakuNode, topic: Topic, message: WakuMessage) =
   ## Publish a `WakuMessage` to a PubSub topic. `WakuMessage` should contain a

--- a/waku/protocol/v2/waku_store.nim
+++ b/waku/protocol/v2/waku_store.nim
@@ -353,9 +353,6 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
 
   handler(response.value.response)
 
-# TODO Move to better place
-type AccountUpdateFunc = proc(peerId: PeerId, amount: int) {.gcsafe.}
-
 # NOTE: Experimental, maybe incorporate as part of query call
 proc queryWithAccounting*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc,
                           accountFor: AccountUpdateFunc) {.async, gcsafe.} =

--- a/waku/protocol/v2/waku_store.nim
+++ b/waku/protocol/v2/waku_store.nim
@@ -382,8 +382,7 @@ proc queryWithAccounting*(w: WakuStore, query: HistoryQuery, handler: QueryHandl
   # NOTE Perform accounting operation
   #  if SWAPAccountingEnabled:
   let peerId = peer.peerInfo.peerId
-  # TODO Replace with WakuMessage's
-  let volume = 1
-  accountFor(peerId, volume)
+  let messages = response.value.response.messages
+  accountFor(peerId, messages.len)
 
   handler(response.value.response)

--- a/waku/protocol/v2/waku_swap.nim
+++ b/waku/protocol/v2/waku_swap.nim
@@ -71,3 +71,13 @@ proc init*(T: type Cheque, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(3, cheque.amount)
 
   ok(cheque)
+
+
+# Accounting
+#
+
+proc accountFor*(peerId: PeerId, n: int) {.gcsafe.} =
+  info "Accounting for", peerId, n
+
+# TODO End to end communication
+# TODO Better state management (STDOUT for now)


### PR DESCRIPTION
Closes https://github.com/status-im/nim-waku/issues/260

Start of accounting PoC bookkeeping and keeping track of balance with peer. See  and https://github.com/vacp2p/specs/blob/master/specs/waku/v2/waku-swap-accounting.md

Ready to review. Changes under flag so no functional code changes. With flag on, it prints accounting stats to STDOUT:

```
NF 2020-11-16 11:43:02.860+08:00 mounting store                             topics="wakunode" tid=7524
hi
hi
INF 2020-11-16 11:43:04.105+08:00 Hit store handler                          tid=7524
DBG 2020-11-16 11:43:04.105+08:00 Using SWAPAccounting query                 topics="wakunode" tid=7524
INF 2020-11-16 11:43:05.363+08:00 Accounting for                             topics="wakuswap" tid=7524 peerId=16*3q4YjS n=2
```

I.e. it has received two WakuMessages from that peer.

Follow up issues to be addressed in future PRs:
- Better state management
- End to end