### PR TITLE
Fix Windows CI

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -372,6 +372,8 @@ procSuite "Waku v2 JSON-RPC API":
     for x in 1..(maxSize + 1):
       # Try to cache 1 more than maximum allowed
       filters.notify(WakuMessage(payload: @[byte x], contentTopic: defaultContentTopic), requestId)
+    
+    await sleepAsync(2000.millis)
 
     response = await client.get_waku_v2_filter_v1_messages(defaultContentTopic)
     check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -88,6 +88,7 @@ procSuite "Waku Store":
     listenSwitch.mount(proto)
 
     await subscriptions.notify("foo", msg)
+    await sleepAsync(1.millis)  # Sleep a millisecond to ensure messages are stored chronologically
     await subscriptions.notify("foo", msg2)
 
     var completionFut = newFuture[bool]()
@@ -162,6 +163,7 @@ procSuite "Waku Store":
 
     for wakuMsg in msgList:
       await subscriptions.notify("foo", wakuMsg)
+      await sleepAsync(1.millis)  # Sleep a millisecond to ensure messages are stored chronologically
 
     var completionFut = newFuture[bool]()
 
@@ -212,6 +214,7 @@ procSuite "Waku Store":
 
     for wakuMsg in msgList:
       await subscriptions.notify("foo", wakuMsg)
+      await sleepAsync(1.millis)  # Sleep a millisecond to ensure messages are stored chronologically
     var completionFut = newFuture[bool]()
 
     proc handler(response: HistoryResponse) {.gcsafe, closure.} =
@@ -262,6 +265,7 @@ procSuite "Waku Store":
 
     for wakuMsg in msgList:
       await subscriptions.notify("foo", wakuMsg)
+      await sleepAsync(1.millis)  # Sleep a millisecond to ensure messages are stored chronologically
     var completionFut = newFuture[bool]()
 
     proc handler(response: HistoryResponse) {.gcsafe, closure.} =

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -14,7 +14,7 @@ logScope:
   topics = "filter api"
 
 const futTimeout* = 5.seconds # Max time to wait for futures
-const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
+const maxCache* = 30 # Max number of messages cached per topic @TODO make this configurable
 
 proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer, messageCache: MessageCache) =
   

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -15,7 +15,7 @@ logScope:
   topics = "relay api"
 
 const futTimeout* = 5.seconds # Max time to wait for futures
-const maxCache* = 100 # Max number of messages cached per topic @TODO make this configurable
+const maxCache* = 30 # Max number of messages cached per topic @TODO make this configurable
 
 proc installRelayApiHandlers*(node: WakuNode, rpcsrv: RpcServer, topicCache: TopicCache) =
   

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -262,9 +262,9 @@ proc paginateWithIndex*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[
     initQuery = true # an empty cursor means it is an intial query
     case dir
       of PagingDirection.FORWARD: 
-        cursor = list[0].index # perform paging from the begining of the list
+        cursor = msgList[0].index # perform paging from the begining of the list
       of PagingDirection.BACKWARD: 
-        cursor = list[list.len - 1].index # perform paging from the end of the list
+        cursor = msgList[list.len - 1].index # perform paging from the end of the list
   var foundIndexOption = msgList.findIndex(cursor) 
   if foundIndexOption.isNone: # the cursor is not valid
     return (@[], PagingInfo(pageSize: 0, cursor:pinfo.cursor, direction: pinfo.direction))


### PR DESCRIPTION
This PR fixes #477

Windows CI has been failing since `contentTopic` changed to `string`. There were two unrelated failures.

### 1. `Store` retrieval failure 
This failure was caused by two factors:
- **A difference in message sorting order in the `store` protocol between platforms**: This only affected the `store` unit tests. Sorting order is supposed to prioritise timestamps to achieve chronological ordering, followed by `digest`. Due to a difference in the result/speed of the `epochTime()` function between platforms/OSs, in the `windows-latest` virtual environment the timestamps were exactly equal for all messages. An artificial delay between message notifications in the `store` test solved this problem.
- **A bug in `store` protocol in determining the start/end index of stored messages**:  The start/end indexes were determined from the unsorted list (which maintained insertion order) rather than the sorted list (which maintains chronological order). On non-Windows systems these lists were identically ordered due to `1` above.

#### Why has this not affected us before?

Since `contentTopic` forms the most significant part of the `digest` for stored messages, this was affected by the type change to `string`. Previously we were lucky that the _sort-by-digest_ list (on Windows, due to timestamp resolution) equalled the _sort-by-timestamp_ list (on non-Windows) equalled the _unsorted-insertion-order_ list (for `start` or `end` index).

### 2. `Filter API` failure

The API cache (that allows for message polling) had a default size sufficiently large that the [max RPC response body length](https://github.com/status-im/nim-json-rpc/blob/master/json_rpc/clients/httpclient.nim#L24) could be exceeded in some responses. This likely only affected Windows due to differences in string encodings, though I haven't been able to pinpoint this yet. 

A more complete solution will allow for configurable cache sizes. Tracking issue created [here](https://github.com/status-im/nim-waku/issues/478)

