### PR TITLE
Add optional keepAlive for relay peers

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -72,6 +72,11 @@ type
       desc: "Enable spam protection through rln-relay: true|false",
       defaultValue: false
       name: "rlnrelay" }: bool
+    
+    keepAlive* {.
+      desc: "Enable keep-alive for idle connections: true|false",
+      defaultValue: false
+      name: "keep-alive" }: bool
 
     swap* {.
       desc: "Enable swap protocol: true|false",

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -454,7 +454,7 @@ proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string) =
   let pb  = PubSub(node.wakuRelay)
   pb.addValidator(pubsubTopic, validator)
 
-proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string](), rlnRelayEnabled = false) {.gcsafe.} =
+proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string](), rlnRelayEnabled = false, keepAlive = false) {.gcsafe.} =
   let wakuRelay = WakuRelay.init(
     switch = node.switch,
     # Use default
@@ -463,6 +463,8 @@ proc mountRelay*(node: WakuNode, topics: seq[string] = newSeq[string](), rlnRela
     sign = false,
     verifySignature = false
   )
+
+  wakuRelay.keepAlive = keepAlive
 
   node.wakuRelay = wakuRelay
   node.switch.mount(wakuRelay)
@@ -691,7 +693,7 @@ when isMainModule:
 
   # Relay setup
   if conf.relay:  # True by default
-    mountRelay(node, conf.topics.split(" "), rlnRelayEnabled = conf.rlnrelay)
+    mountRelay(node, conf.topics.split(" "), rlnRelayEnabled = conf.rlnrelay, keepAlive = conf.keepAlive)
 
     if conf.staticnodes.len > 0:
       waitFor connectToNodes(node, conf.staticnodes)


### PR DESCRIPTION
This PR provides a workaround fix for #504 and addresses #487.

It adds an optional 5 min `keepAlive` for `WakuRelay` mesh peers. This is to work around the known `libp2p` behaviour where a `chronosstream` will time out after 10 minutes of inactivity.

The `keepAlive` itself sends a `GRAFT` message every 5 minutes to the mesh peers for an idle topic. Since the local node is in the remote peer's mesh already, the remote simply ignores the `GRAFT` but resets the activity timer thus keeping the connection alive. A longer-term solution would use a more appropriate keep-alive mechanism, e.g. [libp2p ping-protocol](https://docs.libp2p.io/concepts/protocols/#ping).

Since this functionality is only necessary where peers must maintain a stable connection while idle for long periods of time (e.g. the `test` cluster) it's disabled by default.

A possible future improvement is to only trigger the `keepAlive` for topics that are actually idle, i.e. tracking activity.