### PR TITLE
Updates the field number of proof and timestamp

### DIFF
--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -33,6 +33,7 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(2, msg.contentTopic)
   discard ? pb.getField(3, msg.version)
   discard ? pb.getField(4, msg.timestamp)
+# XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
   discard ? pb.getField(21, msg.proof)
 
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -16,11 +16,13 @@ type
     payload*: seq[byte]
     contentTopic*: ContentTopic
     version*: uint32
-    # the proof field indicates that the message is not a spam
-    # this field will be used in the rln-relay protocol
-    proof*: seq[byte]
     # sender generated timestamp
     timestamp*: float64
+    # the proof field indicates that the message is not a spam
+    # this field will be used in the rln-relay protocol
+    # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
+    proof*: seq[byte]
+   
 
 # Encoding and decoding -------------------------------------------------------
 proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -33,9 +33,8 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(2, msg.contentTopic)
   discard ? pb.getField(3, msg.version)
   discard ? pb.getField(4, msg.timestamp)
-# XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
+  # XXX Experimental, this is part of https://rfc.vac.dev/spec/17/ spec and not yet part of WakuMessage spec
   discard ? pb.getField(21, msg.proof)
-
 
   ok(msg)
 

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -30,8 +30,9 @@ proc init*(T: type WakuMessage, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(1, msg.payload)
   discard ? pb.getField(2, msg.contentTopic)
   discard ? pb.getField(3, msg.version)
-  discard ? pb.getField(4, msg.proof)
-  discard ? pb.getField(5, msg.timestamp)
+  discard ? pb.getField(4, msg.timestamp)
+  discard ? pb.getField(21, msg.proof)
+
 
   ok(msg)
 
@@ -41,5 +42,5 @@ proc encode*(message: WakuMessage): ProtoBuffer =
   result.write(1, message.payload)
   result.write(2, message.contentTopic)
   result.write(3, message.version)
-  result.write(4, message.proof)
-  result.write(5, message.timestamp)
+  result.write(4, message.timestamp)
+  result.write(21, message.proof)


### PR DESCRIPTION
Addresses https://github.com/vacp2p/rfc/pull/325#pullrequestreview-628565224
This is to change the field number of proof and timestamp fields in the waku message protobuf schema. 
- The field number of proof is changed from 4 to 21, this is because the proof is related to RLN which is yet an experimental feature. Thus, for now `proof` is an optional field. 
- Following this update, the timestamp field number is shifted to 4.