### PR TITLE
Accounting: Move flag to config and add basic test for accounting state

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -213,9 +213,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
         echo &"{payload}"
       info "Hit store handler"
 
-    # TODO Use same flag as wakunode
-    # To be fixed here: https://github.com/status-im/nim-waku/issues/271
-    if false:
+    if conf.swap:
       node.mountSwap()
 
     await node.query(HistoryQuery(topics: @[DefaultContentTopic]), storeHandler)

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -1,9 +1,21 @@
 import
   std/[unittest, options, tables, sets],
-  chronos, chronicles,
-  ../../waku/v2/protocol/waku_swap,
-  ../../waku/v2/waku_types,
-  ../test_helpers, ./utils
+  chronos, chronicles, stew/shims/net as stewNet, stew/byteutils,
+  libp2p/switch,
+  libp2p/protobuf/minprotobuf,
+  libp2p/stream/[bufferstream, connection],
+  libp2p/crypto/[crypto, secp],
+  libp2p/switch,
+  libp2p/protocols/pubsub/rpc/message,
+  libp2p/multistream,
+  libp2p/transports/transport,
+  libp2p/transports/tcptransport,
+  eth/keys,
+  ../../waku/v2/protocol/[waku_store, message_notifier, waku_swap],
+  ../../waku/v2/node/message_store,
+  ../../waku/v2/node/wakunode2,
+  ../test_helpers, ./utils,
+  ../../waku/v2/waku_types
 
 procSuite "Waku SWAP Accounting":
   test "Handshake Encode/Decode":
@@ -31,3 +43,49 @@ procSuite "Waku SWAP Accounting":
     check:
       decodedCheque.isErr == false
       decodedCheque.get() == cheque
+
+  asyncTest "Update accounting state after store operations":
+    let
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"),
+        Port(60000))
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
+        Port(60001))
+      contentTopic = ContentTopic(1)
+      message = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
+
+    var completionFut = newFuture[bool]()
+
+    # Start nodes and mount protocols
+    await node1.start()
+    node1.mountStore()
+    node1.mountSwap()
+    await node2.start()
+    node2.mountStore()
+    node1.mountSwap()
+
+    await node2.subscriptions.notify("/waku/2/default-waku/proto", message)
+
+    await sleepAsync(2000.millis)
+
+    node1.wakuStore.setPeer(node2.peerInfo)
+
+    proc storeHandler(response: HistoryResponse) {.gcsafe, closure.} =
+      debug "storeHandler hit"
+      check:
+        response.messages[0] == message
+      completionFut.complete(true)
+
+    await node1.query(HistoryQuery(topics: @[contentTopic]), storeHandler)
+
+    # TODO Other node accounting field not set
+    # info "node2", msgs = node2.wakuSwap.accounting # crashes
+    # node2.wakuSwap.accounting[node1.peerInfo.peerId] = -1
+
+    check:
+      (await completionFut.withTimeout(5.seconds)) == true
+      # Accounting table updated with one message credit
+      node1.wakuSwap.accounting[node2.peerInfo.peerId] == 1
+    await node1.stop()
+    await node2.stop()

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -63,6 +63,11 @@ type
       defaultValue: true
       name: "relay" }: bool
 
+    swap* {.
+      desc: "Flag whether to start swap protocol",
+      defaultValue: false
+      name: "swap" }: bool
+
     filternode* {.
       desc: "Enode URL to filter.",
       defaultValue: ""

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -22,10 +22,6 @@ logScope:
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
 
-# TODO Toggle
-# To be fixed here: https://github.com/status-im/nim-waku/issues/271
-const SWAPAccountingEnabled* = false
-
 # key and crypto modules different
 type
   KeyPair* = crypto.KeyPair
@@ -223,9 +219,11 @@ proc query*(node: WakuNode, query: HistoryQuery, handler: QueryHandlerFunc) {.as
   ## QueryHandlerFunc is a method that takes a HistoryResponse.
   ##
   ## Status: Implemented.
-  await node.wakuStore.query(query, handler)
 
-  if SWAPAccountingEnabled:
+  if node.wakuSwap.isNil:
+    debug "Using default query"
+    await node.wakuStore.query(query, handler)
+  else:
     debug "Using SWAPAccounting query"
     await node.wakuStore.queryWithAccounting(query, handler, node.wakuSwap)
 
@@ -396,9 +394,7 @@ when isMainModule:
 
   waitFor node.start()
 
-  # TODO Move to conf
-  if SWAPAccountingEnabled:
-    info "SWAP Accounting enabled"
+  if conf.swap:
     mountSwap(node)
 
   if conf.store:


### PR DESCRIPTION
Addresses https://github.com/status-im/nim-waku/issues/271 and adds a test for updating accounting state after store operations.

Flag is `--swap` and works like other protocol flags. It is off by default.

Also fixes a minor bug where store query was called twice when flag was enabled.

Future issues added:
- https://github.com/status-im/nim-waku/issues/285
https://github.com/status-im/nim-waku/issues/284