### PR TITLE
Better error handling with Results from interactions with swap-contracts-module

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -7,7 +7,7 @@ import
   ./v2/test_waku_filter,
   ./v2/test_waku_pagination,
   ./v2/test_waku_payload,
-#  ./v2/test_waku_swap,
+  ./v2/test_waku_swap,
   ./v2/test_message_store,
   ./v2/test_jsonrpc_waku,
   ./v2/test_peer_manager,

--- a/tests/v2/test_waku_swap_contracts.nim
+++ b/tests/v2/test_waku_swap_contracts.nim
@@ -19,10 +19,11 @@ procSuite "Basic balance test":
 
   test "Get balance from running node":
     # NOTE: This corresponds to the first default account in Hardhat
-    let balance = waku_swap_contracts.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+    let balRes = waku_swap_contracts.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 
     check:
-      parseFloat(balance) > 0
+      balRes.isOk()
+      parseFloat(balRes[]) > 0
 
   test "Setup Swap":
     let json = waku_swap_contracts.setupSwap()
@@ -38,10 +39,15 @@ procSuite "Basic balance test":
       contains(aliceAddress, "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 
   test "Sign Cheque":
-    signature = waku_swap_contracts.signCheque(aliceSwapAddress)
+    var sigRes = waku_swap_contracts.signCheque(aliceSwapAddress)
+
+    # Used in later tests
+    if sigRes.isOk():
+      signature = sigRes[]
 
     check:
-      contains(signature, "0x")
+      sigRes.isOk()
+      contains(sigRes[], "0x")
 
   test "Get ERC20 Balances":
     let json = getERC20Balances(erc20address)

--- a/tests/v2/test_waku_swap_contracts.nim
+++ b/tests/v2/test_waku_swap_contracts.nim
@@ -20,13 +20,19 @@ procSuite "Basic balance test":
   test "Get balance from running node":
     # NOTE: This corresponds to the first default account in Hardhat
     let balRes = waku_swap_contracts.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+    var balance: float
+    if balRes.isOk():
+      let json = balRes[]
+      let balanceStr = json["balance"].getStr()
+      balance = parseFloat(balanceStr)
 
     check:
       balRes.isOk()
-      parseFloat(balRes[]) > 0
+      balance > 0
 
   test "Setup Swap":
-    let json = waku_swap_contracts.setupSwap()
+    let res = waku_swap_contracts.setupSwap()
+    let json = res[]
 
     var aliceAddress = json["aliceAddress"].getStr()
     aliceSwapAddress = json["aliceSwapAddress"].getStr()
@@ -40,14 +46,13 @@ procSuite "Basic balance test":
 
   test "Sign Cheque":
     var sigRes = waku_swap_contracts.signCheque(aliceSwapAddress)
-
-    # Used in later tests
     if sigRes.isOk():
-      signature = sigRes[]
+      let json = sigRes[]
+      signature = json["signature"].getStr()
 
     check:
       sigRes.isOk()
-      contains(sigRes[], "0x")
+      contains(signature, "0x")
 
   test "Get ERC20 Balances":
     let res = waku_swap_contracts.getERC20Balances(erc20address)

--- a/tests/v2/test_waku_swap_contracts.nim
+++ b/tests/v2/test_waku_swap_contracts.nim
@@ -50,20 +50,21 @@ procSuite "Basic balance test":
       contains(sigRes[], "0x")
 
   test "Get ERC20 Balances":
-    let json = getERC20Balances(erc20address)
+    let res = waku_swap_contracts.getERC20Balances(erc20address)
 
     check:
-      json["bobBalance"].getInt() == 10000
+      res.isOk()
+      res[]["bobBalance"].getInt() == 10000
 
   test "Redeem cheque and check balance":
-    let json = waku_swap_contracts.redeemCheque(aliceSwapAddress, signature)
-    var resp = json["resp"].getStr()
-    debug "json", json
+    let redeemRes = waku_swap_contracts.redeemCheque(aliceSwapAddress, signature)
+    var resp = redeemRes[]["resp"].getStr()
+    debug "Redeem resp", resp
 
-    debug "Get balances"
-    let json2 = getERC20Balances(erc20address)
-    debug "json", json2
+    let balRes = getERC20Balances(erc20address)
 
     # Balance for Bob has now increased
     check:
-      json2["bobBalance"].getInt() == 10500
+      redeemRes.isOk()
+      balRes.isOk()
+      balRes[]["bobBalance"].getInt() == 10500

--- a/tests/v2/test_waku_swap_contracts.nim
+++ b/tests/v2/test_waku_swap_contracts.nim
@@ -22,7 +22,7 @@ procSuite "Basic balance test":
     let balance = waku_swap_contracts.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 
     check:
-      contains(balance, "ETH")
+      parseFloat(balance) > 0
 
   test "Setup Swap":
     let json = waku_swap_contracts.setupSwap()

--- a/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
@@ -27,7 +27,12 @@ proc getBalance*(accountAddress: string): string =
     let task = "balance --account " & $accountAddress
     let (output, errC) = execNodeTask(task)
     debug "getBalance", output
-    return output
+
+  # XXX Assume succeeds
+    let json = parseJson(output)
+    let balance = json["balance"].getStr()
+    debug "getBalance", json=json, balance=balance
+    return balance
 
 proc setupSwap*(): JsonNode =
     let task = "setupSwap"
@@ -37,7 +42,7 @@ proc setupSwap*(): JsonNode =
     let json = parseJson(output)
     return json
  
-# TODO Signature
+# TODO JSON
 proc signCheque*(swapAddress: string): string =
   let task = "signCheque --swapaddress '" & $swapAddress & "'"
   let (output, errC) = execNodeTask(task)

--- a/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_contracts.nim
@@ -3,7 +3,7 @@
 # Assumes swap-contracts-module node is running.
 #
 
-#{.push raises: [Defect].}
+{.push raises: [Defect].}
 
 import
   std/[osproc, strutils, json],
@@ -13,76 +13,58 @@ logScope:
   topics = "wakuswapcontracts"
 
 # TODO Richer error types than string, overkill for now...
-type NodeTaskStrResult = Result[string, string]
 type NodeTaskJsonResult = Result[JsonNode, string]
 
-# XXX In general this is not a good API, more a collection of hacky glue code for PoC.
-#
-# TODO Error handling
+# XXX In general this is not a great API, more a collection of hacky glue code for PoC.
 
 # Interacts with node in sibling path and interacts with a local Hardhat node.
 const taskPrelude = "npx hardhat --network localhost "
 const cmdPrelude = "cd ../swap-contracts-module; " & taskPrelude
 
-proc execNodeTask(taskStr: string): tuple[output: TaintedString, exitCode: int] =
-  let cmdString = $cmdPrelude & $taskStr
-  debug "execNodeTask", cmdString
-  return osproc.execCmdEx(cmdString)
+# proc execNodeTask(taskStr: string): tuple[output: TaintedString, exitCode: int] =
+#   let cmdString = $cmdPrelude & $taskStr
+#   debug "execNodeTask", cmdString
+#   return osproc.execCmdEx(cmdString)
 
 proc execNodeTaskJson(taskStr: string): NodeTaskJsonResult =
   let cmdString = $cmdPrelude & $taskStr
   debug "execNodeTask", cmdString
-  let (output, errC) = osproc.execCmdEx(cmdString)
-
-  if errC>0:
-    error "Error executing node task", output
-    return err(output)
-
-  debug "Command executed", output
 
   try:
-    let json = parseJson(output)
-    return ok(json)
-  except JsonParsingError:
-    return err("Unable to parse JSON:" & $output)
+    let (output, errC) = osproc.execCmdEx(cmdString)
+    if errC>0:
+      error "Error executing node task", output
+      return err(output)
 
+    debug "Command executed", output
 
-proc getBalance*(accountAddress: string): NodeTaskStrResult =
+    try:
+      let json = parseJson(output)
+      return ok(json)
+    except JsonParsingError:
+      return err("Unable to parse JSON:" & $output)
+    except Exception:
+      return err("Unable to parse JSON:" & $output)
+
+  except OSError:
+    return err("Unable to execute command, OSError:" & $taskStr)
+  except Exception:
+    return err("Unable to execute command:" & $taskStr)
+
+proc getBalance*(accountAddress: string): NodeTaskJsonResult =
     let task = "balance --account " & $accountAddress
     let res = execNodeTaskJson(task)
-    if res.isErr():
-      return err("Unable to execute task" & $res)
+    return res
 
-    let json = res[]
-    let balance = json["balance"].getStr()
-    debug "getBalance", json=json, balance=balance
-    return ok(balance)
-
-proc setupSwap*(): JsonNode =
+proc setupSwap*(): NodeTaskJsonResult =
     let task = "setupSwap"
-    let (output, errC) = execNodeTask(task)
-
-    # XXX Assume succeeds
-    let json = parseJson(output)
-    return json
+    let res = execNodeTaskJson(task)
+    return res
  
-proc signCheque*(swapAddress: string): NodeTaskStrResult =
+proc signCheque*(swapAddress: string): NodeTaskJsonResult =
   let task = "signCheque --swapaddress '" & $swapAddress & "'"
-  var (output, errC) = execNodeTask(task)
-
-  if errC>0:
-    error "Error executing node task", output
-    return err(output)
-
-  debug "Command executed", output
-
-  try:
-    let json = parseJson(output)
-    let signature = json["signature"].getStr()
-    info "signCheque", json=json, signature=signature
-    return ok(signature)
-  except JsonParsingError:
-    return err("Unable to parse JSON:" & $output)
+  var res = execNodeTaskJson(task)
+  return res
 
 proc getERC20Balances*(erc20address: string): NodeTaskJsonResult =
     let task = "getBalances --erc20address '" & $erc20address & "'"
@@ -98,7 +80,7 @@ proc redeemCheque*(swapAddress: string, signature: string): NodeTaskJsonResult =
 when isMainModule:
   var aliceSwapAddress = "0x6C3d502f1a97d4470b881015b83D9Dd1062172e1"
   var sigRes = signCheque(aliceSwapAddress)
-  if sigRes.isOk:
+  if sigRes.isOk():
     echo "All good"
     echo "Signature ", sigRes[]
   else:


### PR DESCRIPTION
Previously it was swallowing errors and crashing when not running.

This will allow tests to be enabled by default, albeit without a working running node certain settlement behavior won't be triggered (though these tests can be separated better than the p2p paths)

- Use results, raise defect, exception handling
- JSON used more consistently
- Re-enable waku swap tests (not crashing, just not settling if node interaction isn't working)