### PR TITLE
fix: direction encoding

### DIFF
--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -301,7 +301,7 @@ procSuite "Waku Store":
   test "PagingInfo Protobuf encod/init test":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
-      pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
+      pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.FORWARD)
       pb = pagingInfo.encode()
       decodedPagingInfo = PagingInfo.init(pb.buffer)
 
@@ -309,6 +309,7 @@ procSuite "Waku Store":
       # the fields of decodedPagingInfo must be the same as the original pagingInfo
       decodedPagingInfo.isErr == false
       decodedPagingInfo.value == pagingInfo
+      decodedPagingInfo.value.direction == pagingInfo.direction
     
     let
       emptyPagingInfo = PagingInfo()

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -298,18 +298,6 @@ procSuite "Waku Store":
       decodedEmptyIndex.isErr == false
       decodedEmptyIndex.value == emptyIndex
 
-
-  test "PagingDirection Protobuf encod/init test":
-    let
-      pagingDirection = PagingDirection.BACKWARD
-      pb = pagingDirection.encode()
-      decodedPagingDirection = PagingDirection.init(pb.buffer)
-
-    check:
-      # the decodedPagingDirection must be the same as the original pagingDirection
-      decodedPagingDirection.isErr == false
-      decodedPagingDirection.value == pagingDirection
-
   test "PagingInfo Protobuf encod/init test":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -91,16 +91,6 @@ proc init*(T: type Index, buffer: seq[byte]): ProtoResult[T] =
 
   ok(index) 
 
-proc init*(T: type PagingDirection, buffer: seq[byte]): ProtoResult[T] =
-  ## creates and returns a PagingDirection object out of buffer
-  let pb = initProtoBuffer(buffer)
-
-  var dir: uint32
-  discard ? pb.getField(1, dir)
-  var direction = PagingDirection(dir)
-
-  ok(direction)
-
 proc init*(T: type PagingInfo, buffer: seq[byte]): ProtoResult[T] =
   ## creates and returns a PagingInfo object out of buffer
   var pagingInfo = PagingInfo()
@@ -115,9 +105,9 @@ proc init*(T: type PagingInfo, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getField(2, cursorBuffer)
   pagingInfo.cursor = ? Index.init(cursorBuffer)
 
-  var directionBuffer: seq[byte]
-  discard ? pb.getField(3, directionBuffer)
-  pagingInfo.direction = ? PagingDirection.init(directionBuffer)
+  var direction: uint32
+  discard ? pb.getField(3, direction)
+  pagingInfo.direction = PagingDirection(direction)
 
   ok(pagingInfo) 
   

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -59,16 +59,6 @@ proc encode*(index: Index): ProtoBuffer =
   result.write(1, index.digest.data)
   result.write(2, index.receivedTime)
 
-proc encode*(pd: PagingDirection): ProtoBuffer =
-  ## encodes a PagingDirection into a ProtoBuffer
-  ## returns the resultant ProtoBuffer
-
-  # intiate a ProtoBuffer
-  result = initProtoBuffer()
-
-  # encodes pd
-  result.write(1, uint32(ord(pd)))
-
 proc encode*(pinfo: PagingInfo): ProtoBuffer =
   ## encodes a PagingInfo object into a ProtoBuffer
   ## returns the resultant ProtoBuffer
@@ -79,7 +69,7 @@ proc encode*(pinfo: PagingInfo): ProtoBuffer =
   # encodes pinfo
   result.write(1, pinfo.pageSize)
   result.write(2, pinfo.cursor.encode())
-  result.write(3, pinfo.direction.encode())
+  result.write(3, uint32(ord(pinfo.direction)))
 
 proc init*(T: type Index, buffer: seq[byte]): ProtoResult[T] =
   ## creates and returns an Index object out of buffer


### PR DESCRIPTION
The way the direction is being encoded right should be roughly equivalent to this code. The direction is a Protobuffer, instead of being an enum/uint32 value:
```js
message PagingInfo {
  int64 pageSize = 1;
  Index cursor = 2;
  Direction direction = 3;
}

Direction {
  uint32 value = 1
}
```

To match the [spec description](https://rfc.vac.dev/spec/13/#protobuf), in this PR the `PagingInfo` message encoding/decoding is modified, so its 3rd field (`direction`) contains an uint32 value instead of a encoded message