### PR TITLE
Specify chat2 message format

### DIFF
--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -82,4 +82,4 @@ message Chat2Message {
 }
 ```
 
-where `timestamp` is the Unix timestamp of the message, `nick` is the relevant `chat2` user's selected nickname and `payload` is the actual chat message being sent.
+where `timestamp` is the Unix timestamp of the message, `nick` is the relevant `chat2` user's selected nickname and `payload` is the actual chat message being sent. The `payload` is the byte array representation of a UTF8 encoded string.

--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -69,3 +69,17 @@ This will bypass the random peer selection process and connect to the specified 
 | `/help` | displays available in-chat commands |
 | `/connect` | interactively connect to a new peer |
 | `/nick` | change nickname for current chat session |
+
+## `chat2` message protobuf format
+
+Each `chat2` message is encoded as follows
+
+```protobuf
+message Chat2Message {
+  uint64 timestamp = 1;
+  string nick = 2;
+  bytes payload = 3;
+}
+```
+
+where `timestamp` is the Unix timestamp of the message, `nick` is the relevant `chat2` user's selected nickname and `payload` is the actual chat message being sent.


### PR DESCRIPTION
Now that [more Waku implementations](https://github.com/status-im/js-waku/issues/15) are interfacing with the `test` cluster and other `chat2` nodes, it has become necessary to specify the `chat2` message format explicitly. This will allow individual implementations to handle messages and their properties (`timestamp`, `nick` and `payload`) consistently.