### PR TITLE
Ft-store: Peer management

### DIFF
--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -668,9 +668,24 @@ procSuite "Waku Store":
       # starts a new node
       var dialSwitch2 = newStandardSwitch()
       discard await dialSwitch2.start()
-      let
-        proto2 = WakuStore.init(PeerManager.new(dialSwitch2), crypto.newRng())
-       
+      let proto2 = WakuStore.init(PeerManager.new(dialSwitch2), crypto.newRng())
       proto2.setPeer(listenSwitch.peerInfo)
-      await proto2.resume()
-      check proto2.messages.len == 10
+
+      await proto2.resume(none(seq[PeerInfo]))
+      check:
+        proto2.messages.len == 10
+
+    asyncTest "resume history from a list of candidate peers":
+
+      var offListenSwitch = newStandardSwitch(some(PrivateKey.random(ECDSA, rng[]).get()))
+
+      # starts a new node
+      var dialSwitch3 = newStandardSwitch()
+      discard await dialSwitch3.start()
+      let proto3 = WakuStore.init(PeerManager.new(dialSwitch3), crypto.newRng())
+
+      await proto3.resume(some(@[offListenSwitch.peerInfo, listenSwitch.peerInfo, listenSwitch.peerInfo]))
+      check:
+        proto3.messages.len == 10
+
+       

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -668,11 +668,14 @@ procSuite "Waku Store":
       # starts a new node
       var dialSwitch2 = newStandardSwitch()
       discard await dialSwitch2.start()
+    
       let proto2 = WakuStore.init(PeerManager.new(dialSwitch2), crypto.newRng())
       proto2.setPeer(listenSwitch.peerInfo)
 
-      await proto2.resume(none(seq[PeerInfo]))
+      let successResult = await proto2.resume()
       check:
+        successResult.isOk 
+        successResult.value == 10
         proto2.messages.len == 10
 
     asyncTest "queryFrom":
@@ -685,11 +688,12 @@ procSuite "Waku Store":
         completionFut.complete(true)
 
       let rpc = HistoryQuery(startTime: float(2), endTime: float(5))
-      let success = await proto.queryFrom(rpc, handler, listenSwitch.peerInfo)
+      let successResult = await proto.queryFrom(rpc, handler, listenSwitch.peerInfo)
 
       check:
         (await completionFut.withTimeout(5.seconds)) == true
-        success == true
+        successResult.isOk
+        successResult.value == 4
 
 
     asyncTest "resume history from a list of candidate peers":
@@ -701,8 +705,10 @@ procSuite "Waku Store":
       discard await dialSwitch3.start()
       let proto3 = WakuStore.init(PeerManager.new(dialSwitch3), crypto.newRng())
 
-      await proto3.resume(some(@[offListenSwitch.peerInfo, listenSwitch.peerInfo, listenSwitch.peerInfo]))
+      let successResult = await proto3.resume(some(@[offListenSwitch.peerInfo, listenSwitch.peerInfo, listenSwitch.peerInfo]))
       check:
         proto3.messages.len == 10
+        successResult.isOk
+        successResult.value == 10
 
        

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -459,7 +459,7 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
   waku_store_messages.set(response.value.response.messages.len.int64, labelValues = ["retrieved"])
   handler(response.value.response)
 
-proc queryFrom*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, peer: PeerInfo): Future[Result[int64, string]] {.async.} =
+proc queryFrom*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, peer: PeerInfo): Future[QueryResult] {.async.} =
   # sends the query to the given peer
   # returns the number of retrieved messages if no error occurs, otherwise returns the error string
   let connOpt = await w.peerManager.dialPeer(peer, WakuStoreCodec)
@@ -487,7 +487,7 @@ proc queryFrom*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, pe
   
   
 
-proc queryLoop(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, candidateList: seq[PeerInfo]): Future[Result[int64, string]]  {.async.}= 
+proc queryLoop(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, candidateList: seq[PeerInfo]): Future[QueryResult]  {.async.}= 
   ## loops through the candidateList in order and sends the query to each until one of the query gets resolved successfully
   ## returns the number of retrieved messages, or error if all the requests fail
   for peer in candidateList.items: 
@@ -504,7 +504,7 @@ proc findLastSeen*(list: seq[IndexedWakuMessage]): float =
       lastSeenTime = iwmsg.msg.timestamp 
   return lastSeenTime
 
-proc resume*(ws: WakuStore, peerList: Option[seq[PeerInfo]] = none(seq[PeerInfo])): Future[Result[int64, string]] {.async.} =
+proc resume*(ws: WakuStore, peerList: Option[seq[PeerInfo]] = none(seq[PeerInfo])): Future[QueryResult] {.async.} =
   ## resume proc retrieves the history of waku messages published on the default waku pubsub topic since the last time the waku store node has been online 
   ## messages are stored in the store node's messages field and in the message db
   ## the offline time window is measured as the difference between the current time and the timestamp of the most recent persisted waku message 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -510,8 +510,7 @@ proc resume*(ws: WakuStore, peerList: Option[seq[PeerInfo]]) {.async.} =
   ## an offset of 20 second is added to the time window to count for nodes asynchrony
   ## the history is fetched from one of the peers persisted in the waku store node's peer manager unit  
   ## peerList indicates the list of peers to query from. The history is fetched from the first available peer in this list. Such candidates should be found through a discovery method (to be developed).
-  ## if no peerList is passed, the underlying peer manager unit of the store protocol will pick one of the current connections randomly to fetch the history from. 
-  ## In this case, the history gets fetched successfully if the dialed peer has been online during the queried time window.
+  ## if no peerList is passed, the underlying peer manager unit of the store protocol will pick one of the current connections randomly to fetch the history from. The history gets fetched successfully if the dialed peer has been online during the queried time window.
   var currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)
   debug "resume", currentEpochTime=currentTime

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -486,7 +486,7 @@ proc queryFrom*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, pe
   return true
   
 
-proc queryLoop*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, candidateList: seq[PeerInfo]): Future[bool]  {.async.}= 
+proc queryLoop(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, candidateList: seq[PeerInfo]): Future[bool]  {.async.}= 
   ## loops through the candidateList in order and sends the query to each until one of the query gets resolved successfully without error
   ## returns false if all the requests fail
   for peer in candidateList.items: 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -509,8 +509,9 @@ proc resume*(ws: WakuStore, peerList: Option[seq[PeerInfo]]) {.async.} =
   ## the offline time window is measured as the difference between the current time and the timestamp of the most recent persisted waku message 
   ## an offset of 20 second is added to the time window to count for nodes asynchrony
   ## the history is fetched from one of the peers persisted in the waku store node's peer manager unit  
-  ## the peer selection for the query is implicit and is handled as part of the waku store query procedure
-  ## the history gets fetched successfully if the dialed peer has been online during the queried time window
+  ## peerList indicates the list of peers to query from. The history is fetched from the first available peer in this list. Such candidates should be found through a discovery method (to be developed).
+  ## if no peerList is passed, the underlying peer manager unit of the store protocol will pick one of the current connections randomly to fetch the history from. 
+  ## In this case, the history gets fetched successfully if the dialed peer has been online during the queried time window.
   var currentTime = epochTime()
   var lastSeenTime: float = findLastSeen(ws.messages)
   debug "resume", currentEpochTime=currentTime

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -58,6 +58,8 @@ type
     query*: HistoryQuery
     response*: HistoryResponse
 
+  QueryResult* = Result[int64, string]
+  
   WakuStore* = ref object of LPProtocol
     peerManager*: PeerManager
     rng*: ref BrHmacDrbgContext


### PR DESCRIPTION
This PR closes https://github.com/status-im/nim-waku/issues/513 and closes https://github.com/status-im/nim-waku/issues/458

A list of candidate peers is passed to the resume proc from which the history of messages is going to be retrieved. Such candidates should be found through a discovery method (to be developed in the future).  Passing this list to the resume proc is optional, and if left empty then the underlying peer manager unit of the store protocol will pick one of the current connections randomly to fetch the history from. 