### PR TITLE
Fix nim-waku config inconsistencies

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -257,9 +257,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
 
   var chat = Chat(node: node, transp: transp, subscribed: true, connected: false, started: true, nick: nick, prompt: false)
 
-  if conf.staticnodes_depr.len > 0: # @TODO remove deprecated config item
-    await connectToNodes(chat, conf.staticnodes_depr)
-  elif conf.staticnodes.len > 0:
+  if conf.staticnodes.len > 0:
     await connectToNodes(chat, conf.staticnodes)
   else:
     # Connect to at least one random fleet node

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -242,7 +242,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     (extIp, extTcpPort, extUdpPort) = setupNat(conf.nat, clientId,
       Port(uint16(conf.tcpPort) + conf.portsShift),
       Port(uint16(conf.udpPort) + conf.portsShift))
-    node = WakuNode.init(conf.nodekey_depr, conf.listenAddress, # @TODO remove deprecated config item
+    node = WakuNode.init(conf.nodekey, conf.listenAddress,
       Port(uint16(conf.tcpPort) + conf.portsShift), extIp, extTcpPort)
 
   await node.start()

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -233,7 +233,7 @@ when isMainModule:
     bridge = Chat2Matterbridge.new(
                             mbHostUri = "http://" & $initTAddress(conf.mbHostAddress, Port(conf.mbHostPort)),
                             mbGateway = conf.mbGateway,
-                            nodev2Key = conf.nodekey_depr, # @TODO remove deprecated config item
+                            nodev2Key = conf.nodekey,
                             nodev2BindIp = conf.listenAddress, nodev2BindPort = Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
                             nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = nodev2ExtPort)
   

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -233,7 +233,7 @@ when isMainModule:
     bridge = Chat2Matterbridge.new(
                             mbHostUri = "http://" & $initTAddress(conf.mbHostAddress, Port(conf.mbHostPort)),
                             mbGateway = conf.mbGateway,
-                            nodev2Key = conf.nodekey,
+                            nodev2Key = conf.nodekey_depr, # @TODO remove deprecated config item
                             nodev2BindIp = conf.listenAddress, nodev2BindPort = Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
                             nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = nodev2ExtPort)
   
@@ -247,7 +247,9 @@ when isMainModule:
   if conf.filter:
     mountFilter(bridge.nodev2)
 
-  if conf.staticnodes.len > 0:
+  if conf.staticnodes_depr.len > 0: # @TODO remove deprecated config item
+    waitFor connectToNodes(bridge.nodev2, conf.staticnodes_depr)
+  elif conf.staticnodes.len > 0:
     waitFor connectToNodes(bridge.nodev2, conf.staticnodes)
 
   if conf.storenode != "":

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -247,9 +247,7 @@ when isMainModule:
   if conf.filter:
     mountFilter(bridge.nodev2)
 
-  if conf.staticnodes_depr.len > 0: # @TODO remove deprecated config item
-    waitFor connectToNodes(bridge.nodev2, conf.staticnodes_depr)
-  elif conf.staticnodes.len > 0:
+  if conf.staticnodes.len > 0:
     waitFor connectToNodes(bridge.nodev2, conf.staticnodes)
 
   if conf.storenode != "":

--- a/examples/v2/matterbridge/config_chat2bridge.nim
+++ b/examples/v2/matterbridge/config_chat2bridge.nim
@@ -66,14 +66,25 @@ type
       name: "metrics-server-port" .}: uint16
 
     ### Waku v2 options
-    staticnodes* {.
+    # @TODO: deprecate this item. Name changed from `staticnode` -> `staticnodes`
+    staticnodes_depr* {.
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
       name: "staticnode" }: seq[string]
+    
+    staticnodes* {.
+      desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
+      name: "staticnodes" }: seq[string]
 
-    nodekey* {.
+    # @TODO: deprecate this item. Name changed from `nodekey` -> `node-key`
+    nodekey_depr* {.
       desc: "P2P node private key as hex"
       defaultValue: crypto.PrivateKey.random(Secp256k1, newRng()[]).tryGet()
       name: "nodekey" }: crypto.PrivateKey
+    
+    nodeKey* {.
+      desc: "P2P node private key as hex"
+      defaultValue: crypto.PrivateKey.random(Secp256k1, newRng()[]).tryGet()
+      name: "node-key" }: crypto.PrivateKey
 
     topics* {.
       desc: "Default topics to subscribe to (space separated list)"

--- a/examples/v2/matterbridge/config_chat2bridge.nim
+++ b/examples/v2/matterbridge/config_chat2bridge.nim
@@ -66,14 +66,10 @@ type
       name: "metrics-server-port" .}: uint16
 
     ### Waku v2 options
-    # @TODO: deprecate this item. Name changed from `staticnode` -> `staticnodes`
-    staticnodes_depr* {.
-      desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
-      name: "staticnode" }: seq[string]
     
     staticnodes* {.
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
-      name: "staticnodes" }: seq[string]
+      name: "staticnode" }: seq[string]
 
     # @TODO: deprecate this item. Name changed from `nodekey` -> `node-key`
     nodekey_depr* {.

--- a/examples/v2/matterbridge/config_chat2bridge.nim
+++ b/examples/v2/matterbridge/config_chat2bridge.nim
@@ -71,16 +71,10 @@ type
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
       name: "staticnode" }: seq[string]
 
-    # @TODO: deprecate this item. Name changed from `nodekey` -> `node-key`
-    nodekey_depr* {.
+    nodekey* {.
       desc: "P2P node private key as hex"
       defaultValue: crypto.PrivateKey.random(Secp256k1, newRng()[]).tryGet()
       name: "nodekey" }: crypto.PrivateKey
-    
-    nodeKey* {.
-      desc: "P2P node private key as hex"
-      defaultValue: crypto.PrivateKey.random(Secp256k1, newRng()[]).tryGet()
-      name: "node-key" }: crypto.PrivateKey
 
     topics* {.
       desc: "Default topics to subscribe to (space separated list)"

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -77,20 +77,38 @@ type
       name: "metrics-server-port" .}: uint16
 
     ### Waku v1 options
-    fleetv1* {.
+    # @TODO: deprecate this item. Name changed from `fleetv1` -> `fleet-v1`
+    fleetv1_depr* {.
       desc: "Select the Waku v1 fleet to connect to"
       defaultValue: FleetV1.none
       name: "fleetv1" .}: FleetV1
+    
+    fleetV1* {.
+      desc: "Select the Waku v1 fleet to connect to"
+      defaultValue: FleetV1.none
+      name: "fleet-v1" .}: FleetV1
 
-    staticnodesv1* {.
+    # @TODO: deprecate this item. Name changed from `staticnodev1` -> `staticnodes-v1`
+    staticnodesv1_depr* {.
       desc: "Enode URL to directly connect with. Argument may be repeated"
       name: "staticnodev1" .}: seq[string]
+    
+    staticnodesV1* {.
+      desc: "Enode URL to directly connect with. Argument may be repeated"
+      name: "staticnodes-v1" .}: seq[string]
 
-    nodekeyv1* {.
+    # @TODO: deprecate this item. Name changed from `nodekeyv1` -> `node-key-v1`
+    nodekeyv1_depr* {.
       desc: "DevP2P node private key as hex",
       # TODO: can the rng be passed in somehow via Load?
       defaultValue: keys.KeyPair.random(keys.newRng()[])
       name: "nodekeyv1" .}: keys.KeyPair
+    
+    nodeKeyV1* {.
+      desc: "DevP2P node private key as hex",
+      # TODO: can the rng be passed in somehow via Load?
+      defaultValue: keys.KeyPair.random(keys.newRng()[])
+      name: "node-key-v1" .}: keys.KeyPair
 
     wakuPow* {.
       desc: "PoW requirement of Waku node.",
@@ -98,14 +116,25 @@ type
       name: "waku-pow" .}: float64
 
     ### Waku v2 options
-    staticnodesv2* {.
+    # @TODO: deprecate this item. Name changed from `staticnodev2` -> `staticnodes-v2`
+    staticnodesv2_depr* {.
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
       name: "staticnodev2" }: seq[string]
+    
+    staticnodesV2* {.
+      desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
+      name: "staticnodes-v2" }: seq[string]
 
-    nodekeyv2* {.
+    # @TODO: deprecate this item. Name changed from `nodekeyv2` -> `node-key-v2`
+    nodekeyv2_depr* {.
       desc: "P2P node private key as hex"
       defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
       name: "nodekeyv2" }: crypto.PrivateKey
+    
+    nodeKeyV2* {.
+      desc: "P2P node private key as hex"
+      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
+      name: "node-key-v2" }: crypto.PrivateKey
 
     topics* {.
       desc: "Default topics to subscribe to (space separated list)"
@@ -116,11 +145,6 @@ type
       desc: "Flag whether to start store protocol",
       defaultValue: true
       name: "store" }: bool
-      
-    persistmessages* {.
-      desc: "Enable message persistence: true|false",
-      defaultValue: false
-      name: "persist-messages" }: bool
 
     filter* {.
       desc: "Flag whether to start filter protocol",

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -104,11 +104,11 @@ type
       defaultValue: keys.KeyPair.random(keys.newRng()[])
       name: "nodekeyv1" .}: keys.KeyPair
     
-    nodeKeyV1* {.
+    nodekeyV1* {.
       desc: "DevP2P node private key as hex",
       # TODO: can the rng be passed in somehow via Load?
       defaultValue: keys.KeyPair.random(keys.newRng()[])
-      name: "node-key-v1" .}: keys.KeyPair
+      name: "nodekey-v1" .}: keys.KeyPair
 
     wakuPow* {.
       desc: "PoW requirement of Waku node.",
@@ -131,10 +131,10 @@ type
       defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
       name: "nodekeyv2" }: crypto.PrivateKey
     
-    nodeKeyV2* {.
+    nodekeyV2* {.
       desc: "P2P node private key as hex"
       defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
-      name: "node-key-v2" }: crypto.PrivateKey
+      name: "nodekey-v2" }: crypto.PrivateKey
 
     topics* {.
       desc: "Default topics to subscribe to (space separated list)"

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -95,7 +95,7 @@ type
     
     staticnodesV1* {.
       desc: "Enode URL to directly connect with. Argument may be repeated"
-      name: "staticnodes-v1" .}: seq[string]
+      name: "staticnode-v1" .}: seq[string]
 
     # @TODO: deprecate this item. Name changed from `nodekeyv1` -> `node-key-v1`
     nodekeyv1_depr* {.
@@ -123,7 +123,7 @@ type
     
     staticnodesV2* {.
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
-      name: "staticnodes-v2" }: seq[string]
+      name: "staticnode-v2" }: seq[string]
 
     # @TODO: deprecate this item. Name changed from `nodekeyv2` -> `node-key-v2`
     nodekeyv2_depr* {.

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -200,11 +200,11 @@ when isMainModule:
                                                Port(uint16(conf.udpPort) + conf.portsShift))
 
   let
-    bridge = WakuBridge.new(nodev1Key = conf.nodekeyv1,
+    bridge = WakuBridge.new(nodev1Key = conf.nodekeyv1_depr,  # @TODO remove deprecated config item
                             nodev1Address = nodev1Address,
                             powRequirement = conf.wakuPow,
                             rng = rng,
-                            nodev2Key = conf.nodeKeyv2,
+                            nodev2Key = conf.nodekeyv2_depr, # @TODO remove deprecated config item
                             nodev2BindIp = conf.listenAddress, nodev2BindPort = Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
                             nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = nodev2ExtPort)
   
@@ -212,20 +212,28 @@ when isMainModule:
 
   # Now load rest of config
   # Optionally direct connect nodev1 with a set of nodes
-  if conf.staticnodesv1.len > 0: connectToNodes(bridge.nodev1, conf.staticnodesv1)
-  elif conf.fleetv1 == prod: connectToNodes(bridge.nodev1, WhisperNodes)
-  elif conf.fleetv1 == staging: connectToNodes(bridge.nodev1, WhisperNodesStaging)
-  elif conf.fleetv1 == test: connectToNodes(bridge.nodev1, WhisperNodesTest)
+  # @TODO remove deprecated config items
+  if conf.staticnodesv1_depr.len > 0: connectToNodes(bridge.nodev1, conf.staticnodesv1_depr)
+  elif conf.fleetv1_depr == prod: connectToNodes(bridge.nodev1, WhisperNodes)
+  elif conf.fleetv1_depr == staging: connectToNodes(bridge.nodev1, WhisperNodesStaging)
+  elif conf.fleetv1_depr == test: connectToNodes(bridge.nodev1, WhisperNodesTest)
+
+  if conf.staticnodesV1.len > 0: connectToNodes(bridge.nodev1, conf.staticnodesV1)
+  elif conf.fleetV1 == prod: connectToNodes(bridge.nodev1, WhisperNodes)
+  elif conf.fleetV1 == staging: connectToNodes(bridge.nodev1, WhisperNodesStaging)
+  elif conf.fleetV1 == test: connectToNodes(bridge.nodev1, WhisperNodesTest)
 
   # Mount configured Waku v2 protocols
   if conf.store:
-    mountStore(bridge.nodev2, persistMessages = conf.persistmessages)
+    mountStore(bridge.nodev2, persistMessages = false)  # Bridge does not persist messages
 
   if conf.filter:
     mountFilter(bridge.nodev2)
 
-  if conf.staticnodesv2.len > 0:
-    waitFor connectToNodes(bridge.nodev2, conf.staticnodesv2)
+  if conf.staticnodesv2_depr.len > 0: # @TODO remove deprecated config item
+    waitFor connectToNodes(bridge.nodev2, conf.staticnodesv2_depr)
+  elif conf.staticnodesV2.len > 0:
+    waitFor connectToNodes(bridge.nodev2, conf.staticnodesV2)
 
   if conf.storenode != "":
     setStorePeer(bridge.nodev2, conf.storenode)

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -99,14 +99,9 @@ type
       defaultValue: false
       name: "rln-relay" }: bool
     
-    # @TODO: deprecate this item. Name changed from `staticnode` -> `staticnodes`
-    staticnodes_depr* {. 
-      desc: "Peer multiaddr to directly connect with. Argument may be repeated."
-      name: "staticnode" }: seq[string]
-    
     staticnodes* {.
       desc: "Peer multiaddr to directly connect with. Argument may be repeated."
-      name: "staticnodes" }: seq[string]
+      name: "staticnode" }: seq[string]
     
     keepAlive* {.
       desc: "Enable keep-alive for idle connections: true|false",

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -9,10 +9,23 @@ import
 
 type
   WakuNodeConf* = object
+    ## General node config
+
     logLevel* {.
       desc: "Sets the log level."
       defaultValue: LogLevel.INFO
       name: "log-level" }: LogLevel
+    
+    # @TODO: deprecate this item. Name changed from `nodekey` -> `node-key`
+    nodekey_depr* {.
+      desc: "P2P node private key as 64 char hex string.",
+      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
+      name: "nodekey" }: crypto.PrivateKey
+    
+    nodeKey* {.
+      desc: "P2P node private key as 64 char hex string.",
+      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
+      name: "node-key" }: crypto.PrivateKey
 
     listenAddress* {.
       defaultValue: defaultListenAddress(config)
@@ -38,81 +51,112 @@ type
       desc: "Specify method to use for determining public address. " &
             "Must be one of: any, none, upnp, pmp, extip:<IP>."
       defaultValue: "any" }: string
-
-    staticnodes* {.
-      desc: "Peer multiaddr to directly connect with. Argument may be repeated."
-      name: "staticnode" }: seq[string]
     
-    peerpersist* {.
+    ## Persistence config
+
+    # @TODO: deprecate this item. Name changed from `dbpath` -> `db-path`
+    dbpath_depr* {.
+      desc: "The database path for peristent storage",
+      defaultValue: ""
+      name: "dbpath" }: string
+    
+    dbPath* {.
+      desc: "The database path for peristent storage",
+      defaultValue: ""
+      name: "db-path" }: string
+    
+    # @TODO: deprecate this item. Name changed from `peerpersist` -> `persist-peers`
+    peerpersist_depr* {.
       desc: "Enable peer persistence: true|false",
       defaultValue: false
       name: "peerpersist" }: bool
-
-    storenode* {.
-      desc: "Peer multiaddr to query for storage.",
-      defaultValue: ""
-      name: "storenode" }: string
-
-    persistmessages* {.
+    
+    persistPeers* {.
+      desc: "Enable peer persistence: true|false",
+      defaultValue: false
+      name: "persist-peers" }: bool
+    
+    persistMessages* {.
       desc: "Enable message persistence: true|false",
       defaultValue: false
       name: "persist-messages" }: bool
 
-    store* {.
-      desc: "Enable store protocol: true|false",
-      defaultValue: true
-      name: "store" }: bool
-
-    filter* {.
-      desc: "Enable filter protocol: true|false",
-      defaultValue: false
-      name: "filter" }: bool
+    ## Relay config
     
     relay* {.
       desc: "Enable relay protocol: true|false",
       defaultValue: true
       name: "relay" }: bool
     
-    rlnrelay* {.
+    # @TODO: deprecate this item. Name changed from `rlnrelay` -> `rln-relay`
+    rlnrelay_depr* {.
       desc: "Enable spam protection through rln-relay: true|false",
       defaultValue: false
       name: "rlnrelay" }: bool
+    
+    rlnRelay* {.
+      desc: "Enable spam protection through rln-relay: true|false",
+      defaultValue: false
+      name: "rln-relay" }: bool
+    
+    # @TODO: deprecate this item. Name changed from `staticnode` -> `staticnodes`
+    staticnodes_depr* {. 
+      desc: "Peer multiaddr to directly connect with. Argument may be repeated."
+      name: "staticnode" }: seq[string]
+    
+    staticnodes* {.
+      desc: "Peer multiaddr to directly connect with. Argument may be repeated."
+      name: "staticnodes" }: seq[string]
     
     keepAlive* {.
       desc: "Enable keep-alive for idle connections: true|false",
       defaultValue: false
       name: "keep-alive" }: bool
 
-    swap* {.
-      desc: "Enable swap protocol: true|false",
-      defaultValue: false
-      name: "swap" }: bool
-
-    lightpush* {.
-      desc: "Enable lightpush protocol: true|false",
-      defaultValue: false
-      name: "lightpush" }: bool
-
-    filternode* {.
-      desc: "Peer multiaddr to request content filtering of messages.",
-      defaultValue: ""
-      name: "filternode" }: string
-    
-    dbpath* {.
-      desc: "The database path for the store protocol.",
-      defaultValue: ""
-      name: "dbpath" }: string
-
     topics* {.
       desc: "Default topics to subscribe to (space separated list)."
       defaultValue: "/waku/2/default-waku/proto"
       name: "topics" .}: string
 
-    # NOTE: Signature is different here, we return PrivateKey and not KeyPair
-    nodekey* {.
-      desc: "P2P node private key as 64 char hex string.",
-      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
-      name: "nodekey" }: crypto.PrivateKey
+    ## Store config
+
+    store* {.
+      desc: "Enable store protocol: true|false",
+      defaultValue: true
+      name: "store" }: bool
+
+    storenode* {.
+      desc: "Peer multiaddr to query for storage.",
+      defaultValue: ""
+      name: "storenode" }: string
+    
+    ## Filter config
+
+    filter* {.
+      desc: "Enable filter protocol: true|false",
+      defaultValue: false
+      name: "filter" }: bool
+    
+    filternode* {.
+      desc: "Peer multiaddr to request content filtering of messages.",
+      defaultValue: ""
+      name: "filternode" }: string
+    
+    ## Swap config
+
+    swap* {.
+      desc: "Enable swap protocol: true|false",
+      defaultValue: false
+      name: "swap" }: bool
+    
+    ## Lightpush config
+
+    lightpush* {.
+      desc: "Enable lightpush protocol: true|false",
+      defaultValue: false
+      name: "lightpush" }: bool
+    
+    ## JSON-RPC config
 
     rpc* {.
       desc: "Enable Waku JSON-RPC server: true|false",
@@ -138,6 +182,8 @@ type
       desc: "Enable access to JSON-RPC Private API: true|false",
       defaultValue: false
       name: "rpc-private" }: bool
+    
+    ## Metrics config
 
     metricsServer* {.
       desc: "Enable the metrics server: true|false"
@@ -154,10 +200,16 @@ type
       defaultValue: 8008
       name: "metrics-server-port" }: uint16
 
-    logMetrics* {.
+    # @TODO: deprecate this item. Name changed from `log-metrics` -> `metrics-logging`
+    logMetrics_depr* {.
       desc: "Enable metrics logging: true|false"
       defaultValue: false
       name: "log-metrics" }: bool
+
+    metricsLogging* {.
+      desc: "Enable metrics logging: true|false"
+      defaultValue: false
+      name: "metrics-logging" }: bool
 
 # NOTE: Keys are different in nim-libp2p
 proc parseCmdArg*(T: type crypto.PrivateKey, p: TaintedString): T =

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -16,16 +16,10 @@ type
       defaultValue: LogLevel.INFO
       name: "log-level" }: LogLevel
     
-    # @TODO: deprecate this item. Name changed from `nodekey` -> `node-key`
-    nodekey_depr* {.
+    nodekey* {.
       desc: "P2P node private key as 64 char hex string.",
       defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
       name: "nodekey" }: crypto.PrivateKey
-    
-    nodeKey* {.
-      desc: "P2P node private key as 64 char hex string.",
-      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
-      name: "node-key" }: crypto.PrivateKey
 
     listenAddress* {.
       defaultValue: defaultListenAddress(config)

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -664,7 +664,7 @@ when isMainModule:
     ## config, the external port is the same as the bind port.
     extPort = if extIp.isSome() and extTcpPort.isNone(): some(Port(uint16(conf.tcpPort) + conf.portsShift))
               else: extTcpPort
-    node = WakuNode.init(conf.nodekey_depr, # @TODO remove deprecated config item
+    node = WakuNode.init(conf.nodekey,
                          conf.listenAddress, Port(uint16(conf.tcpPort) + conf.portsShift), 
                          extIp, extPort,
                          pStorage)

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -630,8 +630,15 @@ when isMainModule:
   # Storage setup
   var sqliteDatabase: SqliteDatabase
 
-  if conf.dbpath != "":
+  if conf.dbpath_depr != "":  # @TODO remove deprecated config item
     let dbRes = SqliteDatabase.init(conf.dbpath)
+    if dbRes.isErr:
+      warn "failed to init database", err = dbRes.error
+      waku_node_errors.inc(labelValues = ["init_db_failure"])
+    else:
+      sqliteDatabase = dbRes.value
+  elif conf.dbPath != "":
+    let dbRes = SqliteDatabase.init(conf.dbPath)
     if dbRes.isErr:
       warn "failed to init database", err = dbRes.error
       waku_node_errors.inc(labelValues = ["init_db_failure"])
@@ -640,7 +647,7 @@ when isMainModule:
   
   var pStorage: WakuPeerStorage
 
-  if conf.peerpersist and not sqliteDatabase.isNil:
+  if (conf.peerpersist_depr or conf.persistPeers) and not sqliteDatabase.isNil: # @TODO remove deprecated config item
     let res = WakuPeerStorage.new(sqliteDatabase)
     if res.isErr:
       warn "failed to init new WakuPeerStorage", err = res.error
@@ -657,7 +664,7 @@ when isMainModule:
     ## config, the external port is the same as the bind port.
     extPort = if extIp.isSome() and extTcpPort.isNone(): some(Port(uint16(conf.tcpPort) + conf.portsShift))
               else: extTcpPort
-    node = WakuNode.init(conf.nodeKey,
+    node = WakuNode.init(conf.nodekey_depr, # @TODO remove deprecated config item
                          conf.listenAddress, Port(uint16(conf.tcpPort) + conf.portsShift), 
                          extIp, extPort,
                          pStorage)
@@ -673,7 +680,7 @@ when isMainModule:
   if (conf.storenode != "") or (conf.store):
     var store: WakuMessageStore
 
-    if (not sqliteDatabase.isNil) and conf.persistmessages:
+    if (not sqliteDatabase.isNil) and conf.persistMessages:
       let res = WakuMessageStore.init(sqliteDatabase)
       if res.isErr:
         warn "failed to init WakuMessageStore", err = res.error
@@ -681,7 +688,7 @@ when isMainModule:
       else:
         store = res.value
 
-    mountStore(node, store, conf.persistmessages)
+    mountStore(node, store, conf.persistMessages)
 
     if conf.storenode != "":
       setStorePeer(node, conf.storenode)
@@ -689,11 +696,13 @@ when isMainModule:
   # Relay setup
   mountRelay(node,
              conf.topics.split(" "),
-             rlnRelayEnabled = conf.rlnrelay,
+             rlnRelayEnabled = conf.rlnrelay_depr or conf.rlnRelay, # @TODO remove deprecated config item
              keepAlive = conf.keepAlive,
              relayMessages = conf.relay) # Indicates if node is capable to relay messages
 
-  if conf.staticnodes.len > 0:
+  if conf.staticnodes_depr.len > 0: # @TODO remove deprecated config item
+    waitFor connectToNodes(node, conf.staticnodes_depr)
+  elif conf.staticnodes.len > 0:
     waitFor connectToNodes(node, conf.staticnodes)
 
   # NOTE Must be mounted after relay
@@ -710,7 +719,7 @@ when isMainModule:
   if conf.rpc:
     startRpc(node, conf.rpcAddress, Port(conf.rpcPort + conf.portsShift), conf)
 
-  if conf.logMetrics:
+  if conf.logMetrics_depr or conf.metricsLogging: # @TODO remove deprecated config item
     startMetricsLog()
 
   when defined(insecure):

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -631,7 +631,7 @@ when isMainModule:
   var sqliteDatabase: SqliteDatabase
 
   if conf.dbpath_depr != "":  # @TODO remove deprecated config item
-    let dbRes = SqliteDatabase.init(conf.dbpath)
+    let dbRes = SqliteDatabase.init(conf.dbpath_depr)
     if dbRes.isErr:
       warn "failed to init database", err = dbRes.error
       waku_node_errors.inc(labelValues = ["init_db_failure"])

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -700,9 +700,7 @@ when isMainModule:
              keepAlive = conf.keepAlive,
              relayMessages = conf.relay) # Indicates if node is capable to relay messages
 
-  if conf.staticnodes_depr.len > 0: # @TODO remove deprecated config item
-    waitFor connectToNodes(node, conf.staticnodes_depr)
-  elif conf.staticnodes.len > 0:
+  if conf.staticnodes.len > 0:
     waitFor connectToNodes(node, conf.staticnodes)
 
   # NOTE Must be mounted after relay


### PR DESCRIPTION
## Background

This PR partially addresses #540. It fixes some inconsistencies in the naming of Waku v2 config items. It is the first of three steps necessary to change CLI parameters without breaking existing deployments.

### Step 1 (this PR):

Add new, consistent config items in such a way that we still support the current items. In other words, keep the old CLI parameters intact. Refactor existing field names by postfixing them with `_depr`. This will mark them for removal in `Step 3`.

### Step 2:

Propagate changes to existing deployments:
- [ ] open PR adding support for the new config items on `prod` and `test` fleets
- [ ] inform external `nim-waku` clients, such as WalletConnect

### Step 3:

Remove deprecated config items from the codebase.

## Conventions followed

I've tried adhering to the following conventions:
1. config items with similar semantics should follow similar naming conventions (e.g. `persist-peers` should look similar to `persist-messages`)
2. where a config item is composed of more than one word, use camelCase for field names while hyphenating the CLI parameter
3. parameters that take a "plural" argument should be in plural form (e.g. prefer `staticnodes` to `staticnode`)
4. the field name and CLI parameter for each item should agree
5. use consistent namespacing where possible (e.g. change `log-metrics` to `metrics-logging` to be consistent with other `metrics` config items)

## Summary of changes
The following CLI parameters have changed. The old parameters will be deprecated and removed in `Step 3`:

### For `wakunode2`, `chat2` and `chat2bridge`
- ~`nodekey` changed to `node-key`~ UPDATE: this would make it inconsistent with Waku v1. Reverted in 455edea
- `dbpath` changed to `db-path`
- `peerpersist` changed to `persist-peers`
- `rlnrelay` changed to `rln-relay`
- ~`staticnode` changed to `staticnodes`~ UPDATE: reverted in f4dd214. Reasoning [here](https://github.com/status-im/nim-waku/pull/543#discussion_r630059461)
- `log-metrics` changed to `metrics-logging`

### For `wakubridge`
All items overlapping with the above list, with the following additions
- `fleetv1` changed to `fleet-v1`
- `staticnodev1` changed to `staticnode-v1`
- `nodekeyv1` changed to `node-key-v1`
- `staticnodev2` changed to `staticnode-v2`
- `nodekeyv2` changed to `node-key-v2`

## What has not changed?
The concepts `staticnodes`, `filternode` and `storenode` are such tight concepts that I did not consider them as composites of two words. In other words, the config parameters were **not** changed to `filter-node`, `store-node` or `static-nodes`.