### PR TITLE
Added content topic polling on FilterAPI

### DIFF
--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -1,23 +1,46 @@
 {.push raises: [Exception, Defect].}
 
 import
+  std/[tables,sequtils],
   json_rpc/rpcserver,
   eth/[common, rlp, keys, p2p],
   ../../waku_types,
   ../wakunode2
 
+const futTimeout = 5.seconds
+
 proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
-  const futTimeout = 5.seconds
+  ## Create a message cache indexed on content topic
+  ## @TODO consider moving message cache elsewhere. Perhaps to node?
+  var
+    messageCache = initTable[ContentTopic, seq[WakuMessage]]()
+  
+  proc filterHandler(msg: WakuMessage) {.gcsafe, closure.} =
+    debug "WakuMessage received", msg=msg
+    # Add message to current cache
+    # @TODO limit max content topics and messages
+    messageCache.mgetOrPut(msg.contentTopic, @[]).add(msg)
 
   ## Filter API version 1 definitions
+  
+  rpcsrv.rpc("get_waku_v2_filter_v1_messages") do(contentTopic: ContentTopic) -> seq[WakuMessage]:
+    ## Returns all WakuMessages received on a content topic since the
+    ## last time this method was called
+    ## @TODO ability to specify a return message limit
+    debug "get_waku_v2_filter_v1_messages", contentTopic=contentTopic
+
+    if messageCache.hasKey(contentTopic):
+      let msgs = messageCache[contentTopic]
+      # Clear cache before next call
+      messageCache[contentTopic] = @[]
+      return msgs
+    else:
+      # Not subscribed to this content topic
+      raise newException(ValueError, "Not subscribed to content topic: " & $contentTopic)
   
   rpcsrv.rpc("post_waku_v2_filter_v1_subscription") do(contentFilters: seq[ContentFilter], topic: Option[string]) -> bool:
     ## Subscribes a node to a list of content filters
     debug "post_waku_v2_filter_v1_subscription"
-
-    proc filterHandler(msg: WakuMessage) {.gcsafe, closure.} =
-      debug "WakuMessage received", msg=msg, topic=topic
-      # @TODO handle message
 
     # Construct a filter request
     # @TODO use default PubSub topic if undefined
@@ -25,6 +48,11 @@ proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     
     if (await node.subscribe(fReq, filterHandler).withTimeout(futTimeout)):
       # Successfully subscribed to all content filters
+      
+      for cTopic in concat(contentFilters.mapIt(it.topics)):
+        # Create message cache for each subscribed content topic
+        messageCache[cTopic] = @[]
+      
       return true
     else:
       # Failed to subscribe to one or more content filters
@@ -40,6 +68,11 @@ proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
     if (await node.unsubscribe(fReq).withTimeout(futTimeout)):
       # Successfully unsubscribed from all content filters
+
+      for cTopic in concat(contentFilters.mapIt(it.topics)):
+        # Remove message cache for each unsubscribed content topic
+        messageCache.del(cTopic)
+
       return true
     else:
       # Failed to unsubscribe from one or more content filters

--- a/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
@@ -15,5 +15,6 @@ proc get_waku_v2_store_v1_messages(topics: seq[ContentTopic], pagingOptions: Opt
 
 # Filter API
 
+proc get_waku_v2_filter_v1_messages(contentTopic: ContentTopic): seq[WakuMessage]
 proc post_waku_v2_filter_v1_subscription(contentFilters: seq[ContentFilter], topic: Option[string]): bool
 proc delete_waku_v2_filter_v1_subscription(contentFilters: seq[ContentFilter], topic: Option[string]): bool


### PR DESCRIPTION
A further incremental PR towards #299

This adds a simple way to poll a content topic for new messages on the Filter API. Messages are cached in-memory and cleared after every call.

#### What is still outstanding for polling?
- **Must have**: a proper way to limit cache size to prevent memory leaks
- **Could have**: a limit on the number of messages returned per call
- **Could have**: moving the message cache from RPC server setup code to a better place. Perhaps the node itself?

#### What is still outstanding for the broader API?
- **Should have**: Admin API
- **Should have**: Private API