### PR TITLE
Duplicate filtering for `bridge`

### DIFF
--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -22,58 +22,81 @@ import
   ../test_helpers
 
 procSuite "WakuBridge":
-  let rng = keys.newRng()
+  ###############
+  # Suite setup #
+  ###############
+
+  let
+    rng = keys.newRng()
+
+    # Bridge
+    nodev1Key = keys.KeyPair.random(rng[])
+    nodev2Key = crypto.PrivateKey.random(Secp256k1, rng[])[]
+    bridge = WakuBridge.new(
+        nodev1Key= nodev1Key,
+        nodev1Address = localAddress(30303),
+        powRequirement = 0.002,
+        rng = rng,
+        nodev2Key = nodev2Key,
+        nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(60000))
+    
+    # Waku v1 node
+    v1Node = setupTestNode(rng, Waku)
+
+    # Waku v2 node
+    v2NodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+    v2Node = WakuNode.init(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
+
+    contentTopic = ContentTopic("0001")
+    topic = toArray(4, contentTopic.toBytes()[0..3])
+    payloadV1 = "hello from V1".toBytes()
+    payloadV2 = "hello from V2".toBytes()
+    message = WakuMessage(payload: payloadV2, contentTopic: contentTopic)
+  
+  ########################
+  # Tests setup/teardown #
+  ########################
+  
+  setup:
+    # Runs before each test
+    waitFor bridge.start()
+
+    waitFor v2Node.start()
+    v2Node.mountRelay(@[DefaultBridgeTopic])
+
+    discard waitFor v1Node.rlpxConnect(newNode(bridge.nodev1.toENode()))
+    waitFor v2Node.connectToNodes(@[bridge.nodev2.peerInfo])
+  
+  teardown:
+    # Runs after each test
+    bridge.nodeV1.resetMessageQueue()
+    v1Node.resetMessageQueue()
+    waitFor allFutures([bridge.stop(), v2Node.stop()])
+
+  ###############
+  # Suite tests #
+  ###############
 
   asyncTest "Messages are bridged between Waku v1 and Waku v2":
-    let
-      # Bridge
-      nodev1Key = keys.KeyPair.random(rng[])
-      nodev2Key = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      bridge = WakuBridge.new(
-          nodev1Key= nodev1Key,
-          nodev1Address = localAddress(30303),
-          powRequirement = 0.002,
-          rng = rng,
-          nodev2Key = nodev2Key,
-          nodev2BindIp = ValidIpAddress.init("0.0.0.0"), nodev2BindPort= Port(60000))
-      
-      # Waku v1 node
-      v1Node = setupTestNode(rng, Waku)
-
-      # Waku v2 node
-      v2NodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      v2Node = WakuNode.init(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
-
-      contentTopic = ContentTopic("0001")
-      topic = toArray(4, contentTopic.toBytes()[0..3])
-      payloadV1 = "hello from V1".toBytes()
-      payloadV2 = "hello from V2".toBytes()
-      message = WakuMessage(payload: payloadV2, contentTopic: contentTopic)
-
-    await bridge.start()
-
-    await v2Node.start()
-    v2Node.mountRelay(@[defaultBridgeTopic])
-
-    discard await v1Node.rlpxConnect(newNode(bridge.nodev1.toENode()))
-    await v2Node.connectToNodes(@[bridge.nodev2.peerInfo])
-
     var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+
+    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =      
       let msg = WakuMessage.init(data)
+      
       if msg.isOk() and msg.value().version == 1:
         check:
           # Message fields are as expected
           msg.value().contentTopic == contentTopic # Topic translation worked
           string.fromBytes(msg.value().payload).contains("from V1")
+        
         completionFut.complete(true)
 
-    v2Node.subscribe(defaultBridgeTopic, relayHandler)
+    v2Node.subscribe(DefaultBridgeTopic, relayHandler)
 
     await sleepAsync(2000.millis)
 
     # Test bridging from V2 to V1
-    await v2Node.publish(defaultBridgeTopic, message)
+    await v2Node.publish(DefaultBridgeTopic, message)
 
     await sleepAsync(2000.millis)
 
@@ -97,5 +120,13 @@ procSuite "WakuBridge":
       # v2Node received payload published by v1Node
       await completionFut.withTimeout(5.seconds)
 
-    await bridge.stop()
-    
+    # Test filtering of WakuMessage duplicates
+    v1Node.resetMessageQueue()
+
+    await v2Node.publish(DefaultBridgeTopic, message)
+
+    await sleepAsync(2000.millis)
+
+    check:
+      # v1Node did not receive duplicate of previous message
+      v1Node.protocolState(Waku).queue.items.len == 0


### PR DESCRIPTION
This PR closes #554

It adds duplicate filtering to the Waku v1 <> v2 bridge.

Duplicate messages occurred because the default relay handler, registered on the bridge for the default bridge topic, will be triggered after publishing the message bridged from v1. This in turn triggers the v2 -> v1 bridge with a duplicate.
This only happens in direction v1 -> v2.

PR includes general improvements to unit test.