### PR TITLE
Add WakuBridge and test

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -12,7 +12,8 @@ import
   ./v2/test_jsonrpc_waku,
   ./v2/test_peer_manager,
   ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  ./v2/test_waku_rln_relay
+  ./v2/test_waku_rln_relay,
+  ./v2/test_waku_bridge
 
 # TODO Only enable this once swap module is integrated more nicely as a dependency, i.e. as submodule with CI etc
 # For PoC execute it manually and run separate module here: https://github.com/vacp2p/swap-contracts-module

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -1,0 +1,89 @@
+{.used.}
+
+import
+  std/unittest,
+  chronicles, chronos, stew/shims/net as stewNet, stew/byteutils,
+  libp2p/crypto/crypto,
+  libp2p/crypto/secp,
+  libp2p/peerid,
+  libp2p/multiaddress,
+  libp2p/switch,
+  libp2p/protocols/pubsub/rpc/messages,
+  libp2p/protocols/pubsub/pubsub,
+  eth/p2p,
+  eth/keys,
+  ../../waku/common/wakubridge,
+  ../../waku/v1/protocol/waku_protocol,
+  ../../waku/v2/protocol/[waku_message, message_notifier],
+  ../../waku/v2/protocol/waku_store/waku_store,
+  ../../waku/v2/protocol/waku_filter/waku_filter,
+  ../../waku/v2/node/wakunode2,
+  ../test_helpers
+
+procSuite "WakuBridge":
+  let rng = keys.newRng()
+
+  asyncTest "Messages are bridged between Waku v1 and Waku v2":
+    let
+      # Bridge
+      nodev1Key = keys.KeyPair.random(rng[])
+      nodev2Key = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      bridge = WakuBridge.new(
+          nodev1Key= nodev1Key,
+          nodev1Address = localAddress(30303),
+          powRequirement = 0.002,
+          rng = rng,
+          nodev2Key = nodev2Key,
+          nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(60000))
+      
+      # Waku v1 node
+      v1Node = setupTestNode(rng, Waku)
+
+      # Waku v2 node
+      v2NodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      v2Node = WakuNode.init(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
+
+      topic = [byte 0x00, 0, 0, byte 0x01]
+      contentTopic = ContentTopic(1)
+      payloadV1 = "hello from V1".toBytes()
+      payloadV2 = "hello from V2".toBytes()
+      message = WakuMessage(payload: payloadV2, contentTopic: contentTopic)
+
+    await bridge.start()
+
+    await v2Node.start()
+    v2Node.mountRelay(@[defaultBridgeTopic])
+
+    discard await v1Node.rlpxConnect(newNode(bridge.nodev1.toENode()))
+    await v2Node.connectToNodes(@[bridge.nodev2.peerInfo])
+
+    var completionFut = newFuture[bool]()
+    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+      let msg = WakuMessage.init(data)
+      if msg.isOk() and msg.value().version == 1:
+        completionFut.complete(true)
+
+    v2Node.subscribe(defaultBridgeTopic, relayHandler)
+
+    await sleepAsync(2000.millis)
+
+    # Test bridging from V2 to V1
+    await v2Node.publish(defaultBridgeTopic, message)
+
+    await sleepAsync(2000.millis)
+
+    check:
+      # v1Node received message published by v2Node
+      v1Node.protocolState(Waku).queue.items.len == 1
+    
+    # Test bridging from V1 to V2
+    check:
+      v1Node.postMessage(ttl = 5,
+                         topic = topic,
+                         payload = payloadV1) == true
+
+      # v2Node received payload published by v1Node
+      await completionFut.withTimeout(5.seconds)
+
+    await bridge.stop()
+    

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -215,6 +215,8 @@ procSuite "Waku rln relay":
     # start rln-relay
     await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
+    await node.stop()
+
 suite "Waku rln relay":
   test "Keygen Nim Wrappers":
     var 


### PR DESCRIPTION
This PR is a further increment towards #205

### Description

Implementation is based on the [Waku bridge specification](https://specs.vac.dev/specs/waku/v2/waku-bridge).

It modifies the Waku bridge script that previously ran a Waku v1 and Waku v2 node in a single process with message bridging, and:
- Introduces the `WakuBridge` node containing both a Waku v1 and Waku v2 node under the hood:
	- The Waku v1 node has `Waku` protocol enabled by default
	- The Waku v2 node mounts `relay` by default and listens/publishes on a default PubSub topic specifically for bridging (currently: `"/waku/2/default-bridge/proto"`)
- The `WakuBridge` transfers envelopes from Waku v1 to Waku v2 and `WakuMessages` from Waku v2 to Waku v1:
	- envelope `topic` corresponds to `WakuMessage` `contentTopic`
	- envelope `data` corresponds to `WakuMessage` `payload`
	- `WakuMessages` have `version` set to `1`

### Next steps:
- More sophisticated tests
- Add bridge metrics
- Filter duplicates to ensure no back and forth "bouncing" of messages between v1 and v2