### PR TITLE
Fix Windows CI: binary reference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,5 +88,5 @@ jobs:
       - name: Run Tests
         run: |
           mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% LOG_LEVEL=TRACE
-          build\wakunode.exe --help
+          build\wakunode1.exe --help
           mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% test


### PR DESCRIPTION
Fixes Windows CI. Problem first reported in https://github.com/status-im/nim-waku/pull/310. Binary target was renamed from `wakunode` -> `wakunode1`.