### PR TITLE
Start relay protocol on wakunode2

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -162,6 +162,9 @@ proc start*(node: WakuNode) {.async.} =
   ## XXX: this should be /ip4..., / stripped?
   info "Listening on", full = listenStr
 
+  if not node.wakuRelay.isNil:
+    await node.wakuRelay.start()
+
 proc stop*(node: WakuNode) {.async.} =
   if not node.wakuRelay.isNil:
     await node.wakuRelay.stop()
@@ -416,6 +419,13 @@ proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string](), rlnRela
     # TODO currently the message validator is set for the defaultTopic, this can be configurable to accept other pubsub topics as well 
     addRLNRelayValidator(node, defaultTopic)
     info "WakuRLNRelay is mounted successfully"
+  
+  if node.libp2pTransportLoops.len > 0:
+    # Node has already started. Start the WakuRelay protocol
+
+    waitFor node.wakuRelay.start()
+
+    info "relay mounted and started successfully"
 
 
 ## Helpers


### PR DESCRIPTION
This PR fixes #445

It ensures that `relay` protocol, and the underlying `gossipsub`, is started on a `wakunode2`.

This fix assumes the following:
1. A `node` can be started and `relay` protocol mounted in any order.
2. When `relay` is mounted, it should start if and only if the `node` was already started. Otherwise it should start on `node` start.

**Note**: I'm not sure if the original intention was to be somewhat more strict in terms of the ordering above, e.g. that protocols should always be mounted _before_ the node starts listening. In our current examples, tests and scripts, the `mount()`<->`start()` order seems to be interchangeable, which allows for mounting protocols on live nodes.