### PR TITLE
Fix filter notifications

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -318,7 +318,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
       info "Hit filter handler"
 
     await node.subscribe(
-      FilterRequest(contentFilters: @[ContentFilter(topics: @[DefaultContentTopic])], topic: DefaultTopic, subscribe: true),
+      FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[DefaultContentTopic])], pubSubTopic: DefaultTopic, subscribe: true),
       filterHandler
     )
 

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -291,8 +291,8 @@ procSuite "Waku v2 JSON-RPC API":
       # Light node has not yet subscribed to any filters
       node.filters.len() == 0
 
-    let contentFilters = @[ContentFilter(topics: @[defaultContentTopic, ContentTopic("2")]),
-                           ContentFilter(topics: @[ContentTopic("3"), ContentTopic("4")])]
+    let contentFilters = @[ContentFilter(contentTopics: @[defaultContentTopic, ContentTopic("2")]),
+                           ContentFilter(contentTopics: @[ContentTopic("3"), ContentTopic("4")])]
     var response = await client.post_waku_v2_filter_v1_subscription(contentFilters = contentFilters, topic = some(defaultTopic))
     
     check:
@@ -330,7 +330,7 @@ procSuite "Waku v2 JSON-RPC API":
 
     # First ensure subscription exists
 
-    let sub = await client.post_waku_v2_filter_v1_subscription(contentFilters = @[ContentFilter(topics: @[defaultContentTopic])], topic = some(defaultTopic))
+    let sub = await client.post_waku_v2_filter_v1_subscription(contentFilters = @[ContentFilter(contentTopics: @[defaultContentTopic])], topic = some(defaultTopic))
     check:
       sub
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -39,7 +39,7 @@ procSuite "Waku Filter":
 
     let
       proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
-      rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], pubSubTopic: defaultTopic, subscribe: true)
 
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo)
@@ -88,7 +88,7 @@ procSuite "Waku Filter":
 
     let
       proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
-      rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], pubSubTopic: defaultTopic, subscribe: true)
 
     dialSwitch.mount(proto)
     proto.setPeer(listenSwitch.peerInfo)
@@ -118,7 +118,7 @@ procSuite "Waku Filter":
     responseCompletionFuture = newFuture[bool]()
 
     let
-      rpcU = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: false)
+      rpcU = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], pubSubTopic: defaultTopic, subscribe: false)
 
     await proto.unsubscribe(rpcU)
 
@@ -145,7 +145,7 @@ procSuite "Waku Filter":
 
     let
       proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
-      rpc = FilterRequest(contentFilters: @[ContentFilter(topics: @[contentTopic])], topic: defaultTopic, subscribe: true)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], pubSubTopic: defaultTopic, subscribe: true)
 
     dialSwitch.mount(proto)
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -28,7 +28,7 @@ procSuite "WakuNode":
         Port(60000))
       pubSubTopic = "chat"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
-      filterRequest = FilterRequest(topic: pubSubTopic, contentFilters: @[ContentFilter(topics: @[contentTopic])], subscribe: true)
+      filterRequest = FilterRequest(pubSubTopic: pubSubTopic, contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], subscribe: true)
       message = WakuMessage(payload: "hello world".toBytes(),
         contentTopic: contentTopic)
 
@@ -80,7 +80,7 @@ procSuite "WakuNode":
         Port(60002))
       pubSubTopic = "chat"
       contentTopic = ContentTopic("/waku/2/default-content/proto")
-      filterRequest = FilterRequest(topic: pubSubTopic, contentFilters: @[ContentFilter(topics: @[contentTopic])], subscribe: true)
+      filterRequest = FilterRequest(pubSubTopic: pubSubTopic, contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], subscribe: true)
       message = WakuMessage(payload: "hello world".toBytes(),
         contentTopic: contentTopic)
 
@@ -147,8 +147,8 @@ procSuite "WakuNode":
       otherPayload = @[byte 9]
       defaultMessage = WakuMessage(payload: defaultPayload, contentTopic: defaultContentTopic)
       otherMessage = WakuMessage(payload: otherPayload, contentTopic: otherContentTopic)
-      defaultFR = FilterRequest(contentFilters: @[ContentFilter(topics: @[defaultContentTopic])], subscribe: true)
-      otherFR = FilterRequest(contentFilters: @[ContentFilter(topics: @[otherContentTopic])], subscribe: true)
+      defaultFR = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[defaultContentTopic])], subscribe: true)
+      otherFR = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[otherContentTopic])], subscribe: true)
 
     await node1.start()
     node1.mountRelay()
@@ -272,7 +272,7 @@ procSuite "WakuNode":
         msg == message
       completionFut.complete(true)
 
-    await node1.subscribe(FilterRequest(topic: "/waku/2/default-waku/proto", contentFilters: @[ContentFilter(topics: @[contentTopic])], subscribe: true), handler)
+    await node1.subscribe(FilterRequest(pubSubTopic: "/waku/2/default-waku/proto", contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], subscribe: true), handler)
 
     await sleepAsync(2000.millis)
 

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -58,12 +58,12 @@ proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer, messageCache: 
 
     # Construct a filter request
     # @TODO use default PubSub topic if undefined
-    let fReq = if topic.isSome: FilterRequest(topic: topic.get, contentFilters: contentFilters, subscribe: true) else: FilterRequest(contentFilters: contentFilters, subscribe: true)
+    let fReq = if topic.isSome: FilterRequest(pubSubTopic: topic.get, contentFilters: contentFilters, subscribe: true) else: FilterRequest(contentFilters: contentFilters, subscribe: true)
     
     if (await node.subscribe(fReq, filterHandler).withTimeout(futTimeout)):
       # Successfully subscribed to all content filters
       
-      for cTopic in concat(contentFilters.mapIt(it.topics)):
+      for cTopic in concat(contentFilters.mapIt(it.contentTopics)):
         # Create message cache for each subscribed content topic
         messageCache[cTopic] = @[]
       
@@ -78,12 +78,12 @@ proc installFilterApiHandlers*(node: WakuNode, rpcsrv: RpcServer, messageCache: 
 
     # Construct a filter request
     # @TODO consider using default PubSub topic if undefined
-    let fReq = if topic.isSome: FilterRequest(topic: topic.get, contentFilters: contentFilters, subscribe: false) else: FilterRequest(contentFilters: contentFilters, subscribe: false)
+    let fReq = if topic.isSome: FilterRequest(pubSubTopic: topic.get, contentFilters: contentFilters, subscribe: false) else: FilterRequest(contentFilters: contentFilters, subscribe: false)
 
     if (await node.unsubscribe(fReq).withTimeout(futTimeout)):
       # Successfully unsubscribed from all content filters
 
-      for cTopic in concat(contentFilters.mapIt(it.topics)):
+      for cTopic in concat(contentFilters.mapIt(it.contentTopics)):
         # Remove message cache for each unsubscribed content topic
         messageCache.del(cTopic)
 

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -10,7 +10,7 @@ export waku_message
 
 type
   ContentFilter* = object
-    topics*: seq[ContentTopic]
+    contentTopics*: seq[ContentTopic]
 
   ContentFilterHandler* = proc(msg: WakuMessage) {.gcsafe, closure.}
 
@@ -23,7 +23,7 @@ type
 
   FilterRequest* = object
     contentFilters*: seq[ContentFilter]
-    topic*: string
+    pubSubTopic*: string
     subscribe*: bool
 
   MessagePush* = object


### PR DESCRIPTION
This PR is a first increment towards fixing #498 and fixes #500

It does the following:
 - helps separate `FILTER` from `RELAY` by removing light node notification logic from default `RELAY` topic handlers. Light nodes are now only notified about new filter messages in the filter push message handler. Since `RELAY` is mounted on light nodes, this double `notify()` also caused duplicate messages on the light node (#500).
 - fixes full `FILTER` node logic that would previously only push messages to a light node if it had defined a `pubSubTopic` in the filter. `12/WAKU-FILTER`, however, specifies that a `FilterRequest` only optionally needs to specify a `pubsubTopic` - an empty `pubsubTopic` implies that matching should only be done on the `contentFilter`.
 - changes ambiguous `topic` variable names to `pubSubTopic` and `contentTopic` within `FILTER` context

### Further improvements:
- where fields are optional they should explicitly use `Option` from the `std/options` module. Currently we rely on empty initialisations to test whether optional fields are set or not. This approach is prone to errors.