### PR TITLE
Implement graceful shutdown for `wakunode2` and `chat2`

### DIFF
--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -69,6 +69,7 @@ This will bypass the random peer selection process and connect to the specified 
 | `/help` | displays available in-chat commands |
 | `/connect` | interactively connect to a new peer |
 | `/nick` | change nickname for current chat session |
+| `/exit` | exits the current chat session |
 
 ## `chat2` message protobuf format
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -30,6 +30,7 @@ const Help = """
   help: Prints this help
   connect: dials a remote peer
   nick: change nickname for current chat session
+  exit: exits chat session
 """
 
 const
@@ -203,14 +204,11 @@ proc writeAndPrint(c: Chat) {.async.} =
       c.nick = await readNick(c.transp)
       echo "You are now known as " & c.nick
 
-#    elif line.startsWith("/exit"):
-#      if p.connected and p.conn.closed.not:
-#        await p.conn.close()
-#        p.connected = false
-#
-#      await p.switch.stop()
-#      echo "quitting..."
-#      quit(0)
+    elif line.startsWith("/exit"):
+     await c.node.stop()
+
+     echo "quitting..."
+     quit(0)
     else:
       # XXX connected state problematic
       if c.started:
@@ -368,6 +366,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   node.subscribe(topic, handler)
 
   await chat.readWriteLoop()
+
   runForever()
   #await allFuturesThrowing(libp2pFuts)
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -208,7 +208,7 @@ proc writeAndPrint(c: Chat) {.async.} =
      await c.node.stop()
 
      echo "quitting..."
-     quit(0)
+     quit(QuitSuccess)
     else:
       # XXX connected state problematic
       if c.started:


### PR DESCRIPTION
This PR fixes #455 and partially addresses #487

It adds graceful shutdown procedures on Ctrl-C and SIGTERM for `wakunode2`.
`chat2` can now be shut down gracefully by issuing an `/exit` command.