### PR TITLE
Limit cache size on Filter API and Relay API

### DIFF
--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -7,7 +7,8 @@ import
   ../../waku_types,
   ../wakunode2
 
-const futTimeout = 5.seconds
+const futTimeout* = 5.seconds # Max time to wait for futures
+const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
 
 proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
   ## Create a message cache indexed on content topic
@@ -16,10 +17,20 @@ proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     messageCache = initTable[ContentTopic, seq[WakuMessage]]()
   
   proc filterHandler(msg: WakuMessage) {.gcsafe, closure.} =
-    debug "WakuMessage received", msg=msg
     # Add message to current cache
-    # @TODO limit max content topics and messages
-    messageCache.mgetOrPut(msg.contentTopic, @[]).add(msg)
+    trace "WakuMessage received", msg=msg
+    
+    # Make a copy of msgs for this topic to modify
+    var msgs = messageCache.getOrDefault(msg.contentTopic, @[])
+
+    if msgs.len >= maxCache:
+      # Message cache on this topic exceeds maximum. Delete oldest.
+      msgs.delete(0,0)
+    msgs.add(msg)
+
+    # Replace indexed entry with copy
+    # @TODO max number of content topics could be limited in node
+    messageCache[msg.contentTopic] = msgs
 
   ## Filter API version 1 definitions
   

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -12,10 +12,13 @@ import
 const futTimeout* = 5.seconds # Max time to wait for futures
 const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
 
+type
+  TopicCache* = Table[string, seq[WakuMessage]]
+
 proc installRelayApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
   ## Create a per-topic message cache
   var
-    topicCache = initTable[string, seq[WakuMessage]]()
+    topicCache: TopicCache
   
   proc topicHandler(topic: string, data: seq[byte]) {.async.} =
     trace "Topic handler triggered"
@@ -29,6 +32,7 @@ proc installRelayApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
       if msgs.len >= maxCache:
         # Message cache on this topic exceeds maximum. Delete oldest.
+        # @TODO this may become a bottle neck if called as the norm rather than exception when adding messages. Performance profile needed.
         msgs.delete(0,0)
       msgs.add(msg[])
 


### PR DESCRIPTION
This PR adds minor improvements for #299, specifically the Filter and Relay APIs:
- limit number of messages cacheable per topic/content topic
- modify a copy rather than the underlying data structure (this split should make it easier to eventually move the cache somewhere else, or even make it global)