### PR TITLE
Handling initial paging requests over a message history of size one

### DIFF
--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -147,7 +147,27 @@ procSuite "pagination":
       newPagingInfo.cursor == pagingInfo.cursor
       newPagingInfo.direction == pagingInfo.direction
       newPagingInfo.pageSize == 0
- 
+
+    # test initial paging query over a message list with one message
+    var singleItemMsgList = msgList[0..0]
+    pagingInfo = PagingInfo(pageSize: 10, direction: PagingDirection.FORWARD)
+    (data, newPagingInfo) = paginateWithIndex(singleItemMsgList, pagingInfo)
+    check:
+      data.len == 1
+      newPagingInfo.cursor == msgList[0].index
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 1
+
+    # test pagination over a message list with one message
+    singleItemMsgList = msgList[0..0]
+    pagingInfo = PagingInfo(pageSize: 10, cursor: msgList[0].index, direction: PagingDirection.FORWARD)
+    (data, newPagingInfo) = paginateWithIndex(singleItemMsgList, pagingInfo)
+    check:
+      data.len == 0
+      newPagingInfo.cursor == msgList[0].index
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 0
+
   test "Backward pagination test":
     var
       msgList = createSampleList(10)
@@ -214,6 +234,26 @@ procSuite "pagination":
     check:
       data.len == 0
       newPagingInfo.cursor == pagingInfo.cursor
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 0
+    
+    # test initial paging query over a message list with one message
+    var singleItemMsgList = msgList[0..0]
+    pagingInfo = PagingInfo(pageSize: 10, direction: PagingDirection.BACKWARD)
+    (data, newPagingInfo) = paginateWithIndex(singleItemMsgList, pagingInfo)
+    check:
+      data.len == 1
+      newPagingInfo.cursor == msgList[0].index
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 1
+    
+    # test paging query over a message list with one message
+    singleItemMsgList = msgList[0..0]
+    pagingInfo = PagingInfo(pageSize: 10, cursor: msgList[0].index, direction: PagingDirection.BACKWARD)
+    (data, newPagingInfo) = paginateWithIndex(singleItemMsgList, pagingInfo)
+    check:
+      data.len == 0
+      newPagingInfo.cursor == msgList[0].index
       newPagingInfo.direction == pagingInfo.direction
       newPagingInfo.pageSize == 0
 

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -104,7 +104,7 @@ procSuite "pagination":
       newPagingInfo.pageSize == 2
     
     # test for an initial pagination request with an empty cursor to fetch the entire history
-    pagingInfo = PagingInfo(pageSize: uint64(msgList.len), direction: PagingDirection.FORWARD)
+    pagingInfo = PagingInfo(pageSize: 13, direction: PagingDirection.FORWARD)
     (data, newPagingInfo) = paginateWithIndex(msgList, pagingInfo)
     check:
       data.len == 10
@@ -211,7 +211,7 @@ procSuite "pagination":
       newPagingInfo.pageSize == 2
     
     # test for an initial pagination request with an empty cursor to fetch the entire history
-    pagingInfo = PagingInfo(pageSize: uint64(msgList.len), direction: PagingDirection.BACKWARD)
+    pagingInfo = PagingInfo(pageSize: 13, direction: PagingDirection.BACKWARD)
     (data, newPagingInfo) = paginateWithIndex(msgList, pagingInfo)
     check:
       data.len == 10

--- a/tests/v2/test_waku_pagination.nim
+++ b/tests/v2/test_waku_pagination.nim
@@ -102,6 +102,16 @@ procSuite "pagination":
       newPagingInfo.cursor == msgList[1].index
       newPagingInfo.direction == pagingInfo.direction
       newPagingInfo.pageSize == 2
+    
+    # test for an initial pagination request with an empty cursor to fetch the entire history
+    pagingInfo = PagingInfo(pageSize: uint64(msgList.len), direction: PagingDirection.FORWARD)
+    (data, newPagingInfo) = paginateWithIndex(msgList, pagingInfo)
+    check:
+      data.len == 10
+      data == msgList[0..9]
+      newPagingInfo.cursor == msgList[9].index
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 10
 
     # test for an empty msgList
     pagingInfo = PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD)
@@ -148,7 +158,7 @@ procSuite "pagination":
       newPagingInfo.direction == pagingInfo.direction
       newPagingInfo.pageSize == 0
 
-    # test initial paging query over a message list with one message
+    # test initial paging query over a message list with one message 
     var singleItemMsgList = msgList[0..0]
     pagingInfo = PagingInfo(pageSize: 10, direction: PagingDirection.FORWARD)
     (data, newPagingInfo) = paginateWithIndex(singleItemMsgList, pagingInfo)
@@ -199,6 +209,16 @@ procSuite "pagination":
       newPagingInfo.cursor == msgList[8].index
       newPagingInfo.direction == pagingInfo.direction
       newPagingInfo.pageSize == 2
+    
+    # test for an initial pagination request with an empty cursor to fetch the entire history
+    pagingInfo = PagingInfo(pageSize: uint64(msgList.len), direction: PagingDirection.BACKWARD)
+    (data, newPagingInfo) = paginateWithIndex(msgList, pagingInfo)
+    check:
+      data.len == 10
+      data == msgList[0..9]
+      newPagingInfo.cursor == msgList[0].index
+      newPagingInfo.direction == pagingInfo.direction
+      newPagingInfo.pageSize == 10
 
 
     # test for a page size larger than the remaining messages

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -254,7 +254,9 @@ proc paginateWithIndex*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[
   var newCursor: Index # to be returned as part of the new paging info
   case dir
     of PagingDirection.FORWARD: # forward pagination
-      let remainingMessages= uint64(msgList.len) - uint64(foundIndex) - 1
+      # the message that is pointed by the cursor is excluded for the retrieved list, this is because this message has already been retrieved by the querier in its prior request
+      var remainingMessages= uint64(msgList.len) - uint64(foundIndex) - 1 
+      if initQuery:  remainingMessages = remainingMessages + 1
       # the number of queried messages cannot exceed the MaxPageSize and the total remaining messages i.e., msgList.len-foundIndex
       retrievedPageSize = min(uint64(pageSize), MaxPageSize).min(remainingMessages)  
       if initQuery : foundIndex = foundIndex - 1
@@ -262,7 +264,8 @@ proc paginateWithIndex*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[
       e = foundIndex + retrievedPageSize 
       newCursor = msgList[e].index # the new cursor points to the end of the page
     of PagingDirection.BACKWARD: # backward pagination
-      let remainingMessages = foundIndex
+      var remainingMessages = foundIndex 
+      if initQuery:  remainingMessages = remainingMessages + 1
       # the number of queried messages cannot exceed the MaxPageSize and the total remaining messages i.e., foundIndex-0
       retrievedPageSize = min(uint64(pageSize), MaxPageSize).min(remainingMessages) 
       if initQuery : foundIndex = foundIndex + 1


### PR DESCRIPTION
Closes https://github.com/status-im/nim-waku/issues/471
## Problem

The pagination fails to handle initial paging requests when the store node holds only one message. See details in https://github.com/status-im/nim-waku/issues/471. 

In this PR, further test scenarios are developed to cover the identified corner cases.