### PR TITLE
Revert "Make wakunode2 and wakunode2 default to DEBUG log (#462)"

### DIFF
--- a/waku.nimble
+++ b/waku.nimble
@@ -44,7 +44,7 @@ proc test(name: string, lang = "c") =
 
 ### Waku v1 tasks
 task wakunode1, "Build Waku v1 cli node":
-  buildBinary "wakunode1", "waku/v1/node/", "-d:chronicles_log_level=DEBUG"
+  buildBinary "wakunode1", "waku/v1/node/", "-d:chronicles_log_level=TRACE"
 
 task sim1, "Build Waku v1 simulation tools":
   buildBinary "quicksim", "waku/v1/node/", "-d:chronicles_log_level=INFO"
@@ -58,7 +58,7 @@ task test1, "Build & run Waku v1 tests":
 
 ### Waku v2 tasks
 task wakunode2, "Build Waku v2 (experimental) cli node":
-  buildBinary "wakunode2", "waku/v2/node/", "-d:chronicles_log_level=DEBUG"
+  buildBinary "wakunode2", "waku/v2/node/", "-d:chronicles_log_level=TRACE"
 
 task sim2, "Build Waku v2 simulation tools":
   buildBinary "quicksim2", "waku/v2/node/", "-d:chronicles_log_level=DEBUG"


### PR DESCRIPTION
This reverts commit 139f1480 has it removes the ability to get any trace logs due to https://github.com/status-im/nim-waku/issues/473

As it introduced a feature regression, I would suggest to remove it until #473 is fixed.
