### PR TITLE
Improvement/bridge improvements

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   std/[unittest, options, sets, tables, os, strutils, sequtils],
   stew/shims/net as stewNet,

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -1,3 +1,4 @@
+{.used.}
 
 import
   std/[unittest, options, tables, sets],

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   std/[unittest, options, sets, tables, sequtils],
   stew/shims/net as stewNet,

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   chronos, chronicles, options, stint, unittest,
   web3,

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   std/[unittest, options, tables, sets],
   chronos, chronicles, stew/shims/net as stewNet, stew/byteutils,

--- a/tests/v2/test_web3.nim
+++ b/tests/v2/test_web3.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import web3
 proc web3Test() =
   var web3: Web3 # an identifier from web3 package

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -14,6 +14,9 @@ import
 
 export jsonrpc_types
 
+logScope:
+  topics = "admin api"
+
 const futTimeout* = 30.seconds # Max time to wait for futures
 
 proc constructMultiaddrStr*(wireaddr: MultiAddress, peerId: PeerId): string =

--- a/waku/v2/node/jsonrpc/debug_api.nim
+++ b/waku/v2/node/jsonrpc/debug_api.nim
@@ -2,6 +2,9 @@ import
   json_rpc/rpcserver,
   ../wakunode2
 
+logScope:
+  topics = "debug api"
+
 proc installDebugApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Debug API version 1 definitions

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -10,6 +10,9 @@ import
 
 export jsonrpc_types
 
+logScope:
+  topics = "filter api"
+
 const futTimeout* = 5.seconds # Max time to wait for futures
 const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
 

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -1,5 +1,5 @@
 import
-  std/[options, json, sequtils],
+  std/[options, json],
   eth/keys,
   ../../../v1/node/rpc/hexstrings,
   ../../protocol/waku_store/waku_store_types,

--- a/waku/v2/node/jsonrpc/private_api.nim
+++ b/waku/v2/node/jsonrpc/private_api.nim
@@ -10,6 +10,9 @@ import
 
 export waku_payload, jsonrpc_types
 
+logScope:
+  topics = "private api"
+
 const futTimeout* = 5.seconds # Max time to wait for futures
 
 proc installPrivateApiHandlers*(node: WakuNode, rpcsrv: RpcServer, rng: ref BrHmacDrbgContext, topicCache: TopicCache) =

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -11,6 +11,9 @@ import
 
 export jsonrpc_types
 
+logScope:
+  topics = "relay api"
+
 const futTimeout* = 5.seconds # Max time to wait for futures
 const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
 

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -9,6 +9,9 @@ import
 
 export jsonrpc_types
 
+logScope:
+  topics = "store api"
+
 proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
   const futTimeout = 5.seconds
 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -1,5 +1,5 @@
 import 
-  chronicles, options, chronos, stint, sequtils,
+  chronicles, options, chronos, stint,
   web3,
   stew/byteutils,
   eth/keys,


### PR DESCRIPTION
This PR is a further increment towards #205.

I also took the opportunity to do a general cleanup, based on what was required for the `bridge`.

Some test, import and log cleanups to improve general usability (db5eb47):
- removed some unused imports
- added `{.used.}` pragma on top of tests imported in all_tests_v2.nim (please do so for subsequent tests to suppress `UnusedImport` compiler warnings)
- added `logScope` for JSON-RPC APIs

Minor improvements to `bridge` implementation (5bce35e):
- added metrics
- improved unit tests
- import cleanup