### PR TITLE
ci: add rust and cargo to fix builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG NIM_PARAMS
 ARG MAKE_TARGET=wakunode
 
 # Get build tools and required header files
-RUN apk add --no-cache bash build-base pcre-dev linux-headers git
+RUN apk add --no-cache bash git rust cargo build-base pcre-dev linux-headers
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Fixes:
```
15:01:12  Building: Nim compiler
15:01:14  HEAD is now at a80f5d0 move member index to auth object
15:01:14  bash: cargo: command not found
```