### PR TITLE
Prefer announced addrs in listenStr

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -59,7 +59,7 @@ procSuite "Waku v2 JSON-RPC API":
     let response = await client.get_waku_v2_debug_v1_info()
 
     check:
-      response.listenStr == $node.peerInfo.addrs[0] & "/p2p/" & $node.peerInfo.peerId
+      response.listenStr == $node.peerInfo.addrs[^1] & "/p2p/" & $node.peerInfo.peerId
 
     server.stop()
     server.close()


### PR DESCRIPTION
This PR relates to #339.

It changes `info` to prefer the latest announced address as returned `listenStr`.

### Outstanding items:
There is currently no way to manually specify an external port while performing [NAT setup](https://github.com/status-im/nim-waku/blob/master/waku/common/utils/nat.nim#L23-L24). The current implementation assumes the external port is the same as the bind port if only an external IP is configured. Unless this was by design, we should probably allow for manual `extPort` configuration that defaults to the bind port if no port mapping is configured.