### PR TITLE
Change contentTopic to string

### DIFF
--- a/examples/v2/basic2.nim
+++ b/examples/v2/basic2.nim
@@ -35,7 +35,7 @@ proc runBackground() {.async.} =
 
   # Publish to a topic
   let payload = cast[seq[byte]]("hello world")
-  let message = WakuMessage(payload: payload, contentTopic: ContentTopic(1))
+  let message = WakuMessage(payload: payload, contentTopic: ContentTopic("/waku/2/default-content/proto"))
   await node.publish(topic, message)
 
 # TODO Await with try/except here

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -36,8 +36,7 @@ const
   PayloadV1* {.booldefine.} = false
   DefaultTopic = "/waku/2/default-waku/proto"
 
-  Dingpu = "dingpu".toBytes
-  DefaultContentTopic = ContentTopic(uint32.fromBytes(Dingpu))
+  DefaultContentTopic = ContentTopic("dingpu")
 
 # XXX Connected is a bit annoying, because incoming connections don't trigger state change
 # Could poll connection pool or something here, I suppose

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -12,7 +12,7 @@ suite "Message Store":
     let 
       database = SqliteDatabase.init("", inMemory = true)[]
       store = WakuMessageStore.init(database)[]
-      topic = ContentTopic(1)
+      topic = ContentTopic("/waku/2/default-content/proto")
 
     var msgs = @[
       WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic),

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -3,7 +3,7 @@
 import
   std/strutils,
   testutils/unittests,
-  chronicles, chronos, stew/shims/net as stewNet, stew/byteutils,
+  chronicles, chronos, stew/shims/net as stewNet, stew/[byteutils, objects],
   libp2p/crypto/crypto,
   libp2p/crypto/secp,
   libp2p/peerid,
@@ -44,8 +44,8 @@ procSuite "WakuBridge":
       v2NodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
       v2Node = WakuNode.init(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
 
-      topic = [byte 0x00, 0, 0, byte 0x01]
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("0001")
+      topic = toArray(4, contentTopic.toBytes()[0..3])
       payloadV1 = "hello from V1".toBytes()
       payloadV2 = "hello from V2".toBytes()
       message = WakuMessage(payload: payloadV2, contentTopic: contentTopic)

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -21,7 +21,7 @@ procSuite "Waku Filter":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
 
     var dialSwitch = newStandardSwitch()
@@ -70,7 +70,7 @@ procSuite "Waku Filter":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
 
     var dialSwitch = newStandardSwitch()
@@ -134,7 +134,7 @@ procSuite "Waku Filter":
     const defaultTopic = "/waku/2/default-waku/proto"
 
     let
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -26,9 +26,9 @@ procSuite "pagination":
       index.receivedTime != 0 # the timestamp should be a non-zero value
 
     let
-      wm1 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(1))
+      wm1 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic("/waku/2/default-content/proto"))
       index1 = wm1.computeIndex()
-      wm2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(1))
+      wm2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic("/waku/2/default-content/proto"))
       index2 = wm2.computeIndex()
 
     check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -15,7 +15,7 @@ import
   ../test_helpers, ./utils
 
 procSuite "Waku Store":
-  const defaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  const defaultContentTopic = ContentTopic("1")
   
   asyncTest "handle query":
     let

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -15,13 +15,15 @@ import
   ../test_helpers, ./utils
 
 procSuite "Waku Store":
+  const defaultContentTopic = ContentTopic("/waku/2/default-content/proto")
+  
   asyncTest "handle query":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
-      topic = ContentTopic(1)
+      topic = defaultContentTopic
       msg = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic)
-      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(2))
+      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic("2"))
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -61,11 +63,11 @@ procSuite "Waku Store":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
-      topic = ContentTopic(1)
+      topic = defaultContentTopic
       database = SqliteDatabase.init("", inMemory = true)[]
       store = WakuMessageStore.init(database)[]
       msg = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic)
-      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic(2))
+      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: ContentTopic("2"))
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -129,16 +131,16 @@ procSuite "Waku Store":
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
     var
-      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic(2)),
-        WakuMessage(payload: @[byte 1],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 2],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 3],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 4],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 5],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 6],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 7],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 8],contentTopic: ContentTopic(1)), 
-        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic(2))]
+      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2")),
+        WakuMessage(payload: @[byte 1],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 2],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 3],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 4],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 5],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 6],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 7],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 8],contentTopic: defaultContentTopic), 
+        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic("2"))]
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -149,7 +151,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
+      rpc = HistoryQuery(topics: @[defaultContentTopic], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -181,16 +183,16 @@ procSuite "Waku Store":
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
     var
-      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic(2)),
-        WakuMessage(payload: @[byte 1],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 2],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 3],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 4],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 5],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 6],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 7],contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 8],contentTopic: ContentTopic(1)), 
-        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic(2))]
+      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2")),
+        WakuMessage(payload: @[byte 1],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 2],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 3],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 4],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 5],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 6],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 7],contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 8],contentTopic: defaultContentTopic), 
+        WakuMessage(payload: @[byte 9],contentTopic: ContentTopic("2"))]
             
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -220,7 +222,7 @@ procSuite "Waku Store":
         response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
+    let rpc = HistoryQuery(topics: @[defaultContentTopic], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
     await proto.query(rpc, handler)
 
     check:
@@ -231,16 +233,16 @@ procSuite "Waku Store":
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
     var
-      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic(2)),
-        WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 2], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 3], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 4], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 5], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 6], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 7], contentTopic: ContentTopic(1)),
-        WakuMessage(payload: @[byte 8], contentTopic: ContentTopic(1)), 
-        WakuMessage(payload: @[byte 9], contentTopic: ContentTopic(2))]
+      msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2")),
+        WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 2], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 3], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 4], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 5], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 6], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 7], contentTopic: defaultContentTopic),
+        WakuMessage(payload: @[byte 8], contentTopic: defaultContentTopic), 
+        WakuMessage(payload: @[byte 9], contentTopic: ContentTopic("2"))]
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()
@@ -268,7 +270,7 @@ procSuite "Waku Store":
         response.pagingInfo == PagingInfo()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(topics: @[ContentTopic(1)] )
+    let rpc = HistoryQuery(topics: @[defaultContentTopic] )
 
     await proto.query(rpc, handler)
 
@@ -277,7 +279,7 @@ procSuite "Waku Store":
 
   test "Index Protobuf encoder/decoder test":
     let
-      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)))
+      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pb = index.encode()
       decodedIndex = Index.init(pb.buffer)
 
@@ -310,7 +312,7 @@ procSuite "Waku Store":
 
   test "PagingInfo Protobuf encod/init test":
     let
-      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)))
+      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
       pb = pagingInfo.encode()
       decodedPagingInfo = PagingInfo.init(pb.buffer)
@@ -332,9 +334,9 @@ procSuite "Waku Store":
   
   test "HistoryQuery Protobuf encode/init test":
     let
-      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1)))
+      index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query=HistoryQuery(topics: @[ContentTopic(1)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
+      query=HistoryQuery(topics: @[defaultContentTopic], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 
@@ -355,7 +357,7 @@ procSuite "Waku Store":
   
   test "HistoryResponse Protobuf encod/init test":
     let
-      wm = WakuMessage(payload: @[byte 1], contentTopic: ContentTopic(1))
+      wm = WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic)
       index = computeIndex(wm)
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
       res = HistoryResponse(messages: @[wm], pagingInfo:pagingInfo)

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -54,7 +54,7 @@ procSuite "Waku SWAP Accounting":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60001))
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       message = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
 
     var completionFut = newFuture[bool]()
@@ -100,7 +100,7 @@ procSuite "Waku SWAP Accounting":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60001))
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       message = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
 
     var futures = [newFuture[bool](), newFuture[bool]()]

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -27,7 +27,7 @@ procSuite "WakuNode":
       node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
         Port(60000))
       pubSubTopic = "chat"
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       filterRequest = FilterRequest(topic: pubSubTopic, contentFilters: @[ContentFilter(topics: @[contentTopic])], subscribe: true)
       message = WakuMessage(payload: "hello world".toBytes(),
         contentTopic: contentTopic)
@@ -79,7 +79,7 @@ procSuite "WakuNode":
       node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
       pubSubTopic = "chat"
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       filterRequest = FilterRequest(topic: pubSubTopic, contentFilters: @[ContentFilter(topics: @[contentTopic])], subscribe: true)
       message = WakuMessage(payload: "hello world".toBytes(),
         contentTopic: contentTopic)
@@ -141,7 +141,7 @@ procSuite "WakuNode":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       message = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
 
     var completionFut = newFuture[bool]()
@@ -177,7 +177,7 @@ procSuite "WakuNode":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       message = WakuMessage(payload: "hello world".toBytes(), contentTopic: contentTopic)
 
     var completionFut = newFuture[bool]()
@@ -219,7 +219,7 @@ procSuite "WakuNode":
       node3 = WakuNode.init(nodeKey3, ValidIpAddress.init("0.0.0.0"),
         Port(60003))
       pubSubTopic = "test"
-      contentTopic = ContentTopic(1)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message = WakuMessage(payload: payload, contentTopic: contentTopic)
 
@@ -317,12 +317,12 @@ procSuite "WakuNode":
       node3 = WakuNode.init(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
 
       pubSubTopic = "test"
-      contentTopic1 = ContentTopic(1)
+      contentTopic1 = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message1 = WakuMessage(payload: payload, contentTopic: contentTopic1)
 
       payload2 = "you should not see this message!".toBytes()
-      contentTopic2 = ContentTopic(2)
+      contentTopic2 = ContentTopic("2")
       message2 = WakuMessage(payload: payload2, contentTopic: contentTopic2)
 
     # start all the nodes
@@ -410,7 +410,7 @@ procSuite "WakuNode":
       node3 = WakuNode.init(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
 
       pubSubTopic = "defaultTopic"
-      contentTopic1 = ContentTopic(1)
+      contentTopic1 = ContentTopic("/waku/2/default-content/proto")
       payload = "hello world".toBytes()
       message1 = WakuMessage(payload: payload, contentTopic: contentTopic1)
 

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -43,7 +43,7 @@ proc installAdminApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       raise newException(ValueError, "Failed to connect to peers: " & $peers)
 
   rpcsrv.rpc("get_waku_v2_admin_v1_peers") do() -> seq[WakuPeer]:
-    ## Returns history for a list of content topics with optional paging
+    ## Returns a list of peers registered for this node
     debug "get_waku_v2_admin_v1_peers"
 
     # Create a single list of peers from mounted protocols.

--- a/waku/v2/node/jsonrpc/jsonrpc_utils.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_utils.nim
@@ -3,6 +3,7 @@ import
   eth/keys,
   ../../../v1/node/rpc/hexstrings,
   ../../protocol/waku_store/waku_store_types,
+  ../../protocol/waku_message,
   ../waku_payload,
   ./jsonrpc_types
 
@@ -37,15 +38,14 @@ proc toStoreResponse*(historyResponse: HistoryResponse): StoreResponse =
                 pagingOptions: if historyResponse.pagingInfo != PagingInfo(): some(historyResponse.pagingInfo.toPagingOptions()) else: none(StorePagingOptions))
 
 proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32): WakuMessage =
-  # @TODO global definition for default content topic
-  const defaultCT = 0
+  const defaultCT = ContentTopic("/waku/2/default-content/proto")
   WakuMessage(payload: relayMessage.payload,
               contentTopic: if relayMessage.contentTopic.isSome: relayMessage.contentTopic.get else: defaultCT,
               version: version)
 
 proc toWakuMessage*(relayMessage: WakuRelayMessage, version: uint32, rng: ref BrHmacDrbgContext, symkey: Option[SymKey], pubKey: Option[keys.PublicKey]): WakuMessage =
   # @TODO global definition for default content topic
-  const defaultCT = 0
+  const defaultCT = ContentTopic("/waku/2/default-content/proto")
 
   let payload = Payload(payload: relayMessage.payload,
                         dst: pubKey,

--- a/waku/v2/node/quicksim2.nim
+++ b/waku/v2/node/quicksim2.nim
@@ -18,7 +18,7 @@ createRpcSigs(RpcHttpClient, sigWakuPath)
 
 const defaultTopic = "/waku/2/default-waku/proto"
 
-const defaultContentTopic = ContentTopic(1)
+const defaultContentTopic = ContentTopic("waku/2/default-content/proto")
 
 const topicAmount = 10 #100
 

--- a/waku/v2/node/scripts/rpc_publish.nim
+++ b/waku/v2/node/scripts/rpc_publish.nim
@@ -33,7 +33,7 @@ var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
 
 let pubSubTopic = "/waku/2/default-waku/proto"
-let contentTopic = ContentTopic(1)
+let contentTopic = ContentTopic("/waku/2/default-content/proto")
 let relayMessage = WakuRelayMessage(payload: input.toBytes(), contentTopic: some(contentTopic))
 var res = waitfor node.post_waku_v2_relay_v1_message(pubSubTopic, relayMessage)
 echo "Waku publish response: ", res

--- a/waku/v2/node/scripts/rpc_query.nim
+++ b/waku/v2/node/scripts/rpc_query.nim
@@ -32,5 +32,5 @@ echo "Input is:", input
 var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
 
-var res = waitfor node.get_waku_v2_store_v1_messages(@[ContentTopic(parseUInt(input))], none(StorePagingOptions))
+var res = waitfor node.get_waku_v2_store_v1_messages(@[ContentTopic(input)], none(StorePagingOptions))
 echo "Waku query response: ", res

--- a/waku/v2/node/scripts/rpc_subscribe_filter.nim
+++ b/waku/v2/node/scripts/rpc_subscribe_filter.nim
@@ -33,6 +33,6 @@ var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
 
 let pubSubTopic = "/waku/2/default-waku/proto"
-let contentTopic = ContentTopic(1)
+let contentTopic = ContentTopic("/waku/2/default-content/proto")
 var res = waitfor node.post_waku_v2_filter_v1_subscription(@[ContentFilter(topics: @[contentTopic])], some(pubSubTopic))
 echo "Waku query response: ", res

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -10,7 +10,7 @@ import
   libp2p/protobuf/minprotobuf
 
 type
-  ContentTopic* = uint32
+  ContentTopic* = string
 
   WakuMessage* = object
     payload*: seq[byte]


### PR DESCRIPTION
This PR addresses #447 

It changes the `WakuMessage` `contentTopic` back to `string`. Spec changes done in https://github.com/vacp2p/rfc/pull/337

#### Implementation notes:
 - The "default" content topic is now `"waku/2/default-content/proto"`. This is a rather arbitrary choice and may change once we spec [namespacing for content topics](https://github.com/vacp2p/rfc/issues/227)
 - For now, `WakuBridge` maps v2 content topics to v1 topics by selecting the first four bytes. This will change when we introduce [namespacing](https://github.com/vacp2p/rfc/issues/227)
 - Note that changing the `contentTopic` type as argument in JSON-RPC calls affects users of the API (cc @D4nte)
 - `WakuStore` [index computation for messages](https://github.com/status-im/nim-waku/blob/master/waku/v2/protocol/waku_store/waku_store.nim#L44) would have changed somewhat, as it is now using `string.toBytes()` rather than `uint32.toBytes()` in the algorithm. @staheri14, I assume this will be OK going forward, though existing stores (e.g. `test` fleet) may be affected?

#### Next steps:
- Specify namespacing for content topics: https://github.com/vacp2p/rfc/issues/227