### PR TITLE
Add backoff period before subscribing to persistent peers

### DIFF
--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -41,6 +41,11 @@ method initPubSub*(w: WakuRelay) =
   w.verifySignature = false
   w.sign = false
 
+  # Here we can fine-tune GossipSub params for our purposes
+  w.parameters = GossipSubParams.init()
+  # Setting pruneBackoff allows us to restart nodes and trigger a re-subscribe within reasonable time.
+  w.parameters.pruneBackoff = 30.seconds
+
   procCall GossipSub(w).initPubSub()
 
   w.init()


### PR DESCRIPTION
This PR addresses #487 

It does the following:
- ensures that peers do not add themselves to their own peer managers
- introduces a backoff period on _reconnection_ to graft persistent peers without violating GossipSub specifications as per below.

#### Why do we have to back off?

Since GossipSub specifies a backoff period for pruned peers before re-grafting, we have to respect this period when reconnecting to peers from persistent storage. Waiting for at least the backoff period before subscribing seems to be the simplest way to address this for now.

#### Future work/Alternatives:
 1. It should be possible to manually set the backoff period for mesh peers loaded from storage and inform remote peers that you're backing off using a `PRUNE` message. This implies a fairly serious intervention in the default behaviour, though, as it requires altering mesh parameters before a local mesh has been created.
 2. Peers that require immediate reconnection after loading from persistence could be considered direct/explicit peers as per [GossipSub specification](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#explicit-peering-agreements).