### PR TITLE
Integrate peer manager with Swap and Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Refactor: Split out `waku_types` types into right place; create utils folder.
 - Docs: Add information on how to query Status test fleet for node addresses; how to view logs and how to update submodules.
 - PubSub topic `subscribe` and `unsubscribe` no longer returns a future (removed `async` designation)
-- Added a peer manager for `relay` and `filter` peers.
+- Added a peer manager for `relay`, `filter`, `store` and `swap` peers.
 
 ## 2021-01-05 v0.2
 

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -421,6 +421,10 @@ procSuite "Waku v2 JSON-RPC API":
   
   asyncTest "Admin API: get unmanaged peer information":
     const cTopic = ContentTopic(1)
+    let
+      nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
+        Port(60000))
 
     waitFor node.start()
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -11,6 +11,7 @@ import
   ../../waku/v2/protocol/[waku_message, message_notifier],
   ../../waku/v2/protocol/waku_store/waku_store,
   ../../waku/v2/node/message_store/waku_message_store,
+  ../../waku/v2/node/peer_manager,
   ../test_helpers, ./utils
 
 procSuite "Waku Store":
@@ -29,7 +30,7 @@ procSuite "Waku Store":
     discard await listenSwitch.start()
 
     let
-      proto = WakuStore.init(dialSwitch, crypto.newRng())
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
       rpc = HistoryQuery(topics: @[topic])
 
@@ -73,7 +74,7 @@ procSuite "Waku Store":
     discard await listenSwitch.start()
 
     let
-      proto = WakuStore.init(dialSwitch, crypto.newRng(), store)
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       subscription = proto.subscription()
       rpc = HistoryQuery(topics: @[topic])
 
@@ -101,7 +102,7 @@ procSuite "Waku Store":
       (await completionFut.withTimeout(5.seconds)) == true
 
     let 
-      proto2 = WakuStore.init(dialSwitch, crypto.newRng(), store)
+      proto2 = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       key2 = PrivateKey.random(ECDSA, rng[]).get()
 
     var listenSwitch2 = newStandardSwitch(some(key2))
@@ -146,7 +147,7 @@ procSuite "Waku Store":
     discard await listenSwitch.start()
 
     let
-      proto = WakuStore.init(dialSwitch, crypto.newRng())
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
       rpc = HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
@@ -198,7 +199,7 @@ procSuite "Waku Store":
     discard await listenSwitch.start()
 
     let
-      proto = WakuStore.init(dialSwitch, crypto.newRng())
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -248,7 +249,7 @@ procSuite "Waku Store":
     discard await listenSwitch.start()
 
     let
-      proto = WakuStore.init(dialSwitch, crypto.newRng())
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
     proto.setPeer(listenSwitch.peerInfo)
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -292,7 +292,7 @@ proc mountFilter*(node: WakuNode) =
 # because store is using a reference to the swap protocol.
 proc mountSwap*(node: WakuNode) =
   info "mounting swap"
-  node.wakuSwap = WakuSwap.init(node.switch, node.rng)
+  node.wakuSwap = WakuSwap.init(node.peerManager, node.rng)
   node.switch.mount(node.wakuSwap)
   # NYI - Do we need this?
   #node.subscriptions.subscribe(WakuSwapCodec, node.wakuSwap.subscription())
@@ -302,10 +302,10 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil) =
 
   if node.wakuSwap.isNil:
     debug "mounting store without swap"
-    node.wakuStore = WakuStore.init(node.switch, node.rng, store)
+    node.wakuStore = WakuStore.init(node.peerManager, node.rng, store)
   else:
     debug "mounting store with swap"
-    node.wakuStore = WakuStore.init(node.switch, node.rng, store, node.wakuSwap)
+    node.wakuStore = WakuStore.init(node.peerManager, node.rng, store, node.wakuSwap)
 
   node.switch.mount(node.wakuStore)
   node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -2,12 +2,13 @@
 
 import
   bearssl,
-  libp2p/[switch, peerinfo],
+  libp2p/peerinfo,
   libp2p/protocols/protocol,
   ../waku_swap/waku_swap_types,
   ../waku_message,
   ../../node/message_store/message_store,
-  ../../utils/pagination
+  ../../utils/pagination,
+  ../../node/peer_manager
 
 export waku_message
 export pagination
@@ -52,7 +53,7 @@ type
     peerInfo*: PeerInfo
 
   WakuStore* = ref object of LPProtocol
-    switch*: Switch
+    peerManager*: PeerManager
     rng*: ref BrHmacDrbgContext
     peers*: seq[HistoryPeer]
     messages*: seq[IndexedWakuMessage]

--- a/waku/v2/protocol/waku_swap/waku_swap_types.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_types.nim
@@ -2,8 +2,8 @@ import
   std/tables,
   bearssl,
   libp2p/protocols/protocol,
-  libp2p/switch,
-  libp2p/peerinfo
+  libp2p/peerinfo,
+  ../../node/peer_manager  
 
 type
   Beneficiary* = seq[byte]
@@ -24,7 +24,7 @@ type
     peerInfo*: PeerInfo
 
   WakuSwap* = ref object of LPProtocol
-    switch*: Switch
+    peerManager*: PeerManager
     rng*: ref BrHmacDrbgContext
     peers*: seq[SwapPeer]
     text*: string


### PR DESCRIPTION
This is a further increment towards #358

It integrates the Waku peer manager with the `store` and `swap` protocols.

#### Suggested next steps:
1. Peer selection per protocol in peer manager (eventually using scoring mechanisms to select most appropriate peer).
2. Remove local `set` of `peers` for `filter`, `store` and `swap` protocols (i.e. use only `peer manager` for peer storing and selection)
3. Keep track of waku-related metadata for peers (incl. their connection status and behaviour) in an extended peer store.