### PR TITLE
Further chat2 improvements

### DIFF
--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -1,0 +1,71 @@
+# Using the `chat2` application
+
+## Background
+
+The `chat2` application is a basic command-line chat app using the [Waku v2 suite of protocols](https://specs.vac.dev/specs/waku/v2/waku-v2). It connects to a [fleet of test nodes](fleets.status.im) to provide end-to-end p2p chat capabilities. The Waku team is currently using this application for internal testing. If you want try our protocols, or join the dogfooding fun, follow the instructions below.
+
+## Preparation
+
+Ensure you have cloned the `nim-waku` repository and installed all prerequisites as per [these instructions](https://github.com/status-im/nim-waku).
+
+Make the `chat2` target.
+
+```
+make chat2
+```
+
+## Basic application usage
+
+To start the `chat2` application in its most basic form, run the following from the project directory
+
+```
+./build/chat2
+```
+
+You should be prompted to provide a nickname for the chat session.
+
+```
+Choose a nickname >>
+```
+
+After entering a nickname, the app will randomly select and connect to a peer from the test fleet.
+
+```
+No static peers configured. Choosing one at random from test fleet...
+```
+
+Wait for the chat prompt (`>>`) and chat away!
+
+## Retrieving historical messages
+
+The `chat2` application can retrieve historical chat messages from a node supporting and running the [Waku v2 store protocol](https://specs.vac.dev/specs/waku/v2/waku-store). Just specify the selected node's `multiaddr` as `storenode` when starting the app:
+
+```
+./build/chat2 --storenode:/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ
+```
+
+Alternatively, the `chat2` application will select a random `storenode` for you from the test fleet if the `store` option is set to `true` and `storenode` left unspecified.
+
+```
+./build/chat2 --store:true
+```
+
+> *NOTE: Currently (Mar 3, 2021) the only node in the test fleet that provides reliable store functionality is `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ`. We're working on fixing this.*
+
+## Specifying a static peer
+
+In order to connect to a *specific* node as [`relay`](https://specs.vac.dev/specs/waku/v2/waku-relay) peer, define that node's `multiaddr` as a `staticnode` when starting the app:
+
+```
+./build/chat2 --staticnode:/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ
+```
+
+This will bypass the random peer selection process and connect to the specified node.
+
+## In-chat options
+
+| Command | Effect |
+| --- | --- |
+| `/help` | displays available in-chat commands |
+| `/connect` | interactively connect to a new peer |
+| `/nick` | change nickname for current chat session |

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -19,7 +19,7 @@ import
 
 export waku_store_types
 
-declarePublicGauge waku_store_messages, "number of historical messages"
+declarePublicGauge waku_store_messages, "number of historical messages", ["type"]
 declarePublicGauge waku_store_peers, "number of store peers"
 declarePublicGauge waku_store_errors, "number of store protocol errors", ["type"]
 


### PR DESCRIPTION
This is a further incremental PR towards #399

## What's new?

This PR adds the following improvements/fixes to `chat2`:
1. Short date now also prepended to chat messages, in addition to UTC time and nickname.
2. Fixed `metrics error`.
3. Random `storenode` now auto-selected if `store` set to `true` and no `storenode` specified.
4. A basic tutorial.

In principle it should now be possible to run a `chat2` application that auto-selects both a `relay` and `store` peer from the test cluster by simply running the command
```
./build/chat2 --store:true
```
However, see existing issue re historical messages below ->

### Why are my historical messages absent or not ordered by time?

> TL;DR: Basically something strange is happening on the test cluster, likely to do with connectivity or a bug in the `store` protocol. Use `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ` as both `staticnode` and `storenode` in the meantime.

The issues with historical messages and the test nodes acting up has proven more difficult to solve. Here's what I found so far:
1. If you connect to `/ip4/104.154.239.128/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ` as _staticnode_, historical messages won't load and you may not be able to relay messages to other peers, regardless of what `storenode` is configured. It works perfecly well as `storenode`, though, but only if `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ` is configured as `staticnode`. :shrug:
2. If (1) is false, but you have configured any node other than `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ` as `storenode`, historical messages will either appear in a strange order or not at all.

Given the above, it's basically a gamble if you're going to be able to download historical messages in a consistent manner if node selection is done at random. _For now_ I therefore recommend specifying _both_ the `staticnode` and `storenode` as `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ` when starting your application, while I'm investigating the cluster issue and trying to find the bug(s) responsible.

### What's next?
1. Fixing the issue(s) with historical message retrieval.
2. Adding topic selection.
