### PR TITLE
Add post method to Admin API for ad-hoc peer dialing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PubSub topic `subscribe` and `unsubscribe` no longer returns a future (removed `async` designation)
 - Added a peer manager for `relay`, `filter`, `store` and `swap` peers.
 - `relay`, `filter`, `store` and `swap` peers are now stored in a common, shared peer store and no longer in separate sets.
+- Admin API now provides a `post` method to connect to peers on an ad-hoc basis
 
 ## 2021-01-05 v0.2
 

--- a/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
@@ -1,6 +1,7 @@
 # Admin API
 
 proc get_waku_v2_admin_v1_peers(): seq[WakuPeer]
+proc post_waku_v2_admin_v1_peers(peers: seq[string]): bool
 
 # Debug API
 


### PR DESCRIPTION
As part of addressing status-im/nim-waku#408, we require a method within the Admin API that will trigger ad-hoc dialing of peers from a running node. This PR forms the implementation counterpart of this task. Specification change in https://github.com/vacp2p/specs/pull/298.