### PR TITLE
Fix Docker image - missing librln.so file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
+# Fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
+COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+
 # Symlink the correct wakunode binary
 RUN ln -sv /usr/local/bin/$MAKE_TARGET /usr/bin/wakunode
 


### PR DESCRIPTION
@jakubgs now that the rln library is included as a nim-waku submodule, I can fix the Docker image and specifically the error: `Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory`

Just copying the missing file to the image works for me locally. This may violate a dozen best practices, though, so lmk if there's a better way.

The aim is to have the Jenkins jobs `deploy-v2-test` and `deploy-v2-prod` point to the `nim-waku` `master` branch again.

Thanks!