### PR TITLE
Fix: light-mode relay for all light protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fixed: content filtering now works on any PubSub topic and not just the `waku` default.
 - Added the `pubsubTopic` field to the `HistoryQuery`. Now, the message history can be filtered and queried based on the `pubsubTopic`.
 - Added a new table of `Message` to the message store db. The new table has an additional column of `pubsubTopic` and will be used instead of the old table `messages`.  The message history in the old table `messages` will not be accessed and have to be removed.
+- Fix: allow mounting light protocols without `relay`
+- Add `keep-alive` option to maintain stable connection to `relay` peers on idle topics
 
 ## 2021-01-05 v0.2
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -211,7 +211,7 @@ procSuite "WakuNode":
     await node1.stop()
     await node2.stop()
   
-  asyncTest "Filter protocol works between light node and full node":
+  asyncTest "Filter protocol works on node without relay capability":
     let
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
@@ -228,7 +228,7 @@ procSuite "WakuNode":
     node1.mountFilter()
 
     await node2.start()
-    node2.mountLightRelay() # Do not start WakuRelay or subscribe to any topics
+    node2.mountRelay(relayMessages=false) # Do not start WakuRelay or subscribe to any topics
     node2.mountFilter()
     node2.wakuFilter.setPeer(node1.peerInfo)
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -210,6 +210,54 @@ procSuite "WakuNode":
 
     await node1.stop()
     await node2.stop()
+  
+  asyncTest "Filter protocol works between light node and full node":
+    let
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+      defaultTopic = "/waku/2/default-waku/proto"
+      contentTopic = "defaultCT"
+      payload = @[byte 1]
+      message = WakuMessage(payload: payload, contentTopic: contentTopic)
+      filterRequest = FilterRequest(contentFilters: @[ContentFilter(contentTopics: @[contentTopic])], subscribe: true)
+
+    await node1.start()
+    node1.mountRelay()
+    node1.mountFilter()
+
+    await node2.start()
+    node2.mountLightRelay() # Do not start WakuRelay or subscribe to any topics
+    node2.mountFilter()
+    node2.wakuFilter.setPeer(node1.peerInfo)
+
+    check:
+      node1.wakuRelay.isNil == false # Node1 is a full node
+      node2.wakuRelay.isNil == true # Node 2 is a light node
+
+    var completeFut = newFuture[bool]()
+
+    proc filterHandler(msg: WakuMessage) {.gcsafe, closure.} =
+      check:
+        msg.payload == payload
+        msg.contentTopic == contentTopic
+      completeFut.complete(true)
+
+    # Subscribe a contentFilter to trigger a specific application handler when
+    # WakuMessages with that content are received
+    await node2.subscribe(filterRequest, filterHandler)
+
+    await sleepAsync(2000.millis)
+
+    # Let's check that content filtering works on the default topic
+    await node1.publish(defaultTopic, message)
+
+    check:
+      (await completeFut.withTimeout(5.seconds)) == true
+
+    await node1.stop()
+    await node2.stop()
 
   asyncTest "Store protocol returns expected message":
     let


### PR DESCRIPTION
This PR closes #498. It follows the same approach as https://github.com/status-im/nim-waku/pull/518, but fixes the issue in a more general way to apply to any `light` protocol.

(Also sneaked in an unrelated CHANGELOG.md entry, which I forgot about earlier 😄.)

## Background recap

Currently `nim-libp2p` requires the same `PubSub` protocol used in full nodes (in our case, `RELAY`) to be mounted on light nodes for protocol negotiation to succeed. Detailed explanation [here](https://github.com/status-im/nim-waku/issues/498#issuecomment-828543874).
However, once a light node with `RELAY` mounted has connected to a full node (say, to `subscribe` a content filter or to perform a `lightpush`), it will be considered a "normal" PubSub peer in the full node, undergo grafting and pruning and generally behave like a full node.
This fix allows a light node to behave like a "true" light node by mounting a "light" mode of `RELAY` allowing light protocol negotation but no full-message peerings. `RELAY` is only mounted on the switch and never started. `node.wakuRelay` remains `nil` and the light node does not subscribe to any PubSub topics.