### PR TITLE
Makes the arguments of the store jsonrpc api optional

### DIFF
--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -259,7 +259,7 @@ procSuite "Waku v2 JSON-RPC API":
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort)
 
-    let response = await client.get_waku_v2_store_v1_messages(defaultTopic, @[HistoryContentFilter(contentTopic: defaultContentTopic)], some(StorePagingOptions()))
+    let response = await client.get_waku_v2_store_v1_messages(some(defaultTopic), @[HistoryContentFilter(contentTopic: defaultContentTopic)], some(StorePagingOptions()))
     check:
       response.messages.len() == 8
       response.pagingOptions.isNone

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -259,7 +259,7 @@ procSuite "Waku v2 JSON-RPC API":
     let client = newRpcHttpClient()
     await client.connect("127.0.0.1", rpcPort)
 
-    let response = await client.get_waku_v2_store_v1_messages(some(defaultTopic), @[HistoryContentFilter(contentTopic: defaultContentTopic)], some(StorePagingOptions()))
+    let response = await client.get_waku_v2_store_v1_messages(some(defaultTopic), some(@[HistoryContentFilter(contentTopic: defaultContentTopic)]), some(StorePagingOptions()))
     check:
       response.messages.len() == 8
       response.pagingOptions.isNone

--- a/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
@@ -16,7 +16,7 @@ proc delete_waku_v2_relay_v1_subscriptions(topics: seq[string]): bool
 
 # Store API
 
-proc get_waku_v2_store_v1_messages(pubsubTopic: Option[string], contentFilters: Option[seq[HistoryContentFilter]], pagingOptions: Option[StorePagingOptions]): StoreResponse
+proc get_waku_v2_store_v1_messages(pubsubTopicOption: Option[string], contentFiltersOption: Option[seq[HistoryContentFilter]], pagingOptions: Option[StorePagingOptions]): StoreResponse
 
 # Filter API
 

--- a/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
@@ -16,7 +16,7 @@ proc delete_waku_v2_relay_v1_subscriptions(topics: seq[string]): bool
 
 # Store API
 
-proc get_waku_v2_store_v1_messages(pubsubTopic: string, contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]): StoreResponse
+proc get_waku_v2_store_v1_messages(pubsubTopic: Option[string], contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]): StoreResponse
 
 # Filter API
 

--- a/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
+++ b/waku/v2/node/jsonrpc/jsonrpc_callsigs.nim
@@ -16,7 +16,7 @@ proc delete_waku_v2_relay_v1_subscriptions(topics: seq[string]): bool
 
 # Store API
 
-proc get_waku_v2_store_v1_messages(pubsubTopic: Option[string], contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]): StoreResponse
+proc get_waku_v2_store_v1_messages(pubsubTopic: Option[string], contentFilters: Option[seq[HistoryContentFilter]], pagingOptions: Option[StorePagingOptions]): StoreResponse
 
 # Filter API
 

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -17,7 +17,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Store API version 1 definitions
 
-  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(pubsubTopicOption: Option[string], contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
+  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(pubsubTopicOption: Option[string], contentFiltersOption: Option[seq[HistoryContentFilter]], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
@@ -28,7 +28,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       responseFut.complete(response.toStoreResponse())
     
     let historyQuery = HistoryQuery(pubsubTopic: if pubsubTopicOption.isSome: pubsubTopicOption.get() else: "",
-                                    contentFilters: contentFilters,
+                                    contentFilters: if contentFiltersOption.isSome: contentFiltersOption.get() else: @[],
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     
     await node.query(historyQuery, queryFuncHandler)

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -17,7 +17,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Store API version 1 definitions
 
-  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(pubsubTopic: string, contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
+  rpcsrv.rpc("get_waku_v2_store_v1_messages") do(pubsubTopicOption: Option[string], contentFilters: seq[HistoryContentFilter], pagingOptions: Option[StorePagingOptions]) -> StoreResponse:
     ## Returns history for a list of content topics with optional paging
     debug "get_waku_v2_store_v1_messages"
 
@@ -27,7 +27,7 @@ proc installStoreApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
       debug "get_waku_v2_store_v1_messages response"
       responseFut.complete(response.toStoreResponse())
     
-    let historyQuery = HistoryQuery(pubsubTopic: pubsubTopic,
+    let historyQuery = HistoryQuery(pubsubTopic: if pubsubTopicOption.isSome: pubsubTopicOption.get() else: "",
                                     contentFilters: contentFilters,
                                     pagingInfo: if pagingOptions.isSome: pagingOptions.get.toPagingInfo() else: PagingInfo())
     

--- a/waku/v2/node/scripts/rpc_query.nim
+++ b/waku/v2/node/scripts/rpc_query.nim
@@ -37,5 +37,5 @@ echo "Content topic is:", input
 var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
 
-var res = waitfor node.get_waku_v2_store_v1_messages(pubsubTopic, @[HistoryContentFilter(contentTopic: ContentTopic(input))], none(StorePagingOptions))
+var res = waitfor node.get_waku_v2_store_v1_messages(some(pubsubTopic), @[HistoryContentFilter(contentTopic: ContentTopic(input))], none(StorePagingOptions))
 echo "Waku query response: ", res

--- a/waku/v2/node/scripts/rpc_query.nim
+++ b/waku/v2/node/scripts/rpc_query.nim
@@ -37,5 +37,5 @@ echo "Content topic is:", input
 var node = newRpcHttpClient()
 waitfor node.connect("localhost", rpcPort)
 
-var res = waitfor node.get_waku_v2_store_v1_messages(some(pubsubTopic), @[HistoryContentFilter(contentTopic: ContentTopic(input))], none(StorePagingOptions))
+var res = waitfor node.get_waku_v2_store_v1_messages(some(pubsubTopic), some(@[HistoryContentFilter(contentTopic: ContentTopic(input))]), none(StorePagingOptions))
 echo "Waku query response: ", res


### PR DESCRIPTION
Closes https://github.com/status-im/nim-waku/issues/505
No unit test is developed on the nim side due to the issue discussed in https://github.com/status-im/nim-waku/issues/505#issuecomment-828796350
However, the json rpc api is tested through `curl` and the result is as expected i.e., omitting optional arguments results in a valid response with no error. 

The corresponding specs PR: https://github.com/vacp2p/rfc/pull/361