### PR TITLE
Update store protocol interface: add history content filter

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -304,7 +304,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
         echo &"{chatLine}"
       info "Hit store handler"
 
-    await node.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: DefaultContentTopic)]), storeHandler)
+    await node.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: DefaultContentTopic)]), storeHandler)
 
   if conf.filternode != "":
     node.mountFilter()

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -304,7 +304,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
         echo &"{chatLine}"
       info "Hit store handler"
 
-    await node.query(HistoryQuery(topics: @[DefaultContentTopic]), storeHandler)
+    await node.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: DefaultContentTopic)]), storeHandler)
 
   if conf.filternode != "":
     node.mountFilter()

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -34,7 +34,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(topics: @[topic])
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[topic])])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -78,7 +78,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       subscription = proto.subscription()
-      rpc = HistoryQuery(topics: @[topic])
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[topic])])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -152,7 +152,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(topics: @[defaultContentTopic], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -225,7 +225,7 @@ procSuite "Waku Store":
         response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(topics: @[defaultContentTopic], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
+    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
     await proto.query(rpc, handler)
 
     check:
@@ -274,7 +274,7 @@ procSuite "Waku Store":
         response.pagingInfo == PagingInfo()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(topics: @[defaultContentTopic] )
+    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])] )
 
     await proto.query(rpc, handler)
 
@@ -329,7 +329,7 @@ procSuite "Waku Store":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query=HistoryQuery(topics: @[defaultContentTopic], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
+      query=HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 
@@ -417,7 +417,7 @@ procSuite "Waku Store":
           response.messages.anyIt(it.timestamp == float(5))
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(2), endTime: float(5))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(2), endTime: float(5))
       await proto.query(rpc, handler)
 
       check:
@@ -433,7 +433,7 @@ procSuite "Waku Store":
           response.messages.len() == 0
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(2), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(2), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:
@@ -450,7 +450,7 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       # time window is invalid since start time > end time
-      let rpc = HistoryQuery(topics: @[ContentTopic("1")], startTime: float(5), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -34,7 +34,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic)])
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -78,7 +78,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic1), HistoryContentFilter(topic: topic3)])
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: topic1), HistoryContentFilter(contentTopic: topic3)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -124,7 +124,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic)])
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -198,7 +198,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -271,7 +271,7 @@ procSuite "Waku Store":
         response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
+    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
     await proto.query(rpc, handler)
 
     check:
@@ -320,7 +320,7 @@ procSuite "Waku Store":
         response.pagingInfo == PagingInfo()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)] )
+    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: defaultContentTopic)] )
 
     await proto.query(rpc, handler)
 
@@ -375,7 +375,7 @@ procSuite "Waku Store":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic), HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
+      query = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: defaultContentTopic), HistoryContentFilter(contentTopic: defaultContentTopic)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 
@@ -463,7 +463,7 @@ procSuite "Waku Store":
           response.messages.anyIt(it.timestamp == float(5))
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(5))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: ContentTopic("1"))], startTime: float(2), endTime: float(5))
       await proto.query(rpc, handler)
 
       check:
@@ -479,7 +479,7 @@ procSuite "Waku Store":
           response.messages.len() == 0
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: ContentTopic("1"))], startTime: float(2), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:
@@ -496,7 +496,7 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       # time window is invalid since start time > end time
-      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(5), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: ContentTopic("1"))], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -34,7 +34,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[topic])])
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -78,7 +78,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[topic])])
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -152,7 +152,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
+      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -225,7 +225,7 @@ procSuite "Waku Store":
         response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
+    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
     await proto.query(rpc, handler)
 
     check:
@@ -274,7 +274,7 @@ procSuite "Waku Store":
         response.pagingInfo == PagingInfo()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])] )
+    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)] )
 
     await proto.query(rpc, handler)
 
@@ -329,7 +329,7 @@ procSuite "Waku Store":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query=HistoryQuery(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
+      query = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic), ContentFilter(topic: defaultContentTopic)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 
@@ -417,7 +417,7 @@ procSuite "Waku Store":
           response.messages.anyIt(it.timestamp == float(5))
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(2), endTime: float(5))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(5))
       await proto.query(rpc, handler)
 
       check:
@@ -433,7 +433,7 @@ procSuite "Waku Store":
           response.messages.len() == 0
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(2), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:
@@ -450,7 +450,7 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       # time window is invalid since start time > end time
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topics: @[ContentTopic("1")])], startTime: float(5), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -34,7 +34,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: topic)])
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -52,6 +52,52 @@ procSuite "Waku Store":
       check:
         response.messages.len() == 1
         response.messages[0] == msg
+      completionFut.complete(true)
+
+    await proto.query(rpc, handler)
+
+    check:
+      (await completionFut.withTimeout(5.seconds)) == true
+  asyncTest "handle query with multiple content filters":
+    let
+      key = PrivateKey.random(ECDSA, rng[]).get()
+      peer = PeerInfo.init(key)
+      topic1 = defaultContentTopic
+      topic2 = ContentTopic("2")
+      topic3 = ContentTopic("3")
+      msg1 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic1)
+      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic2)
+      msg3 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic3)
+
+    var dialSwitch = newStandardSwitch()
+    discard await dialSwitch.start()
+
+    var listenSwitch = newStandardSwitch(some(key))
+    discard await listenSwitch.start()
+
+    let
+      proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
+      subscription = proto.subscription()
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic1), HistoryContentFilter(topic: topic3)])
+
+    proto.setPeer(listenSwitch.peerInfo)
+
+    var subscriptions = newTable[string, MessageNotificationSubscription]()
+    subscriptions["test"] = subscription
+
+    listenSwitch.mount(proto)
+
+    await subscriptions.notify("foo", msg1)
+    await subscriptions.notify("foo", msg2)
+    await subscriptions.notify("foo", msg3)
+
+    var completionFut = newFuture[bool]()
+
+    proc handler(response: HistoryResponse) {.gcsafe, closure.} =
+      check:
+        response.messages.len() == 2
+        response.messages.anyIt(it == msg1)
+        response.messages.anyIt(it == msg3)
       completionFut.complete(true)
 
     await proto.query(rpc, handler)
@@ -78,7 +124,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng(), store)
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: topic)])
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: topic)])
 
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -152,7 +198,7 @@ procSuite "Waku Store":
     let
       proto = WakuStore.init(PeerManager.new(dialSwitch), crypto.newRng())
       subscription = proto.subscription()
-      rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
+      rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.FORWARD) )
       
     proto.setPeer(listenSwitch.peerInfo)
 
@@ -225,7 +271,7 @@ procSuite "Waku Store":
         response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
+    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: PagingInfo(pageSize: 2, direction: PagingDirection.BACKWARD) )
     await proto.query(rpc, handler)
 
     check:
@@ -274,7 +320,7 @@ procSuite "Waku Store":
         response.pagingInfo == PagingInfo()
       completionFut.complete(true)
 
-    let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic)] )
+    let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic)] )
 
     await proto.query(rpc, handler)
 
@@ -329,7 +375,7 @@ procSuite "Waku Store":
     let
       index = computeIndex(WakuMessage(payload: @[byte 1], contentTopic: defaultContentTopic))
       pagingInfo = PagingInfo(pageSize: 1, cursor: index, direction: PagingDirection.BACKWARD)
-      query = HistoryQuery(contentFilters: @[ContentFilter(topic: defaultContentTopic), ContentFilter(topic: defaultContentTopic)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
+      query = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: defaultContentTopic), HistoryContentFilter(topic: defaultContentTopic)], pagingInfo: pagingInfo, startTime: float64(10), endTime: float64(11))
       pb = query.encode()
       decodedQuery = HistoryQuery.init(pb.buffer)
 
@@ -417,7 +463,7 @@ procSuite "Waku Store":
           response.messages.anyIt(it.timestamp == float(5))
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(5))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(5))
       await proto.query(rpc, handler)
 
       check:
@@ -433,7 +479,7 @@ procSuite "Waku Store":
           response.messages.len() == 0
         completionFut.complete(true)
 
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(2), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:
@@ -450,7 +496,7 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       # time window is invalid since start time > end time
-      let rpc = HistoryQuery(contentFilters: @[ContentFilter(topic: ContentTopic("1"))], startTime: float(5), endTime: float(2))
+      let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(topic: ContentTopic("1"))], startTime: float(5), endTime: float(2))
       await proto.query(rpc, handler)
 
       check:

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -81,7 +81,7 @@ procSuite "Waku SWAP Accounting":
         response.messages[0] == message
       completionFut.complete(true)
 
-    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), storeHandler)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: contentTopic)]), storeHandler)
 
     check:
       (await completionFut.withTimeout(5.seconds)) == true
@@ -127,8 +127,8 @@ procSuite "Waku SWAP Accounting":
       futures[1].complete(true)
 
     # TODO Handshakes - for now we assume implicit, e2e still works for PoC
-    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), handler1)
-    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), handler2)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: contentTopic)]), handler1)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: contentTopic)]), handler2)
 
     check:
       (await allFutures(futures).withTimeout(5.seconds)) == true

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -81,7 +81,7 @@ procSuite "Waku SWAP Accounting":
         response.messages[0] == message
       completionFut.complete(true)
 
-    await node1.query(HistoryQuery(topics: @[contentTopic]), storeHandler)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), storeHandler)
 
     check:
       (await completionFut.withTimeout(5.seconds)) == true
@@ -127,8 +127,8 @@ procSuite "Waku SWAP Accounting":
       futures[1].complete(true)
 
     # TODO Handshakes - for now we assume implicit, e2e still works for PoC
-    await node1.query(HistoryQuery(topics: @[contentTopic]), handler1)
-    await node1.query(HistoryQuery(topics: @[contentTopic]), handler2)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), handler1)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), handler2)
 
     check:
       (await allFutures(futures).withTimeout(5.seconds)) == true

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -239,7 +239,7 @@ procSuite "WakuNode":
       completionFut.complete(true)
 
     
-    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), storeHandler)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: contentTopic)]), storeHandler)
 
     
     check:

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -238,7 +238,7 @@ procSuite "WakuNode":
         response.messages[0] == message
       completionFut.complete(true)
 
-    # await node1.query(HistoryQuery(topics: @[contentTopic]), storeHandler)
+    
     await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), storeHandler)
 
     

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -162,7 +162,9 @@ procSuite "WakuNode":
         response.messages[0] == message
       completionFut.complete(true)
 
-    await node1.query(HistoryQuery(topics: @[contentTopic]), storeHandler)
+    # await node1.query(HistoryQuery(topics: @[contentTopic]), storeHandler)
+    await node1.query(HistoryQuery(contentFilters: @[HistoryContentFilter(topic: contentTopic)]), storeHandler)
+
     
     check:
       (await completionFut.withTimeout(5.seconds)) == true

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -17,7 +17,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Store API version 1 definitions
 
-  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
+  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(topics: seq[ContentTopic], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
@@ -27,6 +27,9 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       debug "get_waku_v2_store_v1_messages response"
       responseFut.complete(response.toStoreResponse())
     
+    var contentFilters: seq[HistoryContentFilter] = @[]
+    for topic in topics:
+      contentFilters.add(HistoryContentFilter(topic: topic))
     let historyQuery = HistoryQuery(contentFilters: contentFilters,
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -17,7 +17,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Store API version 1 definitions
 
-  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(topics: seq[ContentTopic], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
+  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
@@ -27,7 +27,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       debug "get_waku_v2_store_v1_messages response"
       responseFut.complete(response.toStoreResponse())
     
-    let historyQuery = HistoryQuery(topics: topics,
+    let historyQuery = HistoryQuery(contentFilters: contentFilters,
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     
     await node.query(historyQuery, queryFuncHandler)

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -17,7 +17,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Store API version 1 definitions
 
-  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(topics: seq[ContentTopic], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
+  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(contentTopics: seq[ContentTopic], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
@@ -28,8 +28,9 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       responseFut.complete(response.toStoreResponse())
     
     var contentFilters: seq[HistoryContentFilter] = @[]
-    for topic in topics:
-      contentFilters.add(HistoryContentFilter(contentTopic: topic))
+    # items in contentTopics map to the contentTopic field of waku message (not to be confused with pubsub topic)
+    for ct in contentTopics:
+      contentFilters.add(HistoryContentFilter(contentTopic: ct))
     let historyQuery = HistoryQuery(contentFilters: contentFilters,
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -29,7 +29,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     
     var contentFilters: seq[HistoryContentFilter] = @[]
     for topic in topics:
-      contentFilters.add(HistoryContentFilter(topic: topic))
+      contentFilters.add(HistoryContentFilter(contentTopic: topic))
     let historyQuery = HistoryQuery(contentFilters: contentFilters,
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -114,10 +114,11 @@ proc init*(T: type PagingInfo, buffer: seq[byte]): ProtoResult[T] =
 proc init*(T: type HistoryContentFilter, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
 
-  var topic: ContentTopic
-  discard ? pb.getField(1, topic)
+  # ContentTopic corresponds to the contentTopic field of waku message (not to be confused with pubsub topic)
+  var contentTopic: ContentTopic
+  discard ? pb.getField(1, contentTopic)
 
-  ok(HistoryContentFilter(contentTopic: topic))
+  ok(HistoryContentFilter(contentTopic: contentTopic))
 
 proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
   var msg = HistoryQuery()

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -117,7 +117,7 @@ proc init*(T: type HistoryContentFilter, buffer: seq[byte]): ProtoResult[T] =
   var topic: ContentTopic
   discard ? pb.getField(1, topic)
 
-  ok(HistoryContentFilter(topic: topic))
+  ok(HistoryContentFilter(contentTopic: topic))
 
 proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
   var msg = HistoryQuery()
@@ -181,7 +181,7 @@ proc init*(T: type HistoryRPC, buffer: seq[byte]): ProtoResult[T] =
 
 proc encode*(filter: HistoryContentFilter): ProtoBuffer =
   result = initProtoBuffer()
-  result.write(1, filter.topic)
+  result.write(1, filter.contentTopic)
 
 proc encode*(query: HistoryQuery): ProtoBuffer =
   result = initProtoBuffer()
@@ -313,7 +313,7 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   # data holds IndexedWakuMessage whose topics match the query
   var data : seq[IndexedWakuMessage] = @[]
   for filter in query.contentFilters:
-    var matched = w.messages.filterIt(it.msg.contentTopic  == filter.topic)  
+    var matched = w.messages.filterIt(it.msg.contentTopic  == filter.contentTopic)  
     # TODO remove duplicates from data 
     data.add(matched)
 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -114,10 +114,10 @@ proc init*(T: type PagingInfo, buffer: seq[byte]): ProtoResult[T] =
 proc init*(T: type ContentFilter, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
 
-  var topics: seq[ContentTopic]
-  discard ? pb.getRepeatedField(1, topics)
+  var topic: ContentTopic
+  discard ? pb.getField(1, topic)
 
-  ok(ContentFilter(topics: topics))
+  ok(ContentFilter(topic: topic))
 
 proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
   var msg = HistoryQuery()
@@ -181,9 +181,7 @@ proc init*(T: type HistoryRPC, buffer: seq[byte]): ProtoResult[T] =
 
 proc encode*(filter: ContentFilter): ProtoBuffer =
   result = initProtoBuffer()
-
-  for topic in filter.topics:
-    result.write(1, topic)
+  result.write(1, filter.topic)
 
 proc encode*(query: HistoryQuery): ProtoBuffer =
   result = initProtoBuffer()
@@ -315,8 +313,8 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
   # data holds IndexedWakuMessage whose topics match the query
   var data : seq[IndexedWakuMessage] = @[]
   for filter in query.contentFilters:
-    var matched = w.messages.filterIt(it.msg.contentTopic in filter.topics)  
-    # TODO check for duplicate messages 
+    var matched = w.messages.filterIt(it.msg.contentTopic  == filter.topic)  
+    # TODO remove duplicates from data 
     data.add(matched)
 
   # temporal filtering   

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -111,13 +111,13 @@ proc init*(T: type PagingInfo, buffer: seq[byte]): ProtoResult[T] =
 
   ok(pagingInfo) 
 
-proc init*(T: type ContentFilter, buffer: seq[byte]): ProtoResult[T] =
+proc init*(T: type HistoryContentFilter, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
 
   var topic: ContentTopic
   discard ? pb.getField(1, topic)
 
-  ok(ContentFilter(topic: topic))
+  ok(HistoryContentFilter(topic: topic))
 
 proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
   var msg = HistoryQuery()
@@ -131,7 +131,7 @@ proc init*(T: type HistoryQuery, buffer: seq[byte]): ProtoResult[T] =
   discard ? pb.getRepeatedField(2, buffs)
   
   for buf in buffs:
-    msg.contentFilters.add(? ContentFilter.init(buf))
+    msg.contentFilters.add(? HistoryContentFilter.init(buf))
 
 
   var pagingInfoBuffer: seq[byte]
@@ -179,7 +179,7 @@ proc init*(T: type HistoryRPC, buffer: seq[byte]): ProtoResult[T] =
 
   ok(rpc)
 
-proc encode*(filter: ContentFilter): ProtoBuffer =
+proc encode*(filter: HistoryContentFilter): ProtoBuffer =
   result = initProtoBuffer()
   result.write(1, filter.topic)
 

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -17,6 +17,8 @@ export pagination
 const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
 
 type
+  ContentFilter* = object
+    topics*: seq[ContentTopic]
 
   QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
 
@@ -37,7 +39,7 @@ type
     direction*: PagingDirection
 
   HistoryQuery* = object
-    topics*: seq[ContentTopic]
+    contentFilters*: seq[ContentFilter]
     pagingInfo*: PagingInfo # used for pagination
     startTime*: float64 # used for time-window query
     endTime*: float64 # used for time-window query

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -18,7 +18,7 @@ const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
 
 type
   ContentFilter* = object
-    topics*: seq[ContentTopic]
+    topic*: ContentTopic
 
   QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
 

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -17,7 +17,7 @@ export pagination
 const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
 
 type
-  ContentFilter* = object
+  HistoryContentFilter* = object
     topic*: ContentTopic
 
   QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
@@ -39,7 +39,7 @@ type
     direction*: PagingDirection
 
   HistoryQuery* = object
-    contentFilters*: seq[ContentFilter]
+    contentFilters*: seq[HistoryContentFilter]
     pagingInfo*: PagingInfo # used for pagination
     startTime*: float64 # used for time-window query
     endTime*: float64 # used for time-window query

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -18,7 +18,7 @@ const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
 
 type
   HistoryContentFilter* = object
-    topic*: ContentTopic
+    contentTopic*: ContentTopic
 
   QueryHandlerFunc* = proc(response: HistoryResponse) {.gcsafe, closure.}
 


### PR DESCRIPTION
This PR is an increment towards https://github.com/status-im/nim-waku/issues/485
It modifies the structure of the `HistoryRequest`  by replacing the `topics` field  with a sequence of `HistoryContentFilter`s.
Each `ContentFilter` encapsulates a single content topic (later on, more fields can be embedded inside a `HistoryContentFilter`). 

- The protobuf's encode and init procedures are modified accordingly.
- A unit test is developed to check the correct retrieval of historical messages for queries with more than one `HistoryContentFilter`.
- Other parts of codebase which relied on `HistoryQuery` are refined.
- This change also affected the store json rpc api. The internals of "get_waku_v2_store_v1_messages" is changed to convert the set of input `topics` to their `HistoryContentFilter` equivalence. However, the proc input is left untouched. The reason for not yet changing the proc signature is explained in this issue https://github.com/status-im/nim-waku/issues/489. 

## Future steps
The specs ~~shall~~ mirror the change in the `HistoryRequest` protobuf message as indicated in this PR https://github.com/vacp2p/rfc/pull/344.