### PR TITLE
Enabling time window history query

### DIFF
--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -330,11 +330,11 @@ procSuite "Waku Store":
       decodedEmptyPagingInfo.isErr == false
       decodedEmptyPagingInfo.value == emptyPagingInfo
   
-  test "HistoryQuery Protobuf encod/init test":
+  test "HistoryQuery Protobuf encode/init test":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query=HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: pagingInfo)
+      query=HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -377,7 +377,7 @@ procSuite "Waku Store":
       decodedEmptyRes.isErr == false
       decodedEmptyRes.value == emptyRes
     
-  asyncTest "handle temporal history queries":
+  asyncTest "temporal history queries":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
@@ -412,7 +412,7 @@ procSuite "Waku Store":
     for wakuMsg in msgList:
       await subscriptions.notify("foo", wakuMsg)
     
-    asyncTest "handle temporal history query with a valid time-window":
+    asyncTest "handle temporal history query with a valid time window":
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
@@ -428,7 +428,7 @@ procSuite "Waku Store":
       check:
         (await completionFut.withTimeout(5.seconds)) == true
 
-    asyncTest "handle temporal history queries with zero-size window":
+    asyncTest "handle temporal history query with a zero-size time window":
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
@@ -442,7 +442,7 @@ procSuite "Waku Store":
       check:
         (await completionFut.withTimeout(5.seconds)) == true
 
-    asyncTest "handle temporal history queries with invalid time window":
+    asyncTest "handle temporal history query with an invalid time window":
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -429,11 +429,13 @@ procSuite "Waku Store":
         (await completionFut.withTimeout(5.seconds)) == true
 
     asyncTest "handle temporal history query with a zero-size time window":
+      #  a zero-size window results in an empty list of history messages
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
         check:
-          response.messages.len() == 5
+          #  a zero-size window results in an empty list of history messages
+          response.messages.len() == 0
         completionFut.complete(true)
 
       let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(2), endTime: float(2))
@@ -443,10 +445,12 @@ procSuite "Waku Store":
         (await completionFut.withTimeout(5.seconds)) == true
 
     asyncTest "handle temporal history query with an invalid time window":
+      #  an invalid time query will be ignored and only the content topic filter will get through
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
         check:
+          #  an invalid time query will be ignored and only the content topic filter will get through
           response.messages.len() == 5
         completionFut.complete(true)
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -377,16 +377,16 @@ procSuite "Waku Store":
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
     var
-      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic(2)),
-        WakuMessage(payload: @[byte 1],contentTopic: ContentTopic(1), timestamp: float(1)),
-        WakuMessage(payload: @[byte 2],contentTopic: ContentTopic(2), timestamp: float(2)),
-        WakuMessage(payload: @[byte 3],contentTopic: ContentTopic(1), timestamp: float(3)),
-        WakuMessage(payload: @[byte 4],contentTopic: ContentTopic(2), timestamp: float(4)),
-        WakuMessage(payload: @[byte 5],contentTopic: ContentTopic(1), timestamp: float(5)),
-        WakuMessage(payload: @[byte 6],contentTopic: ContentTopic(2), timestamp: float(6)),
-        WakuMessage(payload: @[byte 7],contentTopic: ContentTopic(1), timestamp: float(7)),
-        WakuMessage(payload: @[byte 8],contentTopic: ContentTopic(2), timestamp: float(8)),
-        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic(1),timestamp: float(9))]
+      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2")),
+        WakuMessage(payload: @[byte 1],contentTopic: ContentTopic("1"), timestamp: float(1)),
+        WakuMessage(payload: @[byte 2],contentTopic: ContentTopic("2"), timestamp: float(2)),
+        WakuMessage(payload: @[byte 3],contentTopic: ContentTopic("1"), timestamp: float(3)),
+        WakuMessage(payload: @[byte 4],contentTopic: ContentTopic("2"), timestamp: float(4)),
+        WakuMessage(payload: @[byte 5],contentTopic: ContentTopic("1"), timestamp: float(5)),
+        WakuMessage(payload: @[byte 6],contentTopic: ContentTopic("2"), timestamp: float(6)),
+        WakuMessage(payload: @[byte 7],contentTopic: ContentTopic("1"), timestamp: float(7)),
+        WakuMessage(payload: @[byte 8],contentTopic: ContentTopic("2"), timestamp: float(8)),
+        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic("1"),timestamp: float(9))]
             
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -417,7 +417,7 @@ procSuite "Waku Store":
           response.messages.anyIt(it.timestamp == float(5))
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(2), endTime: float(5))
+      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(2), endTime: float(5))
       await proto.query(rpc, handler)
 
       check:
@@ -433,7 +433,7 @@ procSuite "Waku Store":
           response.messages.len() == 0
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(2), endTime: float(2))
+      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(2), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:
@@ -450,7 +450,7 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       # time window is invalid since start time > end time
-      let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(5), endTime: float(2))
+      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -450,6 +450,7 @@ procSuite "Waku Store":
           response.messages.len() == 5
         completionFut.complete(true)
 
+      # time window is invalid since start time > end time
       let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -429,12 +429,12 @@ procSuite "Waku Store":
         (await completionFut.withTimeout(5.seconds)) == true
 
     asyncTest "handle temporal history query with a zero-size time window":
-      #  a zero-size window results in an empty list of history messages
+      # a zero-size window results in an empty list of history messages
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
         check:
-          #  a zero-size window results in an empty list of history messages
+          # a zero-size window results in an empty list of history messages
           response.messages.len() == 0
         completionFut.complete(true)
 
@@ -445,13 +445,13 @@ procSuite "Waku Store":
         (await completionFut.withTimeout(5.seconds)) == true
 
     asyncTest "handle temporal history query with an invalid time window":
-      #  an invalid time query will be ignored and only the content topic filter will get through
+      # a history query with an invalid time range results in an empty list of history messages
       var completionFut = newFuture[bool]()
 
       proc handler(response: HistoryResponse) {.gcsafe, closure.} =
         check:
-          #  an invalid time query will be ignored and only the content topic filter will get through
-          response.messages.len() == 5
+          # a history query with an invalid time range results in an empty list of history messages
+          response.messages.len() == 0
         completionFut.complete(true)
 
       # time window is invalid since start time > end time

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[options, tables, sets],
+  std/[options, tables, sets, sequtils],
   testutils/unittests, chronos, chronicles,
   libp2p/switch,
   libp2p/protobuf/minprotobuf,
@@ -353,7 +353,7 @@ procSuite "Waku Store":
       decodedEmptyQuery.isErr == false
       decodedEmptyQuery.value == emptyQuery
   
-  test "HistoryResponse Protobuf encod/init test":
+  test "HistoryResponse Protobuf encode/init test":
     let
       wm = WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1))
       index = computeIndex(wm)
@@ -377,3 +377,53 @@ procSuite "Waku Store":
       decodedEmptyRes.isErr == false
       decodedEmptyRes.value == emptyRes
     
+  asyncTest "handle temporal history queries":
+    let
+      key = PrivateKey.random(ECDSA, rng[]).get()
+      peer = PeerInfo.init(key)
+    var
+      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic(2)),
+        WakuMessage(payload: @[byte 1],contentTopic: ContentTopic(1), timestamp: float(1)),
+        WakuMessage(payload: @[byte 2],contentTopic: ContentTopic(2), timestamp: float(2)),
+        WakuMessage(payload: @[byte 3],contentTopic: ContentTopic(1), timestamp: float(3)),
+        WakuMessage(payload: @[byte 4],contentTopic: ContentTopic(2), timestamp: float(4)),
+        WakuMessage(payload: @[byte 5],contentTopic: ContentTopic(1), timestamp: float(5)),
+        WakuMessage(payload: @[byte 6],contentTopic: ContentTopic(2), timestamp: float(6)),
+        WakuMessage(payload: @[byte 7],contentTopic: ContentTopic(1), timestamp: float(7)),
+        WakuMessage(payload: @[byte 8],contentTopic: ContentTopic(2), timestamp: float(8)),
+        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic(1),timestamp: float(9))]
+            
+    var dialSwitch = newStandardSwitch()
+    discard await dialSwitch.start()
+
+    var listenSwitch = newStandardSwitch(some(key))
+    discard await listenSwitch.start()
+
+    let
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
+      subscription = proto.subscription()
+    proto.setPeer(listenSwitch.peerInfo)
+
+    var subscriptions = newTable[string, MessageNotificationSubscription]()
+    subscriptions["test"] = subscription
+
+    listenSwitch.mount(proto)
+
+    for wakuMsg in msgList:
+      await subscriptions.notify("foo", wakuMsg)
+    var completionFut = newFuture[bool]()
+
+    proc handler(response: HistoryResponse) {.gcsafe, closure.} =
+      echo response.messages[0]
+      echo response.messages[1]
+      check:
+        response.messages.len() == 2
+        response.messages.anyIt(it.timestamp == float(3))
+        response.messages.anyIt(it.timestamp == float(5))
+      completionFut.complete(true)
+
+    let rpc = HistoryQuery(topics: @[ContentTopic(1)], startTime: float(2), endTime: float(5))
+    await proto.query(rpc, handler)
+
+    check:
+      (await completionFut.withTimeout(5.seconds)) == true

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -146,6 +146,10 @@ proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
 
   msg.pagingInfo = ? PagingInfo.init(pagingInfoBuffer)
 
+  discard ? pb.getField(3, msg.startTime)
+  discard ? pb.getField(4, msg.endTime)
+
+
   ok(msg)
 
 proc init*(T: type HistoryResponse, buffer: seq[byte]): ProtoResult[T] =
@@ -189,6 +193,9 @@ proc encode*(query: HistoryQuery): ProtoBuffer =
     result.write(1, topic)
   
   result.write(2, query.pagingInfo.encode())
+
+  result.write(3, query.startTime)
+  result.write(4, query.endTime)
 
 proc encode*(response: HistoryResponse): ProtoBuffer =
   result = initProtoBuffer()

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -311,12 +311,9 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
 
   # temporal filtering
   # an invalid time query will be ignored
-  let 
-    # check whether the history query contains a time filter
-    hasTimeQuery = (query.endTime != float64(0) and query.startTime != float64(0))
-    # check whether the time window has a valid range
-    hasValidRange = (query.endTime >= query.startTime)
-  if (hasTimeQuery and hasValidRange):
+   
+  # check whether the history query contains a time filter
+  if (query.endTime != float64(0) and query.startTime != float64(0)):
     # for a valid time query, select messages whose sender generated timestamps fall bw the queried start time and end time
     data = data.filterIt(it.msg.timestamp <= query.endTime and it.msg.timestamp >= query.startTime)
 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -309,9 +309,7 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   # data holds IndexedWakuMessage whose topics match the query
   var data = w.messages.filterIt(it.msg.contentTopic in query.topics)  
 
-  # temporal filtering
-  # an invalid time query will be ignored
-   
+  # temporal filtering   
   # check whether the history query contains a time filter
   if (query.endTime != float64(0) and query.startTime != float64(0)):
     # for a valid time query, select messages whose sender generated timestamps fall bw the queried start time and end time

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -310,8 +310,14 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   var data = w.messages.filterIt(it.msg.contentTopic in query.topics)  
 
   # temporal filtering
-  if (query.endTime > query.startTime):
-    # for a non-zero time range, select messages whose timestamps fall bw the queried start time and end time
+  # an invalid time query will be ignored
+  let 
+    # check whether the history query contains a time filter
+    hasTimeQuery = (query.endTime != float64(0) and query.startTime != float64(0))
+    # check whether the time window has a valid range
+    hasValidRange = (query.endTime >= query.startTime)
+  if (hasTimeQuery and hasValidRange):
+    # for a valid time query, select messages whose sender generated timestamps fall bw the queried start time and end time
     data = data.filterIt(it.msg.timestamp <= query.endTime and it.msg.timestamp >= query.startTime)
 
   

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -312,7 +312,7 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   # temporal filtering
   if (query.endTime > query.startTime):
     # for a non-zero time range, select messages whose timestamps fall bw the queried start time and end time
-    data = data.filterIt(it.msg.timestamp < query.endTime and it.msg.timestamp > query.startTime)
+    data = data.filterIt(it.msg.timestamp <= query.endTime and it.msg.timestamp >= query.startTime)
 
   
   # perform pagination

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -308,6 +308,12 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   result = HistoryResponse(messages: newSeq[WakuMessage]())
   # data holds IndexedWakuMessage whose topics match the query
   var data = w.messages.filterIt(it.msg.contentTopic in query.topics)  
+
+  # temporal filtering
+  if (query.endTime > query.startTime):
+    # for a non-zero time range, select messages whose timestamps fall bw the queried start time and end time
+    data = data.filterIt(it.msg.timestamp < query.endTime and it.msg.timestamp > query.startTime)
+
   
   # perform pagination
   (result.messages, result.pagingInfo)= paginateWithoutIndex(data, query.pagingInfo)

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -39,6 +39,8 @@ type
   HistoryQuery* = object
     topics*: seq[ContentTopic]
     pagingInfo*: PagingInfo # used for pagination
+    startTime*: float64 # used for time-window query
+    endTime*: float64 # used for time-window query
 
   HistoryResponse* = object
     messages*: seq[WakuMessage]


### PR DESCRIPTION
An incremental PR towards https://github.com/vacp2p/research/issues/64 and https://github.com/status-im/nim-waku/issues/458.

As part of enabling a fault-tolerant store protocol, peers must be able to retrieve history messages based on a time range (during which they were absent). In this PR, the logic for handling temporal history queries is added to the store protocol. The unit tests are also included.
