### PR TITLE
Peer manager: improvements; waku_filter integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Refactor: Split out `waku_types` types into right place; create utils folder.
 - Docs: Add information on how to query Status test fleet for node addresses; how to view logs and how to update submodules.
+- PubSub topic `subscribe` and `unsubscribe` no longer returns a future (removed `async` designation)
+- Added a peer manager for `relay` and `filter` peers.
 
 ## 2021-01-05 v0.2
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -8,7 +8,8 @@ import
   libp2p/stream/[bufferstream, connection],
   libp2p/crypto/crypto,
   libp2p/multistream,
-  ../../waku/v2/protocol/[message_notifier],
+  ../../waku/v2/node/peer_manager,
+  ../../waku/v2/protocol/message_notifier,
   ../../waku/v2/protocol/waku_filter/waku_filter,
   ../test_helpers, ./utils
 
@@ -37,7 +38,7 @@ procSuite "Waku Filter":
       responseRequestIdFuture.complete(requestId)
 
     let
-      proto = WakuFilter.init(dialSwitch, crypto.newRng(), handle)
+      proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
       rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
 
     dialSwitch.mount(proto)
@@ -47,14 +48,14 @@ procSuite "Waku Filter":
       discard
 
     let 
-      proto2 = WakuFilter.init(listenSwitch, crypto.newRng(), emptyHandle)
+      proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
       subscription = proto2.subscription()
 
     var subscriptions = newTable[string, MessageNotificationSubscription]()
     subscriptions["test"] = subscription
     listenSwitch.mount(proto2)
 
-    let id = await proto.subscribe(rpc)
+    let id = (await proto.subscribe(rpc)).get()
 
     await sleepAsync(2.seconds)
 
@@ -86,7 +87,7 @@ procSuite "Waku Filter":
       responseCompletionFuture.complete(true)
 
     let
-      proto = WakuFilter.init(dialSwitch, crypto.newRng(), handle)
+      proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
       rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
 
     dialSwitch.mount(proto)
@@ -96,14 +97,14 @@ procSuite "Waku Filter":
       discard
 
     let 
-      proto2 = WakuFilter.init(listenSwitch, crypto.newRng(), emptyHandle)
+      proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
       subscription = proto2.subscription()
 
     var subscriptions = newTable[string, MessageNotificationSubscription]()
     subscriptions["test"] = subscription
     listenSwitch.mount(proto2)
 
-    let id = await proto.subscribe(rpc)
+    let id = (await proto.subscribe(rpc)).get()
 
     await sleepAsync(2.seconds)
 
@@ -128,3 +129,30 @@ procSuite "Waku Filter":
     check:
       # Check that unsubscribe works as expected
       (await responseCompletionFuture.withTimeout(5.seconds)) == false
+  
+  asyncTest "handle filter subscribe failures":
+    const defaultTopic = "/waku/2/default-waku/proto"
+
+    let
+      key = PrivateKey.random(ECDSA, rng[]).get()
+      peer = PeerInfo.init(key)
+      contentTopic = ContentTopic(1)
+      post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
+
+    var dialSwitch = newStandardSwitch()
+    discard await dialSwitch.start()
+
+    var responseRequestIdFuture = newFuture[string]()
+    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+      discard
+
+    let
+      proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
+
+    dialSwitch.mount(proto)
+
+    let idOpt = (await proto.subscribe(rpc))
+
+    check:
+      idOpt.isNone

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -134,10 +134,7 @@ procSuite "Waku Filter":
     const defaultTopic = "/waku/2/default-waku/proto"
 
     let
-      key = PrivateKey.random(ECDSA, rng[]).get()
-      peer = PeerInfo.init(key)
       contentTopic = ContentTopic(1)
-      post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -1,5 +1,5 @@
 import
-  std/[tables, sequtils],
+  std/[tables, sequtils, options],
   bearssl,
   chronos, chronicles, metrics, stew/results,
   libp2p/protocols/pubsub/pubsubpeer,
@@ -9,10 +9,10 @@ import
   libp2p/protobuf/minprotobuf,
   libp2p/stream/connection,
   libp2p/crypto/crypto,
-  libp2p/switch,
   ../message_notifier,
   waku_filter_types,
-  ../../utils/requests
+  ../../utils/requests,
+  ../../node/peer_manager
 
 # NOTE This is just a start, the design of this protocol isn't done yet. It
 # should be direct payload exchange (a la req-resp), not be coupled with the
@@ -185,10 +185,10 @@ method init*(wf: WakuFilter) =
   wf.handler = handle
   wf.codec = WakuFilterCodec
 
-proc init*(T: type WakuFilter, switch: Switch, rng: ref BrHmacDrbgContext, handler: MessagePushHandler): T =
+proc init*(T: type WakuFilter, peerManager: PeerManager, rng: ref BrHmacDrbgContext, handler: MessagePushHandler): T =
   new result
   result.rng = crypto.newRng()
-  result.switch = switch
+  result.peerManager = peerManager
   result.pushHandler = handler
   result.init()
 
@@ -208,26 +208,47 @@ proc subscription*(proto: WakuFilter): MessageNotificationSubscription =
       for filter in subscriber.filter.contentFilters:
         if msg.contentTopic in filter.topics:
           let push = FilterRPC(requestId: subscriber.requestId, push: MessagePush(messages: @[msg]))
-          let conn = await proto.switch.dial(subscriber.peer.peerId, subscriber.peer.addrs, WakuFilterCodec)
-          await conn.writeLP(push.encode().buffer)
+          
+          let connOpt = await proto.peerManager.dialPeer(subscriber.peer, WakuFilterCodec)
+
+          if connOpt.isSome:
+            await connOpt.get().writeLP(push.encode().buffer)
+          else:
+            # @TODO more sophisticated error handling here
+            error "failed to push messages to remote peer"
+            waku_filter_errors.inc(labelValues = ["dial_failure"])
           break
 
   MessageNotificationSubscription.init(@[], handle)
 
-proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[string] {.async, gcsafe.} =
-  let id = generateRequestId(wf.rng)
+proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[Option[string]] {.async, gcsafe.} =
   if wf.peers.len >= 1:
-    let peer = wf.peers[0].peerInfo
-    # @TODO: THERE SHOULD BE ERROR HANDLING HERE, WHAT IF A PEER IS GONE? WHAT IF THERE IS A TIMEOUT ETC.
-    let conn = await wf.switch.dial(peer.peerId, peer.addrs, WakuFilterCodec)
-    await conn.writeLP(FilterRPC(requestId: id, request: request).encode().buffer)
-  result = id
+    let peer = wf.peers[0].peerInfo # @TODO: select peer from manager rather than from local set
+    
+    let connOpt = await wf.peerManager.dialPeer(peer, WakuFilterCodec)
+
+    if connOpt.isSome:
+      # This is the only successful path to subscription
+      let id = generateRequestId(wf.rng)
+      await connOpt.get().writeLP(FilterRPC(requestId: id, request: request).encode().buffer)
+      return some(id)
+    else:
+      # @TODO more sophisticated error handling here
+      error "failed to connect to remote peer"
+      waku_filter_errors.inc(labelValues = ["dial_failure"])
+      return none(string)
 
 proc unsubscribe*(wf: WakuFilter, request: FilterRequest) {.async, gcsafe.} =
   # @TODO: NO REAL REASON TO GENERATE REQUEST ID FOR UNSUBSCRIBE OTHER THAN CREATING SANE-LOOKING RPC.
   let id = generateRequestId(wf.rng)
   if wf.peers.len >= 1:
-    let peer = wf.peers[0].peerInfo
-    # @TODO: THERE SHOULD BE ERROR HANDLING HERE, WHAT IF A PEER IS GONE? WHAT IF THERE IS A TIMEOUT ETC.
-    let conn = await wf.switch.dial(peer.peerId, peer.addrs, WakuFilterCodec)
-    await conn.writeLP(FilterRPC(requestId: id, request: request).encode().buffer)
+    let peer = wf.peers[0].peerInfo # @TODO: select peer from manager rather than from local set
+    
+    let connOpt = await wf.peerManager.dialPeer(peer, WakuFilterCodec)
+    
+    if connOpt.isSome:
+      await connOpt.get().writeLP(FilterRPC(requestId: id, request: request).encode().buffer)
+    else:
+      # @TODO more sophisticated error handling here
+      error "failed to connect to remote peer"
+      waku_filter_errors.inc(labelValues = ["dial_failure"])

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -30,6 +30,12 @@ logScope:
 const
   WakuFilterCodec* = "/vac/waku/filter/2.0.0-beta1"
 
+
+# Error types (metric label values)
+const
+  dialFailure = "dial_failure"
+  decodeRpcFailure = "decode_rpc_failure"
+
 proc notify*(filters: Filters, msg: WakuMessage, requestId: string = "") =
   for key in filters.keys:
     let filter = filters[key]
@@ -166,7 +172,7 @@ method init*(wf: WakuFilter) =
     var res = FilterRPC.init(message)
     if res.isErr:
       error "failed to decode rpc"
-      waku_filter_errors.inc(labelValues = ["decode_rpc_failure"])
+      waku_filter_errors.inc(labelValues = [decodeRpcFailure])
       return
 
     info "filter message received"
@@ -216,7 +222,7 @@ proc subscription*(proto: WakuFilter): MessageNotificationSubscription =
           else:
             # @TODO more sophisticated error handling here
             error "failed to push messages to remote peer"
-            waku_filter_errors.inc(labelValues = ["dial_failure"])
+            waku_filter_errors.inc(labelValues = [dialFailure])
           break
 
   MessageNotificationSubscription.init(@[], handle)
@@ -235,7 +241,7 @@ proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[Option[string]] 
     else:
       # @TODO more sophisticated error handling here
       error "failed to connect to remote peer"
-      waku_filter_errors.inc(labelValues = ["dial_failure"])
+      waku_filter_errors.inc(labelValues = [dialFailure])
       return none(string)
 
 proc unsubscribe*(wf: WakuFilter, request: FilterRequest) {.async, gcsafe.} =
@@ -251,4 +257,4 @@ proc unsubscribe*(wf: WakuFilter, request: FilterRequest) {.async, gcsafe.} =
     else:
       # @TODO more sophisticated error handling here
       error "failed to connect to remote peer"
-      waku_filter_errors.inc(labelValues = ["dial_failure"])
+      waku_filter_errors.inc(labelValues = [dialFailure])

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -1,8 +1,9 @@
 import
   std/[tables],
   bearssl,
-  libp2p/[switch, peerinfo],
+  libp2p/peerinfo,
   libp2p/protocols/protocol,
+  ../../node/peer_manager,
   ../waku_message
 
 export waku_message
@@ -45,7 +46,7 @@ type
 
   WakuFilter* = ref object of LPProtocol
     rng*: ref BrHmacDrbgContext
-    switch*: Switch
+    peerManager*: PeerManager
     peers*: seq[FilterPeer]
     subscribers*: seq[Subscriber]
     pushHandler*: MessagePushHandler


### PR DESCRIPTION
This is a further increment towards #358

It adds the following to the Waku peer manager:
- duplicate handling (a requirement for `filter`, `store` and `swap` peers that are dialed on an ad-hoc basis)
- first step towards integration with `filter` protocol. Since the peer manager includes basic error handling for dialing failures, this has the side effect of improving error handling for the `filter` protocol.

#### Suggested next steps:
1. Peer selection per protocol in peer manager (eventually using scoring mechanisms to select most appropriate peer).
2. Integrate manager with other Waku v2 protocols: `store` and `swap`
3. Remove local `set` of `peers` for `filter`, `store` and `swap` protocols (i.e. use only `peer manager` for peer storing and selection)
4. Keep track of waku-related metadata for peers (incl. their connection status and behaviour) in an extended peer store.