### PR TITLE
Add feature for running targeted tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,16 @@ chat2bridge: | build deps
 # Builds and run the test suite (Waku v1 + v2)
 test: | test1 test2
 
+runtest: | build deps
+ifndef test
+	echo -e "test case was not set. Run make runtest version=<version_number> test=<target_test>"
+else ifndef v
+	echo -e "version number was not set. Run make runtest version=<version_number> test=<target_test>"
+else
+	echo -e $(BUILD_MSG) "build/$@" && \
+	$(ENV_SCRIPT) nim testScript $(NIM_PARAMS) waku.nims $(test) $(v)
+endif
+
 # symlink
 waku.nims:
 	ln -s waku.nimble $@


### PR DESCRIPTION
closes #535

Added a generic command to the makefile for running targeted tests. 
Tests can be run using `make runtest test=test_file_name v=2`