### PR TITLE
Add persistent backoff for peers

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -42,6 +42,11 @@ type
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."
       name: "staticnode" }: seq[string]
+    
+    peerpersist* {.
+      desc: "Enable peer persistence: true|false",
+      defaultValue: false
+      name: "peerpersist" }: bool
 
     storenode* {.
       desc: "Peer multiaddr to query for storage.",

--- a/waku/v2/node/peer_manager/waku_peer_store.nim
+++ b/waku/v2/node/peer_manager/waku_peer_store.nim
@@ -19,8 +19,11 @@ type
   
   ConnectionBook* = object of PeerBook[Connectedness]
 
+  DisconnectBook* = object of PeerBook[int64] # Keeps track of when peers were disconnected in Unix timestamps
+
   WakuPeerStore* = ref object of PeerStore
     connectionBook*: ConnectionBook
+    disconnectBook*: DisconnectBook
 
 proc new*(T: type WakuPeerStore): WakuPeerStore =
   var p: WakuPeerStore

--- a/waku/v2/node/storage/peer/peer_storage.nim
+++ b/waku/v2/node/storage/peer/peer_storage.nim
@@ -12,12 +12,13 @@ type
   PeerStorageResult*[T] = Result[T, string]
 
   DataProc* = proc(peerId: PeerID, storedInfo: StoredInfo,
-                   connectedness: Connectedness) {.closure.}
+                   connectedness: Connectedness, disconnectTime: int64) {.closure.}
 
 # PeerStorage interface
 method put*(db: PeerStorage,
             peerId: PeerID,
             storedInfo: StoredInfo,
-            connectedness: Connectedness): PeerStorageResult[void] {.base.} = discard
+            connectedness: Connectedness,
+            disconnectTime: int64): PeerStorageResult[void] {.base.} = discard
 
 method getAll*(db: PeerStorage, onData: DataProc): PeerStorageResult[bool] {.base.} = discard


### PR DESCRIPTION
This PR addresses #487. It is an alternative approach to persisting statically-defined peers than #495.

- It adds a persistent backoff period for peers after disconnection based on the `pruneBackoff` and `BackoffSlackTime` defined for [GossipSub 1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange).
- Peer persistence is now a separately configurable option. Since this is a specialised use case, it is disabled by default.