### PR TITLE
Fix marshalling of message payloads

### DIFF
--- a/waku/v1/node/rpc/hexstrings.nim
+++ b/waku/v1/node/rpc/hexstrings.nim
@@ -138,7 +138,10 @@ proc `%`*(value: waku_protocol.Topic): JsonNode =
   result = %("0x" & value.toHex)
 
 proc `%`*(value: seq[byte]): JsonNode =
-  result = %("0x" & value.toHex)
+  if value.len > 0:
+    result = %("0x" & value.toHex)
+  else:
+    result = newJNull()
 
 # Helpers for the fromJson procs
 
@@ -210,12 +213,6 @@ proc fromJson*(n: JsonNode, argName: string, result: var waku_protocol.Topic) =
 # Following procs currently required only for testing, the `createRpcSigs` macro
 # requires it as it will convert the JSON results back to the original Nim
 # types, but it needs the `fromJson` calls for those specific Nim types to do so
-proc fromJson*(n: JsonNode, argName: string, result: var seq[byte]) =
-  n.kind.expect(JString, argName)
-  let hexStr = n.getStr()
-  if not hexStr.isValidHexData:
-    raise newException(ValueError, invalidMsg(argName) & " as a hex data \"" & hexStr & "\"")
-  result = hexToSeqByte(hexStr)
 
 proc fromJson*(n: JsonNode, argName: string, result: var Hash256) =
   n.kind.expect(JString, argName)

--- a/waku/v1/node/rpc/hexstrings.nim
+++ b/waku/v1/node/rpc/hexstrings.nim
@@ -141,7 +141,7 @@ proc `%`*(value: seq[byte]): JsonNode =
   if value.len > 0:
     result = %("0x" & value.toHex)
   else:
-    result = newJNull()
+    result = newJArray()
 
 # Helpers for the fromJson procs
 

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -1,5 +1,5 @@
 import
-  std/options,
+  std/[options, json, sequtils],
   eth/keys,
   ../../../v1/node/rpc/hexstrings,
   ../../protocol/waku_store/waku_store_types,
@@ -7,6 +7,16 @@ import
   ./jsonrpc_types
 
 export hexstrings
+
+## Json marshalling
+
+proc `%`*(value: WakuMessage): JsonNode =
+  ## This ensures that seq[byte] fields are marshalled to hex-format JStrings
+  ## (as defined in `hexstrings.nim`) rather than the default JArray[JInt]
+  let jObj = newJObject()
+  for k, v in value.fieldPairs:
+    jObj[k] = %v
+  return jObj
 
 ## Conversion tools
 ## Since the Waku v2 JSON-RPC API has its own defined types,


### PR DESCRIPTION
This PR closes #417 and addresses the implementation portion of #415

It
1. improves marshalling of `WakuMessage` payloads to JSON: a `seq[byte]` is now marshalled into a hex-format `JString`.

Previously:
```
{
    "payload": [
        1,
        1,
        1
    ],
    "contentTopic": 0,
    "version": 3
}
```
Now:
```
{
    "payload": "0x010101",
    "contentTopic": 0,
    "version": 3
}
```

2. removes old marshalling code for hex data strings. This has the side-effect of making the `0x` prefix for hex data strings optional in JSON-RPC calls.
