### PR TITLE
Enables perssist-message flag in the store protocol for wakunode2

### DIFF
--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -47,7 +47,7 @@ The `chat2` application can retrieve historical chat messages from a node suppor
 Alternatively, the `chat2` application will select a random `storenode` for you from the test fleet if `storenode` left unspecified.
 
 ```
-./build/chat2 --store:true
+./build/chat2
 ```
 
 > *NOTE: Currently (Mar 3, 2021) the only node in the test fleet that provides reliable store functionality is `/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ`. We're working on fixing this.*

--- a/docs/tutorial/chat2.md
+++ b/docs/tutorial/chat2.md
@@ -44,7 +44,7 @@ The `chat2` application can retrieve historical chat messages from a node suppor
 ./build/chat2 --storenode:/ip4/134.209.139.210/tcp/30303/p2p/16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ
 ```
 
-Alternatively, the `chat2` application will select a random `storenode` for you from the test fleet if the `store` option is set to `true` and `storenode` left unspecified.
+Alternatively, the `chat2` application will select a random `storenode` for you from the test fleet if `storenode` left unspecified.
 
 ```
 ./build/chat2 --store:true

--- a/docs/tutorial/store.md
+++ b/docs/tutorial/store.md
@@ -20,8 +20,11 @@ Run two nodes and connect them:
 ./build/wakunode2 --ports-shift:1 --staticnode:/ip4/0.0.0.0/tcp/60000/p2p/16Uiu2HAmF4tuht6fmna6uDqoSMgFqhUrdaVR6VQRyGr6sCpfS2jp --storenode:/ip4/0.0.0.0/tcp/60000/p2p/16Uiu2HAmF4tuht6fmna6uDqoSMgFqhUrdaVR6VQRyGr6sCpfS2jp
 ```
 
-When passing the flag `dbpath` with a path, messages are persisted and stored in a database called `store` under the specified path. 
-When none is passed, messages are not persisted and are only stored in-memory.
+When flag `persist-messages` is passed messages are going to be persisted in-memory. 
+If additionally flag `dbpath` is passed with a path, messages are persisted and stored in a database called `store` under the specified path. 
+If flag `persist-messages` is not passed, messages are not persisted and stored at all.
+
+
 
 You should see your nodes connecting.
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -278,7 +278,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     node.mountSwap()
 
   if (conf.storenode != "") or (conf.store == true):
-    node.mountStore()
+    node.mountStore(persistMessages = conf.persistmessages)
 
     var storenode: string
 

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -225,7 +225,7 @@ procSuite "Waku v2 JSON-RPC API":
       key = wakunode2.PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.init(key)
     
-    node.mountStore()
+    node.mountStore(persistMessages = true)
     let
       subscription = node.wakuStore.subscription()
     
@@ -518,7 +518,7 @@ procSuite "Waku v2 JSON-RPC API":
 
     node.mountFilter()
     node.mountSwap()
-    node.mountStore()
+    node.mountStore(persistMessages = true)
 
     # Create and set some peers
     let

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -101,7 +101,7 @@ procSuite "Peer Manager":
 
     node.mountFilter()
     node.mountSwap()
-    node.mountStore()
+    node.mountStore(persistMessages = true)
 
     node.wakuFilter.setPeer(filterPeer)
     node.wakuSwap.setPeer(swapPeer)

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -62,10 +62,10 @@ procSuite "Waku SWAP Accounting":
     # Start nodes and mount protocols
     await node1.start()
     node1.mountSwap()
-    node1.mountStore()
+    node1.mountStore(persistMessages = true)
     await node2.start()
     node2.mountSwap()
-    node2.mountStore()
+    node2.mountStore(persistMessages = true)
 
     await node2.subscriptions.notify("/waku/2/default-waku/proto", message)
 
@@ -108,10 +108,10 @@ procSuite "Waku SWAP Accounting":
     # Start nodes and mount protocols
     await node1.start()
     node1.mountSwap()
-    node1.mountStore()
+    node1.mountStore(persistMessages = true)
     await node2.start()
     node2.mountSwap()
-    node2.mountStore()
+    node2.mountStore(persistMessages = true)
 
     await node2.subscriptions.notify("/waku/2/default-waku/proto", message)
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -225,9 +225,9 @@ procSuite "WakuNode":
     var completionFut = newFuture[bool]()
 
     await node1.start()
-    node1.mountStore()
+    node1.mountStore(persistMessages = true)
     await node2.start()
-    node2.mountStore()
+    node2.mountStore(persistMessages = true)
 
     await node2.subscriptions.notify("/waku/2/default-waku/proto", message)
 

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -114,12 +114,12 @@ type
 
     store* {.
       desc: "Flag whether to start store protocol",
-      defaultValue: false
+      defaultValue: true
       name: "store" }: bool
-
+      
     persistmessages* {.
       desc: "Enable message persistence: true|false",
-      defaultValue: true
+      defaultValue: false
       name: "persist-messages" }: bool
 
     filter* {.

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -119,9 +119,9 @@ type
 
     persistmessages* {.
       desc: "Enable message persistence: true|false",
-      defaultValue: false
+      defaultValue: true
       name: "persist-messages" }: bool
-      
+
     filter* {.
       desc: "Flag whether to start filter protocol",
       defaultValue: false

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -117,6 +117,11 @@ type
       defaultValue: false
       name: "store" }: bool
 
+    persistmessages* {.
+      desc: "Enable message persistence: true|false",
+      defaultValue: false
+      name: "persist-messages" }: bool
+      
     filter* {.
       desc: "Flag whether to start filter protocol",
       defaultValue: false

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -219,7 +219,7 @@ when isMainModule:
 
   # Mount configured Waku v2 protocols
   if conf.store:
-    mountStore(bridge.nodev2)
+    mountStore(bridge.nodev2, persistMessage = conf.persistmessages)
 
   if conf.filter:
     mountFilter(bridge.nodev2)

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -219,7 +219,7 @@ when isMainModule:
 
   # Mount configured Waku v2 protocols
   if conf.store:
-    mountStore(bridge.nodev2, persistMessage = conf.persistmessages)
+    mountStore(bridge.nodev2, persistMessages = conf.persistmessages)
 
   if conf.filter:
     mountFilter(bridge.nodev2)

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -60,7 +60,7 @@ type
 
     store* {.
       desc: "Enable store protocol: true|false",
-      defaultValue: false
+      defaultValue: true
       name: "store" }: bool
 
     filter* {.

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -55,7 +55,7 @@ type
 
     persistmessages* {.
       desc: "Enable message persistence: true|false",
-      defaultValue: false
+      defaultValue: true
       name: "persist-messages" }: bool
 
     store* {.

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -55,7 +55,7 @@ type
 
     persistmessages* {.
       desc: "Enable message persistence: true|false",
-      defaultValue: true
+      defaultValue: false
       name: "persist-messages" }: bool
 
     store* {.

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -53,6 +53,11 @@ type
       defaultValue: ""
       name: "storenode" }: string
 
+    persistmessages* {.
+      desc: "Enable message persistence: true|false",
+      defaultValue: false
+      name: "persist-messages" }: bool
+
     store* {.
       desc: "Enable store protocol: true|false",
       defaultValue: false

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -359,7 +359,7 @@ proc mountSwap*(node: WakuNode) =
   # NYI - Do we need this?
   #node.subscriptions.subscribe(WakuSwapCodec, node.wakuSwap.subscription())
 
-proc mountStore*(node: WakuNode, store: MessageStore = nil) =
+proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: bool = false) =
   info "mounting store"
 
   if node.wakuSwap.isNil:
@@ -370,7 +370,8 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil) =
     node.wakuStore = WakuStore.init(node.peerManager, node.rng, store, node.wakuSwap)
 
   node.switch.mount(node.wakuStore)
-  node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
+  if persistMessages:
+    node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
 proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
   # TODO return a bool value to indicate the success of the call
@@ -649,7 +650,7 @@ when isMainModule:
       else:
         store = res.value
 
-    mountStore(node, store)
+    mountStore(node, store, conf.persistmessages)
 
     if conf.storenode != "":
       setStorePeer(node, conf.storenode)

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -370,8 +370,8 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: boo
     node.wakuStore = WakuStore.init(node.peerManager, node.rng, store, node.wakuSwap)
 
   node.switch.mount(node.wakuStore)
-  # if persistMessages:
-  node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
+  if persistMessages:
+    node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
 proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
   # TODO return a bool value to indicate the success of the call

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -359,7 +359,7 @@ proc mountSwap*(node: WakuNode) =
   # NYI - Do we need this?
   #node.subscriptions.subscribe(WakuSwapCodec, node.wakuSwap.subscription())
 
-proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: bool = false) =
+proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: bool) =
   info "mounting store"
 
   if node.wakuSwap.isNil:
@@ -370,8 +370,8 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: boo
     node.wakuStore = WakuStore.init(node.peerManager, node.rng, store, node.wakuSwap)
 
   node.switch.mount(node.wakuStore)
-  if persistMessages:
-    node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
+  # if persistMessages:
+  node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
 proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
   # TODO return a bool value to indicate the success of the call

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -641,7 +641,7 @@ when isMainModule:
   if (conf.storenode != "") or (conf.store):
     var store: WakuMessageStore
 
-    if not sqliteDatabase.isNil:
+    if (not sqliteDatabase.isNil) and conf.persistmessages:
       let res = WakuMessageStore.init(sqliteDatabase)
       if res.isErr:
         warn "failed to init WakuMessageStore", err = res.error


### PR DESCRIPTION
Addresses https://github.com/status-im/nim-waku/issues/494
It introduces `persist-messages` flag to activate the store protocol  in the light mode. It defaults to `false`.
This flag impacts wakunode2 and disables persisting messages in a database. 

However, as far as I know, in chat2  there is no option to persist messages. Please correct me if I am mistaken @jm-clius @oskarth .
In chat2, the store protocol is mounted in https://github.com/status-im/nim-waku/blob/7e9dac67c8927c953687ee6391c63286377bb9c9/examples/v2/chat2.nim#L280
which invokes this proc whose `store` field is Nil by default
https://github.com/status-im/nim-waku/blob/7e9dac67c8927c953687ee6391c63286377bb9c9/waku/v2/node/wakunode2.nim#L362