### PR TITLE
Fix Relay API: handle messages on previously subscribed topics

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -153,6 +153,23 @@ procSuite "Waku v2 JSON-RPC API":
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort)
 
+    # First see if we can retrieve messages published on the default topic (node is already subscribed)
+    await node2.publish(defaultTopic, message)
+
+    await sleepAsync(2000.millis)
+
+    var messages = await client.get_waku_v2_relay_v1_messages(defaultTopic)
+
+    check:
+      messages.len == 1
+      messages[0].contentTopic == contentTopic
+      messages[0].payload == payload
+    
+    # Ensure that read messages are cleared from cache
+    messages = await client.get_waku_v2_relay_v1_messages(pubSubTopic)  
+    check:
+      messages.len == 0
+
     # Now try to subscribe using API
 
     var response = await client.post_waku_v2_relay_v1_subscriptions(@[pubSubTopic])
@@ -168,7 +185,7 @@ procSuite "Waku v2 JSON-RPC API":
 
     await sleepAsync(2000.millis)
     
-    var messages = await client.get_waku_v2_relay_v1_messages(pubSubTopic)
+    messages = await client.get_waku_v2_relay_v1_messages(pubSubTopic)
 
     check:
       messages.len == 1

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -30,6 +30,9 @@ logScope:
 # Default clientId
 const clientId* = "Nimbus Waku v2 node"
 
+# Default topic
+const defaultTopic = "/waku/2/default-waku/proto"
+
 # key and crypto modules different
 type
   KeyPair* = crypto.KeyPair
@@ -361,7 +364,7 @@ proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string](), rlnRela
       await node.subscriptions.notify(topic, msg.value())
       waku_node_messages.inc(labelValues = ["relay"])
 
-  node.wakuRelay.subscribe("/waku/2/default-waku/proto", relayHandler)
+  node.wakuRelay.subscribe(defaultTopic, relayHandler)
 
   for topic in topics:
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =


### PR DESCRIPTION
This PR closes #411

It fixes a bug in the Relay API where messages on topics previously subscribed to are never handled. The fix adds a handler for each topic already existing (subscribed to) on the node when the Relay API handlers are installed.