### PR TITLE
chat2 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 /metrics/waku-sim-all-nodes-grafana-dashboard.json
 
 rln
+*.log

--- a/waku.nimble
+++ b/waku.nimble
@@ -82,7 +82,7 @@ task chat2, "Build example Waku v2 chat usage":
   # NOTE For debugging, set debug level. For chat usage we want minimal log
   # output to STDOUT. Can be fixed by redirecting logs to file (e.g.)
   #buildBinary name, "examples/v2/", "-d:chronicles_log_level=WARN"
-  buildBinary name, "examples/v2/", "-d:chronicles_log_level=DEBUG"
+  buildBinary name, "examples/v2/", "-d:chronicles_log_level=DEBUG -d:chronicles_sinks=textlines[file] -d:ssl"
 
 task bridge, "Build Waku v1 - v2 bridge":
   buildBinary "wakubridge", "waku/common/", "-d:chronicles_log_level=DEBUG"


### PR DESCRIPTION
This is an incremental PR towards #399

It adds the following improvements to the `chat2` application:
1. Logs are now written to a file (`chat2.log`) rather than to `stdout`. The latter is now only used for the chat app itself.
2. Added a chat prompt (`>> `).
3. A nickname can now be set before starting a chat session and changed using the `/nick` command. This is prepended to each published message.
4. Each message in the chat is now prepended by a UTC timestamp.
5. If no static node is set, one will now be selected (at random) from the list of `wakuv2.test` nodes published at `https://fleets.status.im`. (In order to test this, simply run `./build/chat2` with no `--staticnode` argument. `--storenode` unfortunately still needs to be configured - I ran into some issues while trying to automate its selection.)

### Further improvements:
1. Store node selection in similar manner to static node selection.
2. Instruction manual and better configuration
??

This is very much a WIP, so it would be great to get your initial feedback after trying the app :D