### PR TITLE
Added waku metrics

### DIFF
--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -87,7 +87,7 @@ prometheus with this config, e.g.:
 
 ```bash
 cd ./metrics/prometheus
-prometheus
+prometheus --config.file=prometheus.yml
 ```
 
 A Grafana dashboard containing the example dashboard for each simulation node

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -9,8 +9,6 @@ import
   libp2p/protocols/pubsub/rpc/messages,
   libp2p/stream/connection
 
-declarePublicGauge total_messages, "number of messages received"
-
 logScope:
     topics = "wakurelay"
 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -35,6 +35,9 @@ import
 
 export waku_swap_types
 
+declarePublicGauge waku_swap_peers, "number of swap peers"
+declarePublicGauge waku_swap_errors, "number of swap protocol errors", ["type"]
+
 logScope:
   topics = "wakuswap"
 
@@ -115,6 +118,7 @@ proc init*(wakuSwap: WakuSwap) =
     var res = Cheque.init(message)
     if res.isErr:
       error "failed to decode rpc"
+      waku_swap_errors.inc(labelValues = ["decode_rpc_failure"])
       return
 
     info "received cheque", value=res.value
@@ -171,6 +175,7 @@ proc init*(T: type WakuSwap, switch: Switch, rng: ref BrHmacDrbgContext): T =
 
 proc setPeer*(ws: WakuSwap, peer: PeerInfo) =
   ws.peers.add(SwapPeer(peerInfo: peer))
+  waku_swap_peers.inc()
 
 # TODO End to end communication
 


### PR DESCRIPTION
This PR addresses #324 

It adds a number of metrics for `wakunode2` and related protocols.

1. All waku-related metric names are prefixed `waku_` to make group queries easier (and sorting on Prometheus).
2. Message counters are labelled according to protocol ("relay", "filter" and "store"). For debugging, we could consider adding topic/content topic labels. If the number of topics grow excessively large, however, there will be a corresponding label explosion, so I've avoided this approach for now.
3. There is a single `error` counter per protocol, with different labels for different error types. It's easier to build dashboards/query metrics this way, though care must of course be taken when defining new error types to avoid a label explosion.
4. I've also added a number of gauges to keep track of peers/subscriptions/filters/etc for each `waku` protocol. Under the hood, `libp2p` already provides enough GossipSub/Pubsub metrics for visibility into `WakuRelay` (including PubSub peers, subscribed topics, etc.).

Updates to the grafana dashboards to follow.