### PR TITLE
Remove deprecated config items

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -248,9 +248,9 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   await node.start()
 
   if conf.filternode != "":
-    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = (conf.rlnrelay_depr or conf.rlnRelay), keepAlive = conf.keepAlive) # @TODO remove deprecated config item
+    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = conf.rlnRelay, keepAlive = conf.keepAlive)
   else:
-    node.mountRelay(@[], rlnRelayEnabled = (conf.rlnrelay_depr or conf.rlnRelay), keepAlive = conf.keepAlive) # @TODO remove deprecated config item
+    node.mountRelay(@[], rlnRelayEnabled = conf.rlnRelay, keepAlive = conf.keepAlive)
   
   let nick = await readNick(transp)
   echo "Welcome, " & nick & "!"

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -77,32 +77,15 @@ type
       name: "metrics-server-port" .}: uint16
 
     ### Waku v1 options
-    # @TODO: deprecate this item. Name changed from `fleetv1` -> `fleet-v1`
-    fleetv1_depr* {.
-      desc: "Select the Waku v1 fleet to connect to"
-      defaultValue: FleetV1.none
-      name: "fleetv1" .}: FleetV1
     
     fleetV1* {.
       desc: "Select the Waku v1 fleet to connect to"
       defaultValue: FleetV1.none
       name: "fleet-v1" .}: FleetV1
-
-    # @TODO: deprecate this item. Name changed from `staticnodev1` -> `staticnodes-v1`
-    staticnodesv1_depr* {.
-      desc: "Enode URL to directly connect with. Argument may be repeated"
-      name: "staticnodev1" .}: seq[string]
     
     staticnodesV1* {.
       desc: "Enode URL to directly connect with. Argument may be repeated"
       name: "staticnode-v1" .}: seq[string]
-
-    # @TODO: deprecate this item. Name changed from `nodekeyv1` -> `node-key-v1`
-    nodekeyv1_depr* {.
-      desc: "DevP2P node private key as hex",
-      # TODO: can the rng be passed in somehow via Load?
-      defaultValue: keys.KeyPair.random(keys.newRng()[])
-      name: "nodekeyv1" .}: keys.KeyPair
     
     nodekeyV1* {.
       desc: "DevP2P node private key as hex",
@@ -116,21 +99,11 @@ type
       name: "waku-pow" .}: float64
 
     ### Waku v2 options
-    # @TODO: deprecate this item. Name changed from `staticnodev2` -> `staticnodes-v2`
-    staticnodesv2_depr* {.
-      desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
-      name: "staticnodev2" }: seq[string]
-    
+
     staticnodesV2* {.
       desc: "Multiaddr of peer to directly connect with. Argument may be repeated"
       name: "staticnode-v2" }: seq[string]
 
-    # @TODO: deprecate this item. Name changed from `nodekeyv2` -> `node-key-v2`
-    nodekeyv2_depr* {.
-      desc: "P2P node private key as hex"
-      defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()
-      name: "nodekeyv2" }: crypto.PrivateKey
-    
     nodekeyV2* {.
       desc: "P2P node private key as hex"
       defaultValue: crypto.PrivateKey.random(Secp256k1, keys.newRng()[]).tryGet()

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -200,11 +200,11 @@ when isMainModule:
                                                Port(uint16(conf.udpPort) + conf.portsShift))
 
   let
-    bridge = WakuBridge.new(nodev1Key = conf.nodekeyv1_depr,  # @TODO remove deprecated config item
+    bridge = WakuBridge.new(nodev1Key = conf.nodekeyV1,
                             nodev1Address = nodev1Address,
                             powRequirement = conf.wakuPow,
                             rng = rng,
-                            nodev2Key = conf.nodekeyv2_depr, # @TODO remove deprecated config item
+                            nodev2Key = conf.nodekeyV2,
                             nodev2BindIp = conf.listenAddress, nodev2BindPort = Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
                             nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = nodev2ExtPort)
   
@@ -212,11 +212,6 @@ when isMainModule:
 
   # Now load rest of config
   # Optionally direct connect nodev1 with a set of nodes
-  # @TODO remove deprecated config items
-  if conf.staticnodesv1_depr.len > 0: connectToNodes(bridge.nodev1, conf.staticnodesv1_depr)
-  elif conf.fleetv1_depr == prod: connectToNodes(bridge.nodev1, WhisperNodes)
-  elif conf.fleetv1_depr == staging: connectToNodes(bridge.nodev1, WhisperNodesStaging)
-  elif conf.fleetv1_depr == test: connectToNodes(bridge.nodev1, WhisperNodesTest)
 
   if conf.staticnodesV1.len > 0: connectToNodes(bridge.nodev1, conf.staticnodesV1)
   elif conf.fleetV1 == prod: connectToNodes(bridge.nodev1, WhisperNodes)
@@ -230,9 +225,7 @@ when isMainModule:
   if conf.filter:
     mountFilter(bridge.nodev2)
 
-  if conf.staticnodesv2_depr.len > 0: # @TODO remove deprecated config item
-    waitFor connectToNodes(bridge.nodev2, conf.staticnodesv2_depr)
-  elif conf.staticnodesV2.len > 0:
+  if conf.staticnodesV2.len > 0:
     waitFor connectToNodes(bridge.nodev2, conf.staticnodesV2)
 
   if conf.storenode != "":

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -47,23 +47,11 @@ type
       defaultValue: "any" }: string
     
     ## Persistence config
-
-    # @TODO: deprecate this item. Name changed from `dbpath` -> `db-path`
-    dbpath_depr* {.
-      desc: "The database path for peristent storage",
-      defaultValue: ""
-      name: "dbpath" }: string
     
     dbPath* {.
       desc: "The database path for peristent storage",
       defaultValue: ""
       name: "db-path" }: string
-    
-    # @TODO: deprecate this item. Name changed from `peerpersist` -> `persist-peers`
-    peerpersist_depr* {.
-      desc: "Enable peer persistence: true|false",
-      defaultValue: false
-      name: "peerpersist" }: bool
     
     persistPeers* {.
       desc: "Enable peer persistence: true|false",
@@ -81,12 +69,6 @@ type
       desc: "Enable relay protocol: true|false",
       defaultValue: true
       name: "relay" }: bool
-    
-    # @TODO: deprecate this item. Name changed from `rlnrelay` -> `rln-relay`
-    rlnrelay_depr* {.
-      desc: "Enable spam protection through rln-relay: true|false",
-      defaultValue: false
-      name: "rlnrelay" }: bool
     
     rlnRelay* {.
       desc: "Enable spam protection through rln-relay: true|false",
@@ -188,12 +170,6 @@ type
       desc: "Listening HTTP port of the metrics server."
       defaultValue: 8008
       name: "metrics-server-port" }: uint16
-
-    # @TODO: deprecate this item. Name changed from `log-metrics` -> `metrics-logging`
-    logMetrics_depr* {.
-      desc: "Enable metrics logging: true|false"
-      defaultValue: false
-      name: "log-metrics" }: bool
 
     metricsLogging* {.
       desc: "Enable metrics logging: true|false"

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -630,14 +630,7 @@ when isMainModule:
   # Storage setup
   var sqliteDatabase: SqliteDatabase
 
-  if conf.dbpath_depr != "":  # @TODO remove deprecated config item
-    let dbRes = SqliteDatabase.init(conf.dbpath_depr)
-    if dbRes.isErr:
-      warn "failed to init database", err = dbRes.error
-      waku_node_errors.inc(labelValues = ["init_db_failure"])
-    else:
-      sqliteDatabase = dbRes.value
-  elif conf.dbPath != "":
+  if conf.dbPath != "":
     let dbRes = SqliteDatabase.init(conf.dbPath)
     if dbRes.isErr:
       warn "failed to init database", err = dbRes.error
@@ -647,7 +640,7 @@ when isMainModule:
   
   var pStorage: WakuPeerStorage
 
-  if (conf.peerpersist_depr or conf.persistPeers) and not sqliteDatabase.isNil: # @TODO remove deprecated config item
+  if conf.persistPeers and not sqliteDatabase.isNil:
     let res = WakuPeerStorage.new(sqliteDatabase)
     if res.isErr:
       warn "failed to init new WakuPeerStorage", err = res.error
@@ -696,7 +689,7 @@ when isMainModule:
   # Relay setup
   mountRelay(node,
              conf.topics.split(" "),
-             rlnRelayEnabled = conf.rlnrelay_depr or conf.rlnRelay, # @TODO remove deprecated config item
+             rlnRelayEnabled = conf.rlnRelay,
              keepAlive = conf.keepAlive,
              relayMessages = conf.relay) # Indicates if node is capable to relay messages
 
@@ -717,7 +710,7 @@ when isMainModule:
   if conf.rpc:
     startRpc(node, conf.rpcAddress, Port(conf.rpcPort + conf.portsShift), conf)
 
-  if conf.logMetrics_depr or conf.metricsLogging: # @TODO remove deprecated config item
+  if conf.metricsLogging:
     startMetricsLog()
 
   when defined(insecure):


### PR DESCRIPTION
This PR closes #540 

It is the final step towards fixing config inconsistencies in a backwards compatible manner, as set out in https://github.com/status-im/nim-waku/pull/543.
Fleet nodes were switched over to the new config items in https://github.com/status-im/infra-nim-waku/pull/10.