### PR TITLE
General chat2bridge improvements

### DIFF
--- a/examples/v2/matterbridge/config_chat2bridge.nim
+++ b/examples/v2/matterbridge/config_chat2bridge.nim
@@ -105,11 +105,16 @@ type
       defaultValue: ""
       name: "filternode" }: string
     
-    # Matterbridge options
-    mbHostUri* {.
-      desc: "Matterbridge host API address"
-      defaultValue: "http://127.0.0.1:4242"
-      name: "mb-host-uri" }: string
+    # Matterbridge options    
+    mbHostAddress* {.
+      desc: "Listening address of the Matterbridge host",
+      defaultValue: ValidIpAddress.init("127.0.0.1")
+      name: "mb-host-address" }: ValidIpAddress
+
+    mbHostPort* {.
+      desc: "Listening port of the Matterbridge host",
+      defaultValue: 4242
+      name: "mb-host-port" }: uint16
     
     mbGateway* {.
       desc: "Matterbridge gateway"


### PR DESCRIPTION
This is a further increment towards #404 

It adds the following `chat2` bridge to matterbridge improvements:
1. Better logging and error handling
2. Duplicate message filtering
3. Easier configuration
4. Tutorial on how to configure and use `chat2bridge`
