### PR TITLE
Fix: `filter` protocol only works on default `topic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `relay`, `filter`, `store` and `swap` peers are now stored in a common, shared peer store and no longer in separate sets.
 - Admin API now provides a `post` method to connect to peers on an ad-hoc basis
 - Added persistent peer storage. A node will now attempt to reconnect to `relay` peers after a restart.
+- Changed `contentTopic` back to a string
+- Fixed: content filtering now works on any PubSub topic and not just the `waku` default.
 
 ## 2021-01-05 v0.2
 


### PR DESCRIPTION
This PR fixes #480 

It adds a default handler for all newly subscribed PubSub topics to ensure that the node's `subscriptions` and `filters` are notified of all new messages. This ensures that content filtering works for messages received on any subscribed topic, not just the `waku` default.

Content filters can still optionally specify a pubsub `topic`, which will narrow matches down to only messages published on that `topic`.