### PR TITLE
Minimal accounting state PoC

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -213,6 +213,11 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
         echo &"{payload}"
       info "Hit store handler"
 
+    # TODO Use same flag as wakunode
+    # To be fixed here: https://github.com/status-im/nim-waku/issues/271
+    if false:
+      node.mountSwap()
+
     await node.query(HistoryQuery(topics: @[DefaultContentTopic]), storeHandler)
 
   if conf.filternode != "":

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -22,6 +22,8 @@ logScope:
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
 
+# TODO Toggle
+# To be fixed here: https://github.com/status-im/nim-waku/issues/271
 const SWAPAccountingEnabled* = false
 
 # key and crypto modules different
@@ -225,7 +227,7 @@ proc query*(node: WakuNode, query: HistoryQuery, handler: QueryHandlerFunc) {.as
 
   if SWAPAccountingEnabled:
     debug "Using SWAPAccounting query"
-    await node.wakuStore.queryWithAccounting(query, handler, accountFor)
+    await node.wakuStore.queryWithAccounting(query, handler, node.wakuSwap)
 
 # TODO Extend with more relevant info: topics, peers, memory usage, online time, etc
 proc info*(node: WakuNode): WakuInfo =

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -257,6 +257,13 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil) =
   node.switch.mount(node.wakuStore)
   node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
+proc mountSwap*(node: WakuNode) =
+  info "mounting swap"
+  node.wakuSwap = WakuSwap.init(node.switch, node.rng)
+  node.switch.mount(node.wakuSwap)
+  # NYI - Do we need this?
+  #node.subscriptions.subscribe(WakuSwapCodec, node.wakuSwap.subscription())
+
 proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string]()) {.async, gcsafe.} =
   let wakuRelay = WakuRelay.init(
     switch = node.switch,
@@ -390,8 +397,7 @@ when isMainModule:
   # TODO Move to conf
   if SWAPAccountingEnabled:
     info "SWAP Accounting enabled"
-    # TODO Mount SWAP protocol
-    # TODO Enable account module
+    mountSwap(node)
 
   if conf.store:
     var store: MessageStore

--- a/waku/v2/protocol/waku_store.nim
+++ b/waku/v2/protocol/waku_store.nim
@@ -356,7 +356,7 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
 
 # NOTE: Experimental, maybe incorporate as part of query call
 proc queryWithAccounting*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc,
-                          accountFor: AccountUpdateFunc) {.async, gcsafe.} =
+                          wakuSwap: WakuSwap) {.async, gcsafe.} =
   # @TODO We need to be more stratigic about which peers we dial. Right now we just set one on the service.
   # Ideally depending on the query and our set  of peers we take a subset of ideal peers.
   # This will require us to check for various factors such as:
@@ -381,6 +381,6 @@ proc queryWithAccounting*(w: WakuStore, query: HistoryQuery, handler: QueryHandl
   #  if SWAPAccountingEnabled:
   let peerId = peer.peerInfo.peerId
   let messages = response.value.response.messages
-  accountFor(peerId, messages.len)
+  wakuSwap.accountFor(peerId, messages.len)
 
   handler(response.value.response)

--- a/waku/v2/protocol/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap.nim
@@ -76,15 +76,33 @@ proc init*(T: type Cheque, buffer: seq[byte]): ProtoResult[T] =
 # Accounting
 #
 
-proc accountFor*(peerId: PeerId, n: int) {.gcsafe.} =
-  info "Accounting for", peerId, n
+proc init*(wakuSwap: WakuSwap) =
+  info "wakuSwap init 1"
+  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+    info "NYI swap handle incoming connection"
 
-# TODO End to end communication
-# TODO Better state management (STDOUT for now)
+  proc accountFor(peerId: PeerId, n: int) {.gcsafe, closure.} =
+    info "Accounting for", peerId, n
+    info "Accounting test", text = wakuSwap.text
+    # Nicer way to write this?
+    if wakuSwap.accounting.hasKey(peerId):
+      wakuSwap.accounting[peerId] += n
+    else:
+      wakuSwap.accounting[peerId] = n
+    info "Accounting state", accounting = wakuSwap.accounting[peerId]
+
+  wakuSwap.handler = handle
+  wakuSwap.codec = WakuSwapCodec
+  wakuSwap.accountFor = accountFor
+
+
 proc init*(T: type WakuSwap, switch: Switch, rng: ref BrHmacDrbgContext): T =
+  info "wakuSwap init 2"
   new result
   result.rng = rng
   result.switch = switch
   result.accounting = initTable[PeerId, int]()
   result.text = "test"
   result.init()
+
+# TODO End to end communication

--- a/waku/v2/protocol/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap.nim
@@ -81,3 +81,10 @@ proc accountFor*(peerId: PeerId, n: int) {.gcsafe.} =
 
 # TODO End to end communication
 # TODO Better state management (STDOUT for now)
+proc init*(T: type WakuSwap, switch: Switch, rng: ref BrHmacDrbgContext): T =
+  new result
+  result.rng = rng
+  result.switch = switch
+  result.accounting = initTable[PeerId, int]()
+  result.text = "test"
+  result.init()

--- a/waku/v2/waku_types.nim
+++ b/waku/v2/waku_types.nim
@@ -134,12 +134,15 @@ type
   # @TODO MAYBE MORE INFO?
   Filters* = Table[string, Filter]
 
+  AccountHandler* = proc (peerId: PeerId, amount: int) {.gcsafe, closure.}
+
   WakuSwap* = ref object of LPProtocol
     switch*: Switch
     rng*: ref BrHmacDrbgContext
     #peers*: seq[PeerInfo]
     text*: string
     accounting*: Table[PeerId, int]
+    accountFor*: AccountHandler
 
   # NOTE based on Eth2Node in NBC eth2_network.nim
   WakuNode* = ref object of RootObj

--- a/waku/v2/waku_types.nim
+++ b/waku/v2/waku_types.nim
@@ -134,12 +134,20 @@ type
   # @TODO MAYBE MORE INFO?
   Filters* = Table[string, Filter]
 
+  WakuSwap* = ref object of LPProtocol
+    switch*: Switch
+    rng*: ref BrHmacDrbgContext
+    #peers*: seq[PeerInfo]
+    text*: string
+    accounting*: Table[PeerId, int]
+
   # NOTE based on Eth2Node in NBC eth2_network.nim
   WakuNode* = ref object of RootObj
     switch*: Switch
     wakuRelay*: WakuRelay
     wakuStore*: WakuStore
     wakuFilter*: WakuFilter
+    wakuSwap*: WakuSwap
     peerInfo*: PeerInfo
     libp2pTransportLoops*: seq[Future[void]]
   # TODO Revist messages field indexing as well as if this should be Message or WakuMessage


### PR DESCRIPTION
Addresses https://github.com/status-im/nim-waku/issues/269 to keep accounting state.  Starts to introduce WakuSwap protocol.

Future enhancements:
- End to end https://github.com/status-im/nim-waku/issues/270
- Config flag fix https://github.com/status-im/nim-waku/issues/269
- Better tests (probably as part of 270)

Tested with chat2 as PoC and flag on:

```
INF 2020-11-18 14:47:49.393+08:00 mounting store                             topics="wakunode" tid=10675
INF 2020-11-18 14:47:49.394+08:00 mounting swap                              topics="wakunode" tid=10675
INF 2020-11-18 14:47:49.394+08:00 wakuSwap init 2                            topics="wakunode" tid=10675
INF 2020-11-18 14:47:49.394+08:00 wakuSwap init 1                            topics="wakuswap" tid=10675
Hello
I am writing some stuff
So I can retrieve it later
Byebye
INF 2020-11-18 14:47:50.641+08:00 Hit store handler                          tid=10675
DBG 2020-11-18 14:47:50.641+08:00 Using SWAPAccounting query                 topics="wakunode" tid=10675
INF 2020-11-18 14:47:51.820+08:00 Accounting 2 for                           topics="wakuswap" tid=10675 peerId=16*3q4YjS n=4
INF 2020-11-18 14:47:51.820+08:00 Accounting test                            topics="wakuswap" tid=10675 text=test
[Chronicles] Log message not delivered: Accounting pre
key not found: 16Uiu2HAmJb2e28qLXxT5kZxVUUoJt72EMzNGXB47Rxx5hw3q4YjS
INF 2020-11-18 14:47:51.820+08:00 Accounting post                            topics="wakuswap" tid=10675 accounting=4
Hello

```