### PR TITLE
Apply keep-alive for chat2

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -249,9 +249,9 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   await node.start()
 
   if conf.filternode != "":
-    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = conf.rlnrelay)
+    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = conf.rlnrelay, keepAlive = conf.keepAlive)
   else:
-    node.mountRelay(@[], rlnRelayEnabled = conf.rlnrelay)
+    node.mountRelay(@[], rlnRelayEnabled = conf.rlnrelay, keepAlive = conf.keepAlive)
   
   let nick = await readNick(transp)
   echo "Welcome, " & nick & "!"


### PR DESCRIPTION
Simple change to apply `keep-alive` config to `chat2` applications. This way `chat2` clients can be configured to remain connected if idle for a long time.