### PR TITLE
Adds startTime and endTime to the HistoryQuery

### DIFF
--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -330,11 +330,11 @@ procSuite "Waku Store":
       decodedEmptyPagingInfo.isErr == false
       decodedEmptyPagingInfo.value == emptyPagingInfo
   
-  test "HistoryQuery Protobuf encod/init test":
+  test "HistoryQuery Protobuf encode/init test":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query=HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: pagingInfo)
+      query=HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -146,6 +146,10 @@ proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
 
   msg.pagingInfo = ? PagingInfo.init(pagingInfoBuffer)
 
+  discard ? pb.getField(3, msg.startTime)
+  discard ? pb.getField(4, msg.endTime)
+
+
   ok(msg)
 
 proc init*(T: type HistoryResponse, buffer: seq[byte]): ProtoResult[T] =
@@ -189,6 +193,9 @@ proc encode*(query: HistoryQuery): ProtoBuffer =
     result.write(1, topic)
   
   result.write(2, query.pagingInfo.encode())
+
+  result.write(3, query.startTime)
+  result.write(4, query.endTime)
 
 proc encode*(response: HistoryResponse): ProtoBuffer =
   result = initProtoBuffer()

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -39,6 +39,8 @@ type
   HistoryQuery* = object
     topics*: seq[ContentTopic]
     pagingInfo*: PagingInfo # used for pagination
+    startTime*: float64 # used for time-window query
+    endTime*: float64 # used for time-window query
 
   HistoryResponse* = object
     messages*: seq[WakuMessage]


### PR DESCRIPTION
This is an incremental PR towards vacp2p/research#64. 
Two new fields of `startTime` and `endTime` are added to the `HistoryQuery` to enable time-window queries. 

**Some notes:**
The initial thought was to add time-window queries and the relevant fields to the pagination logic i.e., add them to https://github.com/status-im/nim-waku/blob/683577f04552f4fd22f2b302584f23abd3f0e3d4/waku/v2/protocol/waku_store/waku_store_types.nim#L33 , but inspired by  the Twitter pagination technique https://developer.twitter.com/en/docs/twitter-api/pagination, I found it more meaningful to treat the query process separate from the pagination part.  The idea is that we query a history based on the combination of time-window and topics, then we segment the result into pages in case that the number of retrieved messages is more than the `MaxPageSize` https://github.com/status-im/nim-waku/blob/683577f04552f4fd22f2b302584f23abd3f0e3d4/waku/v2/protocol/waku_store/waku_store_types.nim#L17 


In the subsequent PRs, I will rework the history query process by handling time-based queries.