### PR TITLE
Adds Merkle tree Nim bindings

### DIFF
--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,7 +1,7 @@
 import
   chronos, chronicles, options, stint, unittest,
   web3,
-  stew/byteutils as stewByteUtils, stew/shims/net as stewNet,
+  stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
   ../../waku/v2/node/wakunode2,

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -215,6 +215,14 @@ procSuite "Waku rln relay":
     # start rln-relay
     await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
+proc generateKeyPairBuffer(ctx: ptr RLN[Bn256]): ptr Buffer = 
+  var 
+    keysBuffer : Buffer
+    keysBufferPtr = unsafeAddr(keysBuffer)
+    done = key_gen(ctx, keysBufferPtr) 
+  
+  return keysBufferPtr
+
 proc getSK(keyPairBuffer: ptr Buffer): ptr Buffer =
   var 
     generatedKeys = cast[ptr array[64, byte]](keyPairBuffer.`ptr`)[]

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -225,10 +225,11 @@ procSuite "Waku rln relay":
 
 # TODO unit test for genSKPK
 proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
+  ## generates a pair of secret and public key where pk = hash(sk)
   var keypair = membershipKeyGen(ctx)
   doAssert(keypair.isSome())
+  
   let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
-
   let skBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().secretKey[0]), len: 32)
   return(skBuffer,pkBuffer)
 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -215,6 +215,30 @@ procSuite "Waku rln relay":
     # start rln-relay
     await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
+proc getSK(keyPairBuffer: ptr Buffer): ptr Buffer =
+  var 
+    generatedKeys = cast[ptr array[64, byte]](keyPairBuffer.`ptr`)[]
+    secret = cast[array[32, byte]](generatedKeys[0..31])
+  let skBuffer = Buffer(`ptr`: unsafeAddr(secret[0]), len: 32)
+  let skBufferPtr = unsafeAddr skBuffer
+  return skBufferPtr
+
+proc getPK(keyPairBuffer: ptr Buffer): ptr Buffer =
+  var 
+    generatedKeys = cast[ptr array[64, byte]](keyPairBuffer.`ptr`)[]
+    public = cast[array[32, byte]](generatedKeys[31..^1])
+  let pkBuffer = Buffer(`ptr`: unsafeAddr(public[0]), len: 32)
+  let pkBufferPtr = unsafeAddr pkBuffer
+  return pkBufferPtr
+
+proc genRandPK(): ptr Buffer =
+  var 
+    pkBytes : array[32, byte] 
+  for x in pkBytes.mitems: x = 2
+  let pkBuffer = Buffer(`ptr`: unsafeAddr(pkBytes[0]), len: 32)
+  let pkBufferPtr = unsafeAddr pkBuffer
+  return pkBufferPtr
+
 suite "Waku rln relay":
   test "key_gen Nim Wrappers":
     var 
@@ -284,3 +308,71 @@ suite "Waku rln relay":
     var member_is_added = update_next_member(ctx, keysBufferPtr)
     check:
       member_is_added == true
+  
+  test "generate_proof Nim Wrapper":
+    var ctxInstance = createRLNInstance(32) 
+    doAssert(ctxInstance.isSome())
+    var ctx = ctxInstance.get() # ptr RLN[Bn256]
+
+    
+    var 
+      keypairBufferPtr = generateKeyPairBuffer(ctx)
+      pkBufferPtr = keypairBufferPtr.getPK()
+      skBufferPtr = keypairBufferPtr.getSK()
+    # add members to the tree
+    # TODO add a test for a wrong index, it should fail
+    var index = 6
+    for i in 0..10:
+      echo i
+      if (i == index):
+        var member_is_added = update_next_member(ctx, pkBufferPtr)
+        doAssert(member_is_added)
+      else:
+        let randPkPtr = genRandPK()
+        var member_is_added = update_next_member(ctx, randPkPtr)
+        doAssert(member_is_added)
+
+
+    # var member_is_added = update_next_member(ctx, pkBufferPtr)
+    # doAssert(member_is_added)
+    # debug "ctx after update", ctx
+
+    let
+      epoch: uint = 1
+      epochBytes = cast[array[32,byte]](epoch)
+    debug "epochBytes", epochBytes
+    let decodeEpoch = cast[uint](epochBytes)
+    debug "epoch", decodeEpoch
+
+    doAssert(decodeEpoch == epoch)
+    var messageBytes {.noinit.}: array[32, byte]
+    for x in messageBytes.mitems: x = 1
+    debug "messageBytes", messageBytes
+
+    var epochBytesSeq = @epochBytes
+    var messageBytesSeq = @messageBytes
+    var epochMessage = epochBytesSeq & messageBytesSeq
+    debug "@epochBytes", epochBytesSeq
+    debug "@messageBytes", messageBytesSeq
+    debug "epochMessage", epochMessage
+    var inputBytes{.noinit.}: array[64, byte]
+    for (i, x) in inputBytes.mpairs: x = epochMessage[i]
+    var
+      # inputBytes = cast[array[64, byte]](@epochBytes & @messageBytes)
+      input_buffer = Buffer(`ptr`: unsafeAddr(inputBytes[0]), len: 64)
+      input_buffer_ptr = unsafeAddr(input_buffer)
+
+    debug "inputBytes", inputBytes
+    debug "input_buffer", input_buffer
+
+    var auth: Auth = Auth(secret_buffer: skBufferPtr, index: uint(index))
+    var auth_Ptr = unsafeAddr(auth)
+
+    debug "auth", auth
+
+    var proof: Buffer
+    var proofPtr = unsafeAddr(proof)
+    let proof_res = generate_proof(ctx, input_buffer_ptr, authPtr, proofPtr)
+
+    check:
+      proof_res == true

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -242,12 +242,12 @@ proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
   return(skBuffer,pkBuffer)
 
 
-proc genRandPK(): Buffer =
-  var 
-    pkBytes : array[32, byte] 
-  for x in pkBytes.mitems: x = 2
-  let pkBuffer = Buffer(`ptr`: unsafeAddr(pkBytes[0]), len: 32)
-  return pkBuffer
+# proc genRandPK(): Buffer =
+#   var 
+#     pkBytes : array[32, byte] 
+#   for x in pkBytes.mitems: x = 2
+#   let pkBuffer = Buffer(`ptr`: unsafeAddr(pkBytes[0]), len: 32)
+#   return pkBuffer
 
 suite "Waku rln relay":
   test "key_gen Nim Wrappers":
@@ -349,7 +349,7 @@ suite "Waku rln relay":
 
     # prepare the secret information of the proof i.e., the sk and the user index in the tree
     var auth: Auth = Auth(secret_buffer: skBufferPtr, index: uint(index))
-    var auth_Ptr = unsafeAddr(auth)
+    var authPtr = unsafeAddr(auth)
 
     debug "auth", auth
 
@@ -359,8 +359,8 @@ suite "Waku rln relay":
       if (i == index):
         member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
       else:
-        # var (sk,pk) = genSKPK(ctx)
-        var pk = genRandPK()
+        var (sk,pk) = genSKPK(ctxPtrPtr[])
+        # var pk = genRandPK()
         let pkPtr = unsafeAddr pk
         member_is_added = update_next_member(ctxPtrPtr[], pkPtr)
       doAssert(member_is_added)
@@ -384,6 +384,7 @@ suite "Waku rln relay":
     debug "epoch in Bytes", epochBytes
     debug "message in Bytes", messageBytes
     debug "epoch||Message", epochMessage
+    doAssert(epochMessage.len == 64)
     var inputBytes{.noinit.}: array[64, byte] #the serialized epoch||Message 
     for (i, x) in inputBytes.mpairs: x = epochMessage[i]
     var

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,7 +1,7 @@
 import
   chronos, chronicles, options, stint, unittest,
   web3,
-  stew/byteutils, stew/shims/net as stewNet,
+  stew/byteutils as stewByteUtils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
   ../../waku/v2/node/wakunode2,
@@ -338,24 +338,7 @@ suite "Waku rln relay":
       ctxPtrPtr = unsafeAddr(ctxPtr)
     createRLNInstance(32, ctxPtrPtr)
 
-    # test a simple hash
-    var
-      sample_hash_input_bytes : array[32, byte]
-    for x in sample_hash_input_bytes.mitems: x=0
 
-    echo "sample_hash_input_buffer", sample_hash_input_bytes.toHex()
-    echo sample_hash_input_bytes
-
-    var 
-      sample_hash_input_buffer = Buffer(`ptr`: unsafeAddr(sample_hash_input_bytes[0]), len: 32 ) 
-      output_buffer: Buffer
-    let hash_success = hash(ctxPtrPtr[], unsafeAddr(sample_hash_input_buffer), 32.uint, unsafeAddr(output_buffer) )
-    doAssert(hash_success)
-    var hashoutput = cast[array[32,byte]] (sample_hash_input_buffer.`ptr`[])
-    echo "output_buffer ", hashoutput.toHex()
-
-
-    
     var root {.noinit.} : Buffer = Buffer()
     var rootPtr = unsafeAddr(root)
     var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
@@ -363,8 +346,8 @@ suite "Waku rln relay":
     root = rootPtr[]
     var rootSize = root.len
     # debug "rootSize", rootSize
-    var rootValue = cast[array[32,byte]] (rootPtr.`ptr`[])
-    echo "initial root ", rootValue.toHex
+    var rootValue = cast[ptr array[32,byte]] (rootPtr.`ptr`)
+    echo "initial root ", rootValue[].toHex
 
     var root2 {.noinit.} : Buffer = Buffer()
     var rootPtr2 = unsafeAddr(root2)
@@ -373,8 +356,8 @@ suite "Waku rln relay":
     root2 = rootPtr2[]
     var rootSize2 = root2.len
     # debug "rootSize", rootSize
-    var rootValue2 = cast[array[32,byte]] (rootPtr2.`ptr`[])
-    echo "initial root second call ", rootValue2.toHex
+    var rootValue2 = cast[ptr array[32,byte]] (rootPtr2.`ptr`)
+    echo "initial root second call ", rootValue2[].toHex
 
 
     var root3 {.noinit.} : Buffer = Buffer()
@@ -384,129 +367,176 @@ suite "Waku rln relay":
     root3 = rootPtr3[]
     var rootSize3 = root3.len
     # debug "rootSize", rootSize
-    var rootValue3 = cast[array[32,byte]] (rootPtr3.`ptr`[])
-    echo "initial root third call ", rootValue3.toHex
+    var rootValue3 = cast[ptr array[32,byte]] (rootPtr3.`ptr`)
+    echo "initial root third call ", rootValue3[].toHex
 
    
 
 
-    # # prepare user's secret and public keys 
-    # var (skBuffer,pkBuffer) = genSKPK(ctxPtrPtr[])
-    # let 
-    #   skBufferPtr = unsafeAddr skBuffer
-    #   pkBufferPtr = unsafeAddr pkBuffer
+    # prepare user's secret and public keys 
+    var (skBuffer,pkBuffer) = genSKPK(ctxPtrPtr[])
+    let 
+      skBufferPtr = unsafeAddr skBuffer
+      pkBufferPtr = unsafeAddr pkBuffer
 
-    # # user's index in the tree
-    # var index = 5
+    # user's index in the tree
+    var index = 5
 
-    # # prepare the secret information of the proof i.e., the sk and the user index in the tree
-    # var auth: Auth = Auth(secret_buffer: skBufferPtr, index: uint(index))
-    # var authPtr = unsafeAddr(auth)
+    # prepare the secret information of the proof i.e., the sk and the user index in the tree
+    var auth: Auth = Auth(secret_buffer: skBufferPtr, index: uint(index))
+    var authPtr = unsafeAddr(auth)
 
-    # debug "auth", auth
+    debug "auth", auth
 
-    # rootPtr = unsafeAddr(root)
-    # get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-    # doAssert(get_root_successful)
-    # rootSize = root.len
-    # # debug "rootSize", rootSize
-    # rootValue = cast[array[32,byte]] (root.`ptr`[])
-    # echo "initial root after key gen", rootValue.toHex
-
-
-    # # add some random members to the tree
-    # for i in 0..10:
-    #   echo i
-    #   var member_is_added: bool = false
-    #   if (i == index):
-    #     member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
-    #     var root : Buffer
-    #     var rootPtr = unsafeAddr(root)
-    #     var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-    #     doAssert(get_root_successful)
-    #     var rootSize = root.len
-    #     # debug "rootSize", rootSize
-    #     var rootValue = cast[array[32,byte]] (root.`ptr`[])
-    #     echo "root value ", i, " ", rootValue.toHex
-    #   else:
-    #     var (sk,pk) = genSKPK(ctxPtrPtr[])
-    #     # var pk = genRandPK()
-    #     let pkPtr = unsafeAddr pk
-    #     member_is_added = update_next_member(ctxPtrPtr[], pkPtr)
-    #     var root : Buffer
-    #     var rootPtr = unsafeAddr(root)
-    #     var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-    #     doAssert(get_root_successful)
-    #     var rootSize = root.len
-    #     # debug "rootSize", rootSize
-    #     var rootValue = cast[array[32,byte]] (root.`ptr`[])
-    #     echo "root value ", i, " " , rootValue.toHex
-    #   doAssert(member_is_added)
-
-    # var deleted_member_index = uint(10)
-    # let deletion_success = delete_member(ctxPtrPtr[], deleted_member_index)
-    # doAssert(deletion_success)
-    # # var root : Buffer
-    # rootPtr = unsafeAddr(root)
-    # get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-    # doAssert(get_root_successful)
-    # rootSize = root.len
-    # # debug "rootSize", rootSize
-    # rootValue = cast[array[32,byte]] (root.`ptr`[])
-    # echo "root value after 10 is deleted ", rootValue.toHex
-
-  
-    # # prepare the message
-    # var messageBytes {.noinit.}: array[32, byte]
-    # for x in messageBytes.mitems: x = 1
-    # debug "messageBytes", messageBytes
+    rootPtr = unsafeAddr(root)
+    get_root_successful = get_root(ctxPtrPtr[],rootPtr)
+    doAssert(get_root_successful)
+    rootSize = root.len
+    # debug "rootSize", rootSize
+    rootValue = cast[ptr array[32,byte]] (root.`ptr`)
+    echo "initial root after key gen", rootValue[].toHex
 
 
-    # # prepare the epoch
+    # add some random members to the tree
+    for i in 0..10:
+      echo i
+      var member_is_added: bool = false
+      if (i == index):
+        member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
+        var root : Buffer
+        var rootPtr = unsafeAddr(root)
+        var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
+        doAssert(get_root_successful)
+        var rootSize = root.len
+        # debug "rootSize", rootSize
+        var rootValue = cast[ptr array[32,byte]] (root.`ptr`)
+        echo "root value ", i, " ", rootValue[].toHex
+      else:
+        var (sk,pk) = genSKPK(ctxPtrPtr[])
+        # var pk = genRandPK()
+        let pkPtr = unsafeAddr pk
+        member_is_added = update_next_member(ctxPtrPtr[], pkPtr)
+        var root : Buffer
+        var rootPtr = unsafeAddr(root)
+        var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
+        doAssert(get_root_successful)
+        var rootSize = root.len
+        # debug "rootSize", rootSize
+        var rootValue = cast[ptr array[32,byte]] (root.`ptr`)
+        echo "root value ", i, " " , rootValue[].toHex
+      doAssert(member_is_added)
+
+    var deleted_member_index = uint(10)
+    let deletion_success = delete_member(ctxPtrPtr[], deleted_member_index)
+    doAssert(deletion_success)
+    # var root : Buffer
+    rootPtr = unsafeAddr(root)
+    get_root_successful = get_root(ctxPtrPtr[],rootPtr)
+    doAssert(get_root_successful)
+    rootSize = root.len
+    # debug "rootSize", rootSize
+    rootValue = cast[ptr array[32,byte]] (root.`ptr`)
+    echo "root value after 10 is deleted ", rootValue[].toHex
+
+    # prepare the message
+    var messageBytes {.noinit.}: array[32, byte]
+    for x in messageBytes.mitems: x = 1
+    debug "messageBytes", messageBytes
+
+
+    # prepare the epoch
     # let
     #   epoch: uint = 1
-    #   epochBytes = cast[array[32,byte]](epoch)
-    # debug "epochBytes", epochBytes
+    var  epochBytes : array[32,byte]
+    for x in epochBytes.mitems : x = 0
+    debug "epochBytes", epochBytes
    
 
-    # # serialize message and epoch 
-    # # TODO add a proc for serializing
-    # var epochMessage = @epochBytes & @messageBytes
-    # debug "epoch in Bytes", epochBytes
-    # debug "message in Bytes", messageBytes
-    # debug "epoch||Message", epochMessage
-    # doAssert(epochMessage.len == 64)
-    # var inputBytes{.noinit.}: array[64, byte] #the serialized epoch||Message 
-    # for (i, x) in inputBytes.mpairs: x = epochMessage[i]
-    # var
-    #   input_buffer = Buffer(`ptr`: unsafeAddr(inputBytes[0]), len: 64)
-    #   input_buffer_ptr = unsafeAddr(input_buffer)
+    # serialize message and epoch 
+    # TODO add a proc for serializing
+    var epochMessage = @epochBytes & @messageBytes
+    echo "epoch in Bytes", epochBytes.toHex()
+    echo "message in Bytes", messageBytes.toHex()
+    echo "epoch||Message", stewByteUtils.toHex(epochMessage)
+    doAssert(epochMessage.len == 64)
+    var inputBytes{.noinit.}: array[64, byte] #the serialized epoch||Message 
+    for (i, x) in inputBytes.mpairs: x = epochMessage[i]
+    var
+      input_buffer = Buffer(`ptr`: unsafeAddr(inputBytes[0]), len: 64)
+      input_buffer_ptr = unsafeAddr(input_buffer)
 
-    # debug "inputBytes", inputBytes
+    echo "inputBytes", inputBytes.toHex()
     # debug "input_buffer", input_buffer
 
+    # test a simple hash
+    # var
+    #   sample_hash_input_bytes : array[32, byte]
+    # for x in sample_hash_input_bytes.mitems: x= 1
 
-    # # generate the proof
-    # var proof: Buffer
-    # var proofPtr = unsafeAddr(proof)
-    # let proof_res = generate_proof(ctxPtrPtr[], input_buffer_ptr, authPtr, proofPtr)
+    # echo "sample_hash_input_buffer", sample_hash_input_bytes.toHex()
+    # echo sample_hash_input_bytes
 
+    # var 
+    #   output_buffer: Buffer
+    #   output_buffer_ptr = unsafeAddr output_buffer
+    #   data_length = 32.uint
+    #   sample_hash_input_buffer = Buffer(`ptr`: unsafeAddr(messageBytes[0]), len: 32 ) 
+      
+    # # var (sample_hash_input_buffer,_) = genSKPK(ctxPtrPtr[])
+    # let hash_success = hash(ctxPtrPtr[], unsafeAddr(sample_hash_input_buffer), data_length, output_buffer_ptr)
+    # # doAssert(hash_success)
+    # var hashoutput = cast[ptr array[32,byte]] (output_buffer_ptr.`ptr`)
+    # echo "output_buffer ", hashoutput[].toHex()
+
+
+
+    # generate the proof
+    var proof: Buffer
+    var proofPtr = unsafeAddr(proof)
+    let proof_res = generate_proof(ctxPtrPtr[], input_buffer_ptr, authPtr, proofPtr)
+    var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
+    echo "proof content", proofValue[].toHex
+    let proofHex = proofValue[].toHex
   
-    # check:
-    #   proof_res == true
-    # # TODO further checks on the internal components of the proof, the length is off
-    # let proofRepr = proofPtr[]
-    # debug "proof", proofRepr
+    check:
+      proof_res == true
+      proof.len ==  416
+      proofHex.len == 832
+  
+    var 
+    #   proofArray = cast[ptr array[416, byte]] (proof.`ptr`)[]
+      zkSNARK = proofHex[0..511]
+      proofRoot = proofHex[512..575] #stewByteUtils.toHex(proofArray[256..287])
+      proofEpoch = proofHex[576..639]#stewByteUtils.toHex(proofArray[288..319])
+      shareX = proofHex[640..703]#stewByteUtils.toHex(proofArray[320..352])
+      shareY = proofHex[704..767]#stewByteUtils.toHex(proofArray[353..383])
+      nullifier = proofHex[768..831]#stewByteUtils.toHex(proofArray[384..415])
+    debug "zkSNARK ", zkSNARK
+    echo(zkSNARK.len == 512)
+    debug "root ", proofRoot
+    echo(proofRoot.len == 64)
+    debug "epoch ", proofEpoch
+    echo(proofEpoch.len == 64)
+    debug "shareX", shareX
+    echo(shareX.len == 64)
+    debug "shareY", shareY
+    echo(shareY.len == 64)
+    debug "nullifier", nullifier
+    echo(nullifier.len == 64)
+    
 
-    # # TODO add a test for a wrong index, it should fail
+    # TODO add a test for a wrong index, it should fail
 
-    # var f = 0.uint32
-    # var fPtr = unsafeAddr(f)
-    # let success = verify(ctxPtrPtr[], proofPtr, fPtr)
-    # doAssert(success)
-    # # TODO the value of f must be zero, but it is not, have to investigate more
-    # # doAssert(f==0)
+    var f = 0.uint32
+    var fPtr = unsafeAddr(f)
+    let success = verify(ctxPtrPtr[], unsafeAddr proof, fPtr)
+    doAssert(success)
+    # TODO the value of f must be zero, but it is not, have to investigate more
+    # doAssert(f==0)
     # f = fPtr[] 
-    # debug "f", f 
- 
+    debug "f", f 
 
+
+    
+
+ 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -270,3 +270,17 @@ suite "Waku rln relay":
       key.get().publicKey != empty
     
     debug "the generated membership key pair: ", key 
+  
+  test "update_next_member Nim Wrapper":
+    var ctxInstance = createRLNInstance(32) 
+    doAssert(ctxInstance.isSome())
+    var ctx = ctxInstance.get()
+    
+    var keypair = membershipKeyGen(some(ctx))
+    doAssert(keypair.isSome())
+    let keysBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
+    let keysBufferPtr = unsafeAddr keysBuffer
+
+    var member_is_added = update_next_member(ctx, keysBufferPtr)
+    check:
+      member_is_added == true

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -225,15 +225,15 @@ procSuite "Waku rln relay":
     await node.stop()
 
 
-# TODO unit test for genSKPK
-proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
-  ## generates a pair of secret and public key where pk = hash(sk)
-  var keypair = membershipKeyGen(ctx)
-  doAssert(keypair.isSome())
+# # TODO unit test for genSKPK
+# proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
+#   ## generates a pair of secret and public key where pk = hash(sk)
+#   var keypair = membershipKeyGen(ctx)
+#   doAssert(keypair.isSome())
 
-  let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
-  let skBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().secretKey[0]), len: 32)
-  return(skBuffer,pkBuffer)
+#   let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
+#   let skBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().secretKey[0]), len: 32)
+#   return(skBuffer,pkBuffer)
 
 suite "Waku rln relay":
   test "key_gen Nim Wrappers":

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -216,7 +216,7 @@ procSuite "Waku rln relay":
     await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
 suite "Waku rln relay":
-  test "Keygen Nim Wrappers":
+  test "key_gen Nim Wrappers":
     var 
       merkleDepth: csize_t = 32
       # parameters.key contains the parameters related to the Poseidon hasher
@@ -234,18 +234,20 @@ suite "Waku rln relay":
 
     # ctx holds the information that is going to be used for  the key generation
     var 
-      obj = RLNBn256()
+      obj = RLN[Bn256]()
       objPtr = unsafeAddr(obj)
-      ctx = objPtr
-    let res = newCircuitFromParams(merkleDepth, unsafeAddr parametersBuffer, ctx)
+      objptrptr = unsafeAddr(objPtr)
+      ctx = objptrptr
+    let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctx)
     check:
       # check whether the circuit parameters are generated successfully
       res == true
 
     # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
     var 
-      keysBufferPtr : Buffer
-      done = keyGen(ctx, keysBufferPtr) 
+      keysBuffer : Buffer
+      keysBufferPtr = unsafeAddr(keysBuffer)
+      done = key_gen(ctx[], keysBufferPtr) 
     check:
       # check whether the keys are generated successfully
       done == true

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -329,7 +329,7 @@ suite "Waku rln relay":
     check:
       member_is_added == true
   
-  test "generate_proof Nim Wrapper":
+  test "generate_proof and verify Nim Wrappers":
     # create an RLN instance
     var 
       ctx = RLN[Bn256]()
@@ -355,7 +355,6 @@ suite "Waku rln relay":
 
     # add some random members to the tree
     for i in 0..10:
-      echo i
       var member_is_added: bool = false
       if (i == index):
         member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
@@ -400,13 +399,20 @@ suite "Waku rln relay":
     var proofPtr = unsafeAddr(proof)
     let proof_res = generate_proof(ctxPtrPtr[], input_buffer_ptr, authPtr, proofPtr)
 
+  
     check:
       proof_res == true
-    # TODO further checks on the internal components of the proof
-    let proofRepr = (proofPtr[]).`ptr`[]
-    let size = proofPtr[].len
+    # TODO further checks on the internal components of the proof, the length is off
+    let proofRepr = proofPtr[]
     debug "proof", proofRepr
-    debug " proof len", size
 
     # TODO add a test for a wrong index, it should fail
+
+    var f = 0.uint32
+    let success = verify(ctxPtrPtr[],proofPtr, unsafeAddr(f))
+    doAssert(success)
+    # TODO the value of f must be zero, but it is not, have to investigate more
+    # doAssert(f==0)
+    debug "f", f 
+ 
 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -225,16 +225,6 @@ procSuite "Waku rln relay":
     await node.stop()
 
 
-# # TODO unit test for genSKPK
-# proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
-#   ## generates a pair of secret and public key where pk = hash(sk)
-#   var keypair = membershipKeyGen(ctx)
-#   doAssert(keypair.isSome())
-
-#   let pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
-#   let skBuffer = Buffer(`ptr`: addr(keypair.get().secretKey[0]), len: 32)
-#   return(skBuffer,pkBuffer)
-
 suite "Waku rln relay":
   test "key_gen Nim Wrappers":
     var 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -181,8 +181,8 @@ procSuite "Waku rln relay":
     # create an RLN instance
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # generate the membership keys
@@ -231,8 +231,8 @@ procSuite "Waku rln relay":
 #   var keypair = membershipKeyGen(ctx)
 #   doAssert(keypair.isSome())
 
-#   let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
-#   let skBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().secretKey[0]), len: 32)
+#   let pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+#   let skBuffer = Buffer(`ptr`: addr(keypair.get().secretKey[0]), len: 32)
 #   return(skBuffer,pkBuffer)
 
 suite "Waku rln relay":
@@ -247,7 +247,7 @@ suite "Waku rln relay":
       parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
       pbytes = parameters.toBytes()
       len : csize_t = uint(pbytes.len)
-      parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
+      parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
     check:
       # check the parameters.key is not empty
       pbytes.len != 0
@@ -255,10 +255,10 @@ suite "Waku rln relay":
     # ctx holds the information that is going to be used for  the key generation
     var 
       obj = RLN[Bn256]()
-      objPtr = unsafeAddr(obj)
-      objptrptr = unsafeAddr(objPtr)
+      objPtr = addr(obj)
+      objptrptr = addr(objPtr)
       ctx = objptrptr
-    let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctx)
+    let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctx)
     check:
       # check whether the circuit parameters are generated successfully
       res == true
@@ -266,7 +266,7 @@ suite "Waku rln relay":
     # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
     var 
       keysBuffer : Buffer
-      keysBufferPtr = unsafeAddr(keysBuffer)
+      keysBufferPtr = addr(keysBuffer)
       done = key_gen(ctx[], keysBufferPtr) 
     check:
       # check whether the keys are generated successfully
@@ -283,8 +283,8 @@ suite "Waku rln relay":
     # create an RLN instance
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     var key = membershipKeyGen(ctxPtrPtr[])
@@ -302,14 +302,14 @@ suite "Waku rln relay":
     # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # read the Merkle Tree root
     var 
       root1 {.noinit.} : Buffer = Buffer()
-      rootPtr1 = unsafeAddr(root1)
+      rootPtr1 = addr(root1)
       get_root_successful1 = get_root(ctxPtrPtr[], rootPtr1)
     doAssert(get_root_successful1)
     doAssert(root1.len == 32)
@@ -317,7 +317,7 @@ suite "Waku rln relay":
     # read the Merkle Tree root
     var 
       root2 {.noinit.} : Buffer = Buffer()
-      rootPtr2 = unsafeAddr(root2)
+      rootPtr2 = addr(root2)
       get_root_successful2 = get_root(ctxPtrPtr[], rootPtr2)
     doAssert(get_root_successful2)
     doAssert(root2.len == 32)
@@ -335,15 +335,15 @@ suite "Waku rln relay":
     # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # generate a key pair
     var keypair = membershipKeyGen(ctxPtrPtr[])
     doAssert(keypair.isSome())
-    let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
-    let pkBufferPtr = unsafeAddr pkBuffer
+    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+    let pkBufferPtr = addr pkBuffer
 
     # add the member to the tree
     var member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
@@ -354,8 +354,8 @@ suite "Waku rln relay":
     # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # delete the first member 
@@ -367,14 +367,14 @@ suite "Waku rln relay":
     # create an RLN instance
     var 
       ctx = RLN[Bn256]()
-      ctxPtr = unsafeAddr(ctx)
-      ctxPtrPtr = unsafeAddr(ctxPtr)
+      ctxPtr = addr(ctx)
+      ctxPtrPtr = addr(ctxPtr)
     doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # read the Merkle Tree root
     var 
       root1 {.noinit.} : Buffer = Buffer()
-      rootPtr1 = unsafeAddr(root1)
+      rootPtr1 = addr(root1)
       get_root_successful1 = get_root(ctxPtrPtr[], rootPtr1)
     doAssert(get_root_successful1)
     doAssert(root1.len == 32)
@@ -382,8 +382,8 @@ suite "Waku rln relay":
     # generate a key pair
     var keypair = membershipKeyGen(ctxPtrPtr[])
     doAssert(keypair.isSome())
-    let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
-    let pkBufferPtr = unsafeAddr pkBuffer
+    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+    let pkBufferPtr = addr pkBuffer
 
     # add the member to the tree
     var member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
@@ -392,7 +392,7 @@ suite "Waku rln relay":
     # read the Merkle Tree root after insertion
     var 
       root2 {.noinit.} : Buffer = Buffer()
-      rootPtr2 = unsafeAddr(root2)
+      rootPtr2 = addr(root2)
       get_root_successful2 = get_root(ctxPtrPtr[], rootPtr2)
     doAssert(get_root_successful2)
     doAssert(root2.len == 32)
@@ -405,7 +405,7 @@ suite "Waku rln relay":
     # read the Merkle Tree root after the deletion
     var 
       root3 {.noinit.} : Buffer = Buffer()
-      rootPtr3 = unsafeAddr(root3)
+      rootPtr3 = addr(root3)
       get_root_successful3 = get_root(ctxPtrPtr[], rootPtr3)
     doAssert(get_root_successful3)
     doAssert(root3.len == 32)

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -296,7 +296,7 @@ suite "Waku rln relay":
     debug "the generated membership key pair: ", key 
   
   test "get_root Nim binding":
-    # create an RLN instance which includes an empty Merkle tree inside its struct
+    # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
@@ -329,7 +329,7 @@ suite "Waku rln relay":
     doAssert(rootHex1 == rootHex2)
 
   test "update_next_member Nim Wrapper":
-    # create an RLN instance which includes an empty Merkle tree inside its struct
+    # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
@@ -348,7 +348,7 @@ suite "Waku rln relay":
       member_is_added == true
       
   test "delete_member Nim wrapper":
-    # create an RLN instance which includes an empty Merkle tree inside its struct
+    # create an RLN instance which also includes an empty Merkle tree
     var 
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
@@ -422,214 +422,3 @@ suite "Waku rln relay":
 
     doAssert(rootHex1 == rootHex3)
     doAssert(not(rootHex1 == rootHex2))
-  
-  # test "generate_proof and verify Nim Wrappers":
-  #   # create an RLN instance
-  #   var 
-  #     ctx = RLN[Bn256]()
-  #     ctxPtr = unsafeAddr(ctx)
-  #     ctxPtrPtr = unsafeAddr(ctxPtr)
-  #   createRLNInstance(32, ctxPtrPtr)
-
-
-  #   var root {.noinit.} : Buffer = Buffer()
-  #   var rootPtr = unsafeAddr(root)
-  #   var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-  #   doAssert(get_root_successful)
-  #   root = rootPtr[]
-  #   var rootSize = root.len
-  #   # debug "rootSize", rootSize
-  #   var rootValue = cast[ptr array[32,byte]] (rootPtr.`ptr`)
-  #   echo "initial root ", rootValue[].toHex
-
-  #   var root2 {.noinit.} : Buffer = Buffer()
-  #   var rootPtr2 = unsafeAddr(root2)
-  #   var get_root_successful2 = get_root(ctxPtrPtr[],rootPtr2)
-  #   doAssert(get_root_successful2)
-  #   root2 = rootPtr2[]
-  #   var rootSize2 = root2.len
-  #   # debug "rootSize", rootSize
-  #   var rootValue2 = cast[ptr array[32,byte]] (rootPtr2.`ptr`)
-  #   echo "initial root second call ", rootValue2[].toHex
-
-
-  #   var root3 {.noinit.} : Buffer = Buffer()
-  #   var rootPtr3 = unsafeAddr(root3)
-  #   var get_root_successful3 = get_root(ctxPtrPtr[],rootPtr3)
-  #   doAssert(get_root_successful3)
-  #   root3 = rootPtr3[]
-  #   var rootSize3 = root3.len
-  #   # debug "rootSize", rootSize
-  #   var rootValue3 = cast[ptr array[32,byte]] (rootPtr3.`ptr`)
-  #   echo "initial root third call ", rootValue3[].toHex
-
-   
-
-
-  #   # prepare user's secret and public keys 
-  #   var (skBuffer,pkBuffer) = genSKPK(ctxPtrPtr[])
-  #   let 
-  #     skBufferPtr = unsafeAddr skBuffer
-  #     pkBufferPtr = unsafeAddr pkBuffer
-
-  #   # user's index in the tree
-  #   var index = 5
-
-  #   # prepare the secret information of the proof i.e., the sk and the user index in the tree
-  #   var auth: Auth = Auth(secret_buffer: skBufferPtr, index: uint(index))
-  #   var authPtr = unsafeAddr(auth)
-
-  #   debug "auth", auth
-
-  #   rootPtr = unsafeAddr(root)
-  #   get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-  #   doAssert(get_root_successful)
-  #   rootSize = root.len
-  #   # debug "rootSize", rootSize
-  #   rootValue = cast[ptr array[32,byte]] (root.`ptr`)
-  #   echo "initial root after key gen", rootValue[].toHex
-
-
-  #   # add some random members to the tree
-  #   for i in 0..10:
-  #     echo i
-  #     var member_is_added: bool = false
-  #     if (i == index):
-  #       member_is_added = update_next_member(ctxPtrPtr[], pkBufferPtr)
-  #       var root : Buffer
-  #       var rootPtr = unsafeAddr(root)
-  #       var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-  #       doAssert(get_root_successful)
-  #       var rootSize = root.len
-  #       # debug "rootSize", rootSize
-  #       var rootValue = cast[ptr array[32,byte]] (root.`ptr`)
-  #       echo "root value ", i, " ", rootValue[].toHex
-  #     else:
-  #       var (sk,pk) = genSKPK(ctxPtrPtr[])
-  #       # var pk = genRandPK()
-  #       let pkPtr = unsafeAddr pk
-  #       member_is_added = update_next_member(ctxPtrPtr[], pkPtr)
-  #       var root : Buffer
-  #       var rootPtr = unsafeAddr(root)
-  #       var get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-  #       doAssert(get_root_successful)
-  #       var rootSize = root.len
-  #       # debug "rootSize", rootSize
-  #       var rootValue = cast[ptr array[32,byte]] (root.`ptr`)
-  #       echo "root value ", i, " " , rootValue[].toHex
-  #     doAssert(member_is_added)
-
-  #   var deleted_member_index = uint(10)
-  #   let deletion_success = delete_member(ctxPtrPtr[], deleted_member_index)
-  #   doAssert(deletion_success)
-  #   # var root : Buffer
-  #   rootPtr = unsafeAddr(root)
-  #   get_root_successful = get_root(ctxPtrPtr[],rootPtr)
-  #   doAssert(get_root_successful)
-  #   rootSize = root.len
-  #   # debug "rootSize", rootSize
-  #   rootValue = cast[ptr array[32,byte]] (root.`ptr`)
-  #   echo "root value after 10 is deleted ", rootValue[].toHex
-
-  #   # prepare the message
-  #   var messageBytes {.noinit.}: array[32, byte]
-  #   for x in messageBytes.mitems: x = 1
-  #   debug "messageBytes", messageBytes
-
-
-  #   # prepare the epoch
-  #   # let
-  #   #   epoch: uint = 1
-  #   var  epochBytes : array[32,byte]
-  #   for x in epochBytes.mitems : x = 0
-  #   debug "epochBytes", epochBytes
-   
-
-  #   # serialize message and epoch 
-  #   # TODO add a proc for serializing
-  #   var epochMessage = @epochBytes & @messageBytes
-  #   echo "epoch in Bytes", epochBytes.toHex()
-  #   echo "message in Bytes", messageBytes.toHex()
-  #   echo "epoch||Message", stewByteUtils.toHex(epochMessage)
-  #   doAssert(epochMessage.len == 64)
-  #   var inputBytes{.noinit.}: array[64, byte] #the serialized epoch||Message 
-  #   for (i, x) in inputBytes.mpairs: x = epochMessage[i]
-  #   var
-  #     input_buffer = Buffer(`ptr`: unsafeAddr(inputBytes[0]), len: 64)
-  #     input_buffer_ptr = unsafeAddr(input_buffer)
-
-  #   echo "inputBytes", inputBytes.toHex()
-  #   # debug "input_buffer", input_buffer
-
-  #   # test a simple hash
-  #   # var
-  #   #   sample_hash_input_bytes : array[32, byte]
-  #   # for x in sample_hash_input_bytes.mitems: x= 1
-
-  #   # echo "sample_hash_input_buffer", sample_hash_input_bytes.toHex()
-  #   # echo sample_hash_input_bytes
-
-  #   # var 
-  #   #   output_buffer: Buffer
-  #   #   output_buffer_ptr = unsafeAddr output_buffer
-  #   #   data_length = 32.uint
-  #   #   sample_hash_input_buffer = Buffer(`ptr`: unsafeAddr(messageBytes[0]), len: 32 ) 
-      
-  #   # # var (sample_hash_input_buffer,_) = genSKPK(ctxPtrPtr[])
-  #   # let hash_success = hash(ctxPtrPtr[], unsafeAddr(sample_hash_input_buffer), data_length, output_buffer_ptr)
-  #   # # doAssert(hash_success)
-  #   # var hashoutput = cast[ptr array[32,byte]] (output_buffer_ptr.`ptr`)
-  #   # echo "output_buffer ", hashoutput[].toHex()
-
-
-
-  #   # generate the proof
-  #   var proof: Buffer
-  #   var proofPtr = unsafeAddr(proof)
-  #   let proof_res = generate_proof(ctxPtrPtr[], input_buffer_ptr, authPtr, proofPtr)
-  #   var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
-  #   echo "proof content", proofValue[].toHex
-  #   let proofHex = proofValue[].toHex
-  
-  #   check:
-  #     proof_res == true
-  #     proof.len ==  416
-  #     proofHex.len == 832
-  
-  #   var 
-  #   #   proofArray = cast[ptr array[416, byte]] (proof.`ptr`)[]
-  #     zkSNARK = proofHex[0..511]
-  #     proofRoot = proofHex[512..575] #stewByteUtils.toHex(proofArray[256..287])
-  #     proofEpoch = proofHex[576..639]#stewByteUtils.toHex(proofArray[288..319])
-  #     shareX = proofHex[640..703]#stewByteUtils.toHex(proofArray[320..352])
-  #     shareY = proofHex[704..767]#stewByteUtils.toHex(proofArray[353..383])
-  #     nullifier = proofHex[768..831]#stewByteUtils.toHex(proofArray[384..415])
-  #   debug "zkSNARK ", zkSNARK
-  #   echo(zkSNARK.len == 512)
-  #   debug "root ", proofRoot
-  #   echo(proofRoot.len == 64)
-  #   debug "epoch ", proofEpoch
-  #   echo(proofEpoch.len == 64)
-  #   debug "shareX", shareX
-  #   echo(shareX.len == 64)
-  #   debug "shareY", shareY
-  #   echo(shareY.len == 64)
-  #   debug "nullifier", nullifier
-  #   echo(nullifier.len == 64)
-    
-
-  #   # TODO add a test for a wrong index, it should fail
-
-  #   var f = 0.uint32
-  #   var fPtr = unsafeAddr(f)
-  #   let success = verify(ctxPtrPtr[], unsafeAddr proof, fPtr)
-  #   doAssert(success)
-  #   # TODO the value of f must be zero, but it is not, have to investigate more
-  #   # doAssert(f==0)
-  #   # f = fPtr[] 
-  #   debug "f", f 
-
-
-    
-
- 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -228,7 +228,7 @@ proc genSKPK(ctx: ptr RLN[Bn256]): (Buffer, Buffer) =
   ## generates a pair of secret and public key where pk = hash(sk)
   var keypair = membershipKeyGen(ctx)
   doAssert(keypair.isSome())
-  
+
   let pkBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().publicKey[0]), len: 32)
   let skBuffer = Buffer(`ptr`: unsafeAddr(keypair.get().secretKey[0]), len: 32)
   return(skBuffer,pkBuffer)
@@ -420,6 +420,10 @@ suite "Waku rln relay":
     let rootHex3 = rootValue3[].toHex
     debug "The root after deletion", rootHex3
 
-
-    doAssert(rootHex1 == rootHex3)
+    # the root must change after the insertion
     doAssert(not(rootHex1 == rootHex2))
+
+    ## The initial root of the tree (empty tree) must be identical to 
+    ## the root of the tree after one insertion followed by a deletion
+    doAssert(rootHex1 == rootHex3)
+   

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -183,7 +183,7 @@ procSuite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # generate the membership keys
     let membershipKeyPair = membershipKeyGen(ctxPtrPtr[])
@@ -282,7 +282,7 @@ suite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     var key = membershipKeyGen(ctxPtrPtr[])
     var empty : array[32,byte]
@@ -301,7 +301,7 @@ suite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # read the Merkle Tree root
     var 
@@ -334,7 +334,7 @@ suite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # generate a key pair
     var keypair = membershipKeyGen(ctxPtrPtr[])
@@ -353,7 +353,7 @@ suite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # delete the first member 
     var deleted_member_index = uint(0)
@@ -366,7 +366,7 @@ suite "Waku rln relay":
       ctx = RLN[Bn256]()
       ctxPtr = unsafeAddr(ctx)
       ctxPtrPtr = unsafeAddr(ctxPtr)
-    createRLNInstance(32, ctxPtrPtr)
+    doAssert(createRLNInstance(32, ctxPtrPtr))
 
     # read the Merkle Tree root
     var 

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -426,4 +426,3 @@ suite "Waku rln relay":
     ## The initial root of the tree (empty tree) must be identical to 
     ## the root of the tree after one insertion followed by a deletion
     doAssert(rootHex1 == rootHex3)
-   

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,7 +1,7 @@
 import
   chronos, chronicles, options, stint, unittest,
   web3,
-  stew/shims/net as stewNet,
+  stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
   ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
   ../../waku/v2/node/wakunode2,

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -327,6 +327,7 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil) =
   node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
 proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
+  # TODO return a bool value to indicate the success fo the call
   # check whether inputs are provided
   doAssert(ethClientAddress.isSome())
   doAssert(ethAccountAddress.isSome())
@@ -337,7 +338,7 @@ proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(stri
     ctx = RLN[Bn256]()
     ctxPtr = unsafeAddr(ctx)
     ctxPtrPtr = unsafeAddr(ctxPtr)
-  createRLNInstance(32, ctxPtrPtr)
+  doAssert(createRLNInstance(32, ctxPtrPtr))
 
   # generate the membership keys
   let membershipKeyPair = membershipKeyGen(ctxPtrPtr[])

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -327,7 +327,7 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil) =
   node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
 proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
-  # TODO return a bool value to indicate the success fo the call
+  # TODO return a bool value to indicate the success of the call
   # check whether inputs are provided
   doAssert(ethClientAddress.isSome())
   doAssert(ethAccountAddress.isSome())

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -336,8 +336,8 @@ proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(stri
   # create an RLN instance
   var 
     ctx = RLN[Bn256]()
-    ctxPtr = unsafeAddr(ctx)
-    ctxPtrPtr = unsafeAddr(ctxPtr)
+    ctxPtr = addr(ctx)
+    ctxPtrPtr = addr(ctxPtr)
   doAssert(createRLNInstance(32, ctxPtrPtr))
 
   # generate the membership keys

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -15,7 +15,7 @@ import
   ../protocol/waku_store/waku_store,
   ../protocol/waku_swap/waku_swap,
   ../protocol/waku_filter/waku_filter,
-  ../protocol/waku_rln_relay/waku_rln_relay_utils,
+  ../protocol/waku_rln_relay/[rln,waku_rln_relay_utils],
   ../utils/peers,
   ./message_store/message_store,
   ../utils/requests,
@@ -332,8 +332,15 @@ proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(stri
   doAssert(ethAccountAddress.isSome())
   doAssert(membershipContractAddress.isSome())
 
+  # create an RLN instance
+  var 
+    ctx = RLN[Bn256]()
+    ctxPtr = unsafeAddr(ctx)
+    ctxPtrPtr = unsafeAddr(ctxPtr)
+  createRLNInstance(32, ctxPtrPtr)
+
   # generate the membership keys
-  let membershipKeyPair = membershipKeyGen()
+  let membershipKeyPair = membershipKeyGen(ctxPtrPtr[])
   # check whether keys are generated
   doAssert(membershipKeyPair.isSome())
   debug "the membership key for the rln relay is generated"

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -23,33 +23,18 @@ type Buffer* = object
   `ptr`*: ptr uint8
   len*: uint
 
-type Auth* = object
-  secret_buffer*: ptr Buffer
-  index*: uint
-
-proc hash*(ctx: ptr RLN[Bn256],
-           inputs_buffer: ptr Buffer,
-           input_len: uint,
-           output_buffer: ptr Buffer): bool {.importc: "hash".}
-
 proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
 
 proc new_circuit_from_params*(merkle_depth: uint,
                               parameters_buffer: ptr Buffer,
                               ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
-
+#------------------------------Merkle Tree operations -----------------------------------------
 proc update_next_member*(ctx: ptr RLN[Bn256],
                          input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
 
 proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
 
-proc generate_proof*(ctx: ptr RLN[Bn256],
-                     input_buffer: ptr Buffer,
-                     auth: ptr Auth,
-                     output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
 proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
+#----------------------------------------------------------------------------------------------
 
-proc verify*(ctx: ptr RLN[Bn256],
-             proof_buffer: ptr Buffer,
-             result_ptr: ptr uint32): bool {.importc: "verify".}
 {.pop.}

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -47,6 +47,7 @@ proc generate_proof*(ctx: ptr RLN[Bn256],
                      input_buffer: ptr Buffer,
                      auth: ptr Auth,
                      output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
+proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
 
 proc verify*(ctx: ptr RLN[Bn256],
              proof_buffer: ptr Buffer,

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -2,9 +2,6 @@
 
 import os
 
-# librln.dylib is the rln library taken from https://github.com/kilic/rln (originally implemented in rust with an exposed C API)  
-# contains the key generation and other relevant functions
-
 
 const libPath = "vendor/rln/target/debug/"
 when defined(Windows):
@@ -14,58 +11,44 @@ elif defined(Linux):
 elif defined(MacOsX):
   const libName* = libPath / "librln.dylib"
 
-# Data types -----------------------------
-
-# pub struct Buffer {
-#     pub ptr: *const u8,
-#     pub len: usize,
-# }
-
-type
-  Buffer* = object
-    `ptr`*: pointer
-    len*: csize_t
-  RLNBn256* = object
-
-# Procedures ------------------------------
  # all the following procedures are Nim wrappers for the functions defined in libName
 {.push dynlib: libName.}
 
-# pub extern "C" fn new_circuit_from_params(
-#     merkle_depth: usize,
-#     index: usize,
-#     parameters_buffer: *const Buffer,
-#     ctx: *mut *mut RLN<Bn256>,
-# ) -> bool
-proc newCircuitFromParams*(merkle_depth: csize_t, parameters_buffer: ptr Buffer, ctx: var  ptr RLNBn256): bool{.importc: "new_circuit_from_params".}
+type RLN*[E] {.incompleteStruct.} = object
+type Bn256* = pointer
 
-# pub extern "C" fn key_gen(ctx: *const RLN<Bn256>, keypair_buffer: *mut Buffer) -> bool
-proc keyGen*(ctx: ptr RLNBn256, keypair_buffer: var Buffer): bool {.importc: "key_gen".}
+## Buffer struct is taken from
+# https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
+type Buffer* = object
+  `ptr`*: ptr uint8
+  len*: uint
 
+type Auth* = object
+  secret_buffer*: ptr Buffer
+  index*: uint
 
-# pub extern "C" fn hash(
-#     ctx: *const RLN<Bn256>,
-#     inputs_buffer: *const Buffer,
-#     input_len: *const usize,
-#     output_buffer: *mut Buffer,
-# ) -> bool 
-proc hash*(ctx: ptr RLNBn256, inputs_buffer:ptr Buffer, input_len: ptr csize_t, output_buffer: ptr Buffer ) {.importc: "hash".} #TODO not tested yet
+proc hash*(ctx: ptr RLN[Bn256],
+           inputs_buffer: ptr Buffer,
+           input_len: uint,
+           output_buffer: ptr Buffer): bool {.importc: "hash".}
 
-# pub extern "C" fn verify(
-#     ctx: *const RLN<Bn256>,
-#     proof_buffer: *const Buffer,
-#     public_inputs_buffer: *const Buffer,
-#     result_ptr: *mut u32,
-# ) -> bool
+proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
 
+proc new_circuit_from_params*(merkle_depth: uint,
+                              parameters_buffer: ptr Buffer,
+                              ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
 
+proc update_next_member*(ctx: ptr RLN[Bn256],
+                         input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
 
-# pub extern "C" fn generate_proof(
-#     ctx: *const RLN<Bn256>,
-#     input_buffer: *const Buffer,
-#     output_buffer: *mut Buffer,
-# ) -> bool
+proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
 
+proc generate_proof*(ctx: ptr RLN[Bn256],
+                     input_buffer: ptr Buffer,
+                     auth: ptr Auth,
+                     output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
+
+proc verify*(ctx: ptr RLN[Bn256],
+             proof_buffer: ptr Buffer,
+             result_ptr: ptr uint32): bool {.importc: "verify".}
 {.pop.}
-
-

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -28,6 +28,7 @@ proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: 
 proc new_circuit_from_params*(merkle_depth: uint,
                               parameters_buffer: ptr Buffer,
                               ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
+
 #------------------------------Merkle Tree operations -----------------------------------------
 proc update_next_member*(ctx: ptr RLN[Bn256],
                          input_buffer: ptr Buffer): bool {.importc: "update_next_member".}

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -58,6 +58,7 @@ proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])): bool =
   if (res == false): 
     debug "error in parameters generation"
     return false
+  return true
 
 proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
   ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -31,39 +31,10 @@ contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
 
-# proc createRLNInstance*(d: int): Option[ptr RLN[Bn256]] = 
-#   ## generates an instance of RLN for a Merkle tree with the depth of d
-#   var  
-#     merkleDepth: csize_t = uint(d)
-#     # parameters.key contains the parameters related to the Poseidon hasher
-#     # to generate this file, clone this repo https://github.com/kilic/rln 
-#     # and run the following command in the root directory of the cloned project
-#     # cargo run --example export_test_keys
-#     # the file is generated separately and copied here
-#     parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-#     pbytes = parameters.toBytes()
-#     len : csize_t = uint(pbytes.len)
-#     parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
-
-#   # check the parameters.key is not empty
-#   if(pbytes.len == 0):
-#     debug "error in parameters.key"
-#     return none(ptr RLN[Bn256])
-    
-#   # ctx holds the information that is going to be used for  the key generation
-#   var 
-#     obj = RLN[Bn256]()
-#     objPtr = unsafeAddr(obj)
-#     objptrptr = unsafeAddr(objPtr)
-#     ctx = objptrptr
-#   let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctx)
-#   # check whether the circuit parameters are generated successfully
-#   if(res == false):
-#     debug "error in parameters generation"
-#     return none(ptr RLN[Bn256])
-#   return some(ctx[])
-proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])) = 
-  ## generates an instance of RLN for a Merkle tree with the depth of d
+proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])): bool = 
+  ## generates an instance of RLN 
+  ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
+  ## d indicates the depth of Merkle tree 
   var  
     merkleDepth: csize_t = uint(d)
     # parameters.key contains the parameters related to the Poseidon hasher
@@ -77,33 +48,19 @@ proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])) =
     parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
 
   # check the parameters.key is not empty
-  doAssert(not(pbytes.len == 0))
-    # debug "error in parameters.key"
-    # return none(RLN[Bn256])
-    
-  # ctx holds the information that is going to be used for  the key generation
-  # var 
-  #   obj = RLN[Bn256]()
-  #   objPtr = unsafeAddr(obj)
-  #   objptrptr = unsafeAddr(objPtr)
-  #   ctx = objptrptr
+  if (pbytes.len == 0):
+    debug "error in parameters.key"
+    return false
+  
+  # create an instance of RLN
   let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctxPtrPtr)
   # check whether the circuit parameters are generated successfully
-  doAssert(not(res == false))
-    # debug "error in parameters generation"
-  #   return none(ptr RLN[Bn256])
-  # return some(ctx[])
+  if (res == false): 
+    debug "error in parameters generation"
+    return false
+
 proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
   ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
-  # var ctx: ptr RLN[Bn256]
-  # if inCtx.isSome():
-  #   ctx = inCtx.get()
-  # else:
-  #   let genCtx = createRLNInstance(32)
-  #   if genCtx.isNone():
-  #     debug "error in rln instance creation"
-  #     return none(MembershipKeyPair)
-  #   ctx = genCtx.get()
     
   # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
   var 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -86,15 +86,20 @@ proc membershipKeyGen*(inCtx: Option[ptr RLN[Bn256]] = none(ptr RLN[Bn256])): Op
     debug "error in key generation"
     return none(MembershipKeyPair)
     
-  var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
+  var generatedKeys = cast[array[64, byte]](keysBufferPtr.`ptr`[])
   # the public and secret keys together are 64 bytes
   if (generatedKeys.len != 64):
     debug "the generated keys are invalid"
     return none(MembershipKeyPair)
   
+  # TODO define a separate proc to decode the generated keys to the secret and public components
   var 
-    secret = cast[array[32, byte]](generatedKeys[0..31])
-    public = cast[array[32, byte]](generatedKeys[31..^1])
+    secret: array[32, byte] 
+    public: array[32, byte]
+  for (i,x) in secret.mpairs: x = generatedKeys[i]
+  for (i,x) in public.mpairs: x = generatedKeys[i+32]
+  
+  var 
     keypair = MembershipKeyPair(secretKey: secret, publicKey: public)
 
   return some(keypair)

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -45,7 +45,7 @@ proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])): bool =
     parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
     pbytes = parameters.toBytes()
     len : csize_t = uint(pbytes.len)
-    parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
+    parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
 
   # check the parameters.key is not empty
   if (pbytes.len == 0):
@@ -53,7 +53,7 @@ proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])): bool =
     return false
   
   # create an instance of RLN
-  let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctxPtrPtr)
+  let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctxPtrPtr)
   # check whether the circuit parameters are generated successfully
   if (res == false): 
     debug "error in parameters generation"
@@ -66,7 +66,7 @@ proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
   # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
   var 
     keysBuffer : Buffer
-    keysBufferPtr = unsafeAddr(keysBuffer)
+    keysBufferPtr = addr(keysBuffer)
     done = key_gen(ctxPtr, keysBufferPtr)  
 
   # check whether the keys are generated successfully

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -74,7 +74,7 @@ proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
     debug "error in key generation"
     return none(MembershipKeyPair)
     
-  var generatedKeys = cast[array[64, byte]](keysBufferPtr.`ptr`[])
+  var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
   # the public and secret keys together are 64 bytes
   if (generatedKeys.len != 64):
     debug "the generated keys are invalid"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -31,37 +31,37 @@ contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
 
-proc createRLNInstance*(d: int): Option[ptr RLN[Bn256]] = 
-  ## generates an instance of RLN for a Merkle tree with the depth of d
-  var  
-    merkleDepth: csize_t = uint(d)
-    # parameters.key contains the parameters related to the Poseidon hasher
-    # to generate this file, clone this repo https://github.com/kilic/rln 
-    # and run the following command in the root directory of the cloned project
-    # cargo run --example export_test_keys
-    # the file is generated separately and copied here
-    parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-    pbytes = parameters.toBytes()
-    len : csize_t = uint(pbytes.len)
-    parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
+# proc createRLNInstance*(d: int): Option[ptr RLN[Bn256]] = 
+#   ## generates an instance of RLN for a Merkle tree with the depth of d
+#   var  
+#     merkleDepth: csize_t = uint(d)
+#     # parameters.key contains the parameters related to the Poseidon hasher
+#     # to generate this file, clone this repo https://github.com/kilic/rln 
+#     # and run the following command in the root directory of the cloned project
+#     # cargo run --example export_test_keys
+#     # the file is generated separately and copied here
+#     parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+#     pbytes = parameters.toBytes()
+#     len : csize_t = uint(pbytes.len)
+#     parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
 
-  # check the parameters.key is not empty
-  if(pbytes.len == 0):
-    debug "error in parameters.key"
-    return none(ptr RLN[Bn256])
+#   # check the parameters.key is not empty
+#   if(pbytes.len == 0):
+#     debug "error in parameters.key"
+#     return none(ptr RLN[Bn256])
     
-  # ctx holds the information that is going to be used for  the key generation
-  var 
-    obj = RLN[Bn256]()
-    objPtr = unsafeAddr(obj)
-    objptrptr = unsafeAddr(objPtr)
-    ctx = objptrptr
-  let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctx)
-  # check whether the circuit parameters are generated successfully
-  if(res == false):
-    debug "error in parameters generation"
-    return none(ptr RLN[Bn256])
-  return some(ctx[])
+#   # ctx holds the information that is going to be used for  the key generation
+#   var 
+#     obj = RLN[Bn256]()
+#     objPtr = unsafeAddr(obj)
+#     objptrptr = unsafeAddr(objPtr)
+#     ctx = objptrptr
+#   let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctx)
+#   # check whether the circuit parameters are generated successfully
+#   if(res == false):
+#     debug "error in parameters generation"
+#     return none(ptr RLN[Bn256])
+#   return some(ctx[])
 
 proc membershipKeyGen*(inCtx: Option[ptr RLN[Bn256]] = none(ptr RLN[Bn256])): Option[MembershipKeyPair] =
   ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -30,10 +30,11 @@ const
 contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
-  
-proc createRLNInstance*(merkleTreeDepth: int): Option[ptr RLN[Bn256]] = 
+
+proc createRLNInstance*(d: int): Option[ptr RLN[Bn256]] = 
+  ## generates an instance of RLN for a Merkle tree with the depth of d
   var  
-    merkleDepth: csize_t = uint(merkleTreeDepth)
+    merkleDepth: csize_t = uint(d)
     # parameters.key contains the parameters related to the Poseidon hasher
     # to generate this file, clone this repo https://github.com/kilic/rln 
     # and run the following command in the root directory of the cloned project

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -62,24 +62,54 @@ contract(MembershipContract):
 #     debug "error in parameters generation"
 #     return none(ptr RLN[Bn256])
 #   return some(ctx[])
+proc createRLNInstance*(d: int, ctxPtrPtr: ptr (ptr RLN[Bn256])) = 
+  ## generates an instance of RLN for a Merkle tree with the depth of d
+  var  
+    merkleDepth: csize_t = uint(d)
+    # parameters.key contains the parameters related to the Poseidon hasher
+    # to generate this file, clone this repo https://github.com/kilic/rln 
+    # and run the following command in the root directory of the cloned project
+    # cargo run --example export_test_keys
+    # the file is generated separately and copied here
+    parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+    pbytes = parameters.toBytes()
+    len : csize_t = uint(pbytes.len)
+    parametersBuffer = Buffer(`ptr`: unsafeAddr(pbytes[0]), len: len)
 
-proc membershipKeyGen*(inCtx: Option[ptr RLN[Bn256]] = none(ptr RLN[Bn256])): Option[MembershipKeyPair] =
+  # check the parameters.key is not empty
+  doAssert(not(pbytes.len == 0))
+    # debug "error in parameters.key"
+    # return none(RLN[Bn256])
+    
+  # ctx holds the information that is going to be used for  the key generation
+  # var 
+  #   obj = RLN[Bn256]()
+  #   objPtr = unsafeAddr(obj)
+  #   objptrptr = unsafeAddr(objPtr)
+  #   ctx = objptrptr
+  let res = new_circuit_from_params(merkleDepth, unsafeAddr parametersBuffer, ctxPtrPtr)
+  # check whether the circuit parameters are generated successfully
+  doAssert(not(res == false))
+    # debug "error in parameters generation"
+  #   return none(ptr RLN[Bn256])
+  # return some(ctx[])
+proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
   ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
-  var ctx: ptr RLN[Bn256]
-  if inCtx.isSome():
-    ctx = inCtx.get()
-  else:
-    let genCtx = createRLNInstance(32)
-    if genCtx.isNone():
-      debug "error in rln instance creation"
-      return none(MembershipKeyPair)
-    ctx = genCtx.get()
+  # var ctx: ptr RLN[Bn256]
+  # if inCtx.isSome():
+  #   ctx = inCtx.get()
+  # else:
+  #   let genCtx = createRLNInstance(32)
+  #   if genCtx.isNone():
+  #     debug "error in rln instance creation"
+  #     return none(MembershipKeyPair)
+  #   ctx = genCtx.get()
     
   # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
   var 
     keysBuffer : Buffer
     keysBufferPtr = unsafeAddr(keysBuffer)
-    done = key_gen(ctx, keysBufferPtr)  
+    done = key_gen(ctxPtr, keysBufferPtr)  
 
   # check whether the keys are generated successfully
   if(done == false):


### PR DESCRIPTION
An incremental PR towards https://github.com/status-im/nim-waku/issues/395 and closes https://github.com/status-im/nim-waku/issues/388 and https://github.com/status-im/nim-waku/issues/387. I have also done some clean up and reorganization for the sake of code readability and reusability. 
- Adds Nim bindings for the Merkle tree operations with their unit tests: `get_root`, `update_next_member`, and `delete_member`.
- The prior Nim bindings names are updated to match their original name in the rln Rust lib.
- Removes the untested rln Nim wrappers. 
- The signature of `new_circuit_from_params` is also updated. 
- Updates rln submodule.
- It separates the rln instance creation procedure from the `membershipKeyGen` function.  It is now defined under `createRLNInstance`. The reason for this change was that the rln instance needs to be created and passed across multiple function calls, thus we needed to have access to it outside of the `membershipKeyGen`. Subsequent changes are also made on the `membershipKeyGen` interface.
- A helper proc `genSKPK` is defined in the waku rln-relay test file. It facilitates creating keys as `Buffer` objects for the test scenarios.
- Updates the tests titles to match the Nim wrappers.
- Some helper procs are defined in the waku rln-relay test file.