### PR TITLE
Fault tolerant store protocol: resume message history

### DIFF
--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -663,18 +663,18 @@ procSuite "Waku Store":
       check:
         (await completionFut.withTimeout(5.seconds)) == true
 
-    asyncTest "fin last seen ":
+    test "find last seen ":
       var
-        msgList = @[WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2")),
-          WakuMessage(payload: @[byte 1],contentTopic: ContentTopic("1"), timestamp: float(1)),
-          WakuMessage(payload: @[byte 2],contentTopic: ContentTopic("2"), timestamp: float(2)),
-          WakuMessage(payload: @[byte 3],contentTopic: ContentTopic("1"), timestamp: float(3)),
-          WakuMessage(payload: @[byte 4],contentTopic: ContentTopic("2"), timestamp: float(4)),
-          WakuMessage(payload: @[byte 5],contentTopic: ContentTopic("1"), timestamp: float(5)),
-          WakuMessage(payload: @[byte 6],contentTopic: ContentTopic("2"), timestamp: float(6)),
-          WakuMessage(payload: @[byte 7],contentTopic: ContentTopic("1"), timestamp: float(7)),
-          WakuMessage(payload: @[byte 8],contentTopic: ContentTopic("2"), timestamp: float(8)),
-          WakuMessage(payload: @[byte 9],contentTopic: ContentTopic("1"),timestamp: float(9))]      var completionFut = newFuture[bool]()
+        msgList = @[IndexedWakuMessage(msg: WakuMessage(payload: @[byte 0], contentTopic: ContentTopic("2"))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 1],contentTopic: ContentTopic("1"), timestamp: float(1))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 2],contentTopic: ContentTopic("2"), timestamp: float(2))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 3],contentTopic: ContentTopic("1"), timestamp: float(3))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 4],contentTopic: ContentTopic("2"), timestamp: float(4))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 5],contentTopic: ContentTopic("1"), timestamp: float(9))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 6],contentTopic: ContentTopic("2"), timestamp: float(6))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 7],contentTopic: ContentTopic("1"), timestamp: float(7))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 8],contentTopic: ContentTopic("2"), timestamp: float(8))),
+          IndexedWakuMessage(msg: WakuMessage(payload: @[byte 9],contentTopic: ContentTopic("1"),timestamp: float(5)))]     
 
       check:
-        findLastSeen(msgList) = float(9)
+        findLastSeen(msgList) == float(9)

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -686,7 +686,7 @@ when isMainModule:
     if conf.storenode != "":
       setStorePeer(node, conf.storenode)
     
-    # TODO resume the history using node.wakuStore.resume()
+    # TODO resume the history using node.wakuStore.resume() only if conf.persistmessages is set to true
 
 
   # Relay setup

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -685,6 +685,9 @@ when isMainModule:
 
     if conf.storenode != "":
       setStorePeer(node, conf.storenode)
+    
+    # TODO resume the history using node.wakuStore.resume()
+
 
   # Relay setup
   mountRelay(node,

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -308,6 +308,7 @@ proc paginateWithoutIndex(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (se
   result[1] = updatedPagingInfo
 
 proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
+  echo "queried node", w.messages.len
   result = HistoryResponse(messages: newSeq[WakuMessage]())
   var data : seq[IndexedWakuMessage] = w.messages
 
@@ -449,6 +450,7 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
   await connOpt.get().writeLP(HistoryRPC(requestId: generateRequestId(w.rng),
       query: query).encode().buffer)
 
+  echo "everything is alright"
   var message = await connOpt.get().readLp(64*1024)
   let response = HistoryRPC.init(message)
 
@@ -458,7 +460,7 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
     return
 
   waku_store_messages.set(response.value.response.messages.len.int64, labelValues = ["retrieved"])
-
+  echo "fetched response ", response.value.response.messages.len
   handler(response.value.response)
 
   
@@ -467,14 +469,20 @@ proc findLastSeen*(list: seq[IndexedWakuMessage]): float =
   for iwmsg in list.items : 
     lastSeenTime = if iwmsg.msg.timestamp>lastSeenTime: iwmsg.msg.timestamp else: lastSeenTime 
   return lastSeenTime
- 
-proc resume*(ws: WakuStore) {.async, gcsafe.} =
+
+proc resume*(ws: WakuStore){.async, gcsafe.} =
   debug "resume"
   # TODO fetch the message history of the DefaultTopic since the last seen message in the db
-  let currentTime = epochTime()
+  var currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)
 
-  proc handler(response: HistoryResponse) {.gcsafe.}=
+  # adjust the time window with an offset of 20 seconds
+  let offset: float64 = 200000
+  currentTime = currentTime + offset
+  lastSeenTime = max(lastSeenTime - offset, 0)
+
+  proc handler(response: HistoryResponse) {.gcsafe.} =
+    echo "here", response.messages.len
     for msg in response.messages:
       let index = msg.computeIndex()
       ws.messages.add(IndexedWakuMessage(msg: msg, index: index, pubsubTopic: DefaultTopic))
@@ -485,7 +493,8 @@ proc resume*(ws: WakuStore) {.async, gcsafe.} =
         warn "failed to store messages", err = res.error
         waku_store_errors.inc(labelValues = ["store_failure"])
 
-  let rpc = HistoryQuery(pubsubTopic: DefaultTopic, startTime: lastSeenTime, endTime: lastSeenTime)
+  echo "queried time: ", currentTime, " to ", lastSeenTime
+  let rpc = HistoryQuery(pubsubTopic: DefaultTopic, startTime: lastSeenTime, endTime: currentTime)
   # we rely on the peer selection of the underlying peer manager
   # this a one time attempt, though it should ideally try all the peers in the peer manager to fetch the history
   await ws.query(rpc, handler)

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -477,9 +477,9 @@ proc resume*(ws: WakuStore) {.async, gcsafe.} =
   ## the history gets fetched successfully if the dialed peer has been online during the queried time window
   ## TODO we need to develop a peer discovery method to obtain list of nodes that have been online for a specific time window
   ## TODO such list then can be passed to the resume proc to query from
-  debug "resume", currentEpochTime=currentTime
   var currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)
+  debug "resume", currentEpochTime=currentTime
 
   # adjust the time window with an offset of 20 seconds
   let offset: float64 = 200000

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -388,7 +388,7 @@ method init*(ws: WakuStore) =
   waku_store_messages.set(ws.messages.len.int64, labelValues = ["stored"])
 
   
-proc findLastSeen(list: seq[WakuMessage]): float = 
+proc findLastSeen*(list: seq[WakuMessage]): float = 
   var lastSeenTime = float(0)
   for msg in list.items : 
     lastSeenTime = if msg.timestamp > lastSeenTime: msg.timestamp 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -467,7 +467,7 @@ proc findLastSeen*(list: seq[IndexedWakuMessage]): float =
       lastSeenTime = iwmsg.msg.timestamp 
   return lastSeenTime
 
-proc resume*(ws: WakuStore){.async, gcsafe.} =
+proc resume*(ws: WakuStore) {.async, gcsafe.} =
   ## resume proc retrieves the history of waku messages published on the default waku pubsub topic since the last time the waku store node has been online 
   ## messages are stored in the store node's messages field and in the message db
   ## the offline time window is measured as the difference between the current time and the timestamp of the most recent persisted waku message 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -387,12 +387,6 @@ method init*(ws: WakuStore) =
   
   waku_store_messages.set(ws.messages.len.int64, labelValues = ["stored"])
 
-  
-proc findLastSeen*(list: seq[IndexedWakuMessage]): float = 
-  var lastSeenTime = float64(0)
-  for iwmsg in list.items : 
-    lastSeenTime = if iwmsg.msg.timestamp>lastSeenTime: iwmsg.msg.timestamp else: lastSeenTime 
-  return lastSeenTime
 
 proc init*(T: type WakuStore, peerManager: PeerManager, rng: ref BrHmacDrbgContext,
                    store: MessageStore = nil, wakuSwap: WakuSwap = nil): T =
@@ -466,8 +460,16 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
   waku_store_messages.set(response.value.response.messages.len.int64, labelValues = ["retrieved"])
 
   handler(response.value.response)
+
   
+proc findLastSeen*(list: seq[IndexedWakuMessage]): float = 
+  var lastSeenTime = float64(0)
+  for iwmsg in list.items : 
+    lastSeenTime = if iwmsg.msg.timestamp>lastSeenTime: iwmsg.msg.timestamp else: lastSeenTime 
+  return lastSeenTime
+ 
 proc resume*(ws: WakuStore) {.async, gcsafe.} =
+  debug "resume"
   # TODO fetch the message history of the DefaultTopic since the last seen message in the db
   let currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -480,8 +480,8 @@ proc resume*(ws: WakuStore){.async, gcsafe.} =
   ## the history will be fetched successfully assuming that the store node 
   ## TODO we need to develop a peer discovery method to obtain list of nodes that have been online for a specific time window
   ## TODO such list then can be passed to the resume proc 
-  debug "resume"
   var currentTime = epochTime()
+  debug "resume", currentEpochTime=currentTime
   var lastSeenTime: float = findLastSeen(ws.messages)
 
   # adjust the time window with an offset of 20 seconds

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -387,6 +387,34 @@ method init*(ws: WakuStore) =
   
   waku_store_messages.set(ws.messages.len.int64, labelValues = ["stored"])
 
+  
+proc findLastSeen(list: seq[WakuMessage]): float = 
+  var lastSeenTime = float(0)
+  for msg in list.items : 
+    lastSeenTime = if msg.timestamp > lastSeenTime: msg.timestamp 
+  return lastSeenTime
+    
+  
+proc resume*(ws: WakuStore) =
+  # TODO fetch the message history of the DefaultTopic since the last seen message in the db
+  let currentTime = epochTime()
+  var lastSeenTime: float = findLastSeen(ws.messages)
+
+  proc handler(response: HistoryResponse) {.gcsafe, closure.}=
+    let index = msg.computeIndex()
+    for msg in response.messages:
+      ws.messages.add(IndexedWakuMessage(msg: msg, index: index, pubsubTopic: DefaultTopic))
+      waku_store_messages.inc(labelValues = ["stored"])
+      if ws.store.isNil: continue
+      let res = ws.store.put(index, msg, topic)
+      if res.isErr:
+        warn "failed to store messages", err = res.error
+        waku_store_errors.inc(labelValues = ["store_failure"])
+
+    let rpc = HistoryQuery(pubsubTopic: DefaultTopic, startTime: lastSeenTime, endTime: lastSeenMessageTime)
+    await query(rpc, handler)
+
+
 proc init*(T: type WakuStore, peerManager: PeerManager, rng: ref BrHmacDrbgContext,
                    store: MessageStore = nil, wakuSwap: WakuSwap = nil): T =
   debug "init"

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -469,19 +469,16 @@ proc findLastSeen*(list: seq[IndexedWakuMessage]): float =
 
 proc resume*(ws: WakuStore){.async, gcsafe.} =
   ## resume proc retrieves the history of waku messages published on the default waku pubsub topic since the last time the waku store node has been online 
-  ## The node's last online time is considered to be the sender generated timestamp of the most recent persisted waku message 
-  ## the offline time window is the difference between the current time and the timestamp of the last seen message
-  ## the time window is additionally offsseted by 20 sec to count for nodes asynchrony
-  ## all the messages within that window is fetched and persisted in the store node's messages field and in message store db
-  ## a history query for the offline time window is made and sent over to one of the persisted store enabled peer 
-  ## the peer selection for the query is implicit and is handled as part of the query procedure through peer manager
-  ## the assumption is that the queried node has been online for that time window and hence the history will be fetched successfully
-  ## no query failure is supported for now
-  ## the history will be fetched successfully assuming that the store node 
+  ## messages are stored in the store node's messages field and in the message db
+  ## the offline time window is measured as the difference between the current time and the timestamp of the most recent persisted waku message 
+  ## an offset of 20 second is added to the time window to count for nodes asynchrony
+  ## the history is fetched from one of the peers persisted in the waku store node's peer manager unit  
+  ## the peer selection for the query is implicit and is handled as part of the waku store query procedure
+  ## the history gets fetched successfully if the dialed peer has been online during the queried time window
   ## TODO we need to develop a peer discovery method to obtain list of nodes that have been online for a specific time window
-  ## TODO such list then can be passed to the resume proc 
-  var currentTime = epochTime()
+  ## TODO such list then can be passed to the resume proc to query from
   debug "resume", currentEpochTime=currentTime
+  var currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)
 
   # adjust the time window with an offset of 20 seconds

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -486,6 +486,8 @@ proc resume*(ws: WakuStore) {.async, gcsafe.} =
         waku_store_errors.inc(labelValues = ["store_failure"])
 
   let rpc = HistoryQuery(pubsubTopic: DefaultTopic, startTime: lastSeenTime, endTime: lastSeenTime)
+  # we rely on the peer selection of the underlying peer manager
+  # this a one time attempt, though it should ideally try all the peers in the peer manager to fetch the history
   await ws.query(rpc, handler)
 
 # NOTE: Experimental, maybe incorporate as part of query call

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -15,6 +15,8 @@ export pagination
 
 # Constants required for pagination -------------------------------------------
 const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
+const DefaultTopic* = "/waku/2/default-waku/proto"
+
 
 type
   HistoryContentFilter* = object


### PR DESCRIPTION
This is to close https://github.com/status-im/nim-waku/issues/512


- In this basic implementation,  when a restart occurs, the wakunode2 which has the store protocol mounted attempts to fetch the history of message since his last on-time. 
- The last on-time is considered to be the timestamp of the most recent message in the nodes message db.
- A historical time query for that time period is made and the fetched messages get stored in the db as well as in the memory. 
- An offset of 20 second is added to the time window due to the assumption that nodes may be out of sync by at most 20 seconds.

The applied changes are not yet integrated in wakunode2 and  just a placeholder to run the `resume` proc is included in the code (waiting for hackathon to finish to make the changes effective). 


## Further improvements
- Currently, we rely on the peer manager component to pick one of the already existing store enabled connections to query from. A better solution would be to identify peers which were online for that targeted time period and pass a list of such candidates  to the resume procedure to query from. Will be working on it in the next PR.
- Another aspect is to mention is that an offline node can only query for the messages that are published on the waku default pubsub topic, more specific, can only query for a known pubsub topic. Ideally one should be all the pubsub topics (or should not?) i.e., regardless of pubsub topic. However, this is not doable in the current design as the messages embedded in a history response have no field to indicate their pubsub topic  therefore the querying node has no way to associate the retrieved messaged with their pubsub topic. 
