### PR TITLE
Minor bridge improvements

### DIFF
--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -172,7 +172,9 @@ proc start*(cmb: Chat2MatterBridge) {.async.} =
   debug "Start listening on Waku v2"
   await cmb.nodev2.start()
   
-  cmb.nodev2.mountRelay() # Always mount relay for bridge
+  # Always mount relay for bridge
+  # `triggerSelf` is false on a `bridge` to avoid duplicates
+  cmb.nodev2.mountRelay(triggerSelf = false)
 
   # Bridging
   # Handle messages on Waku v2 and bridge to Matterbridge

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -441,12 +441,13 @@ proc mountRelay*(node: WakuNode,
                  topics: seq[string] = newSeq[string](),
                  rlnRelayEnabled = false,
                  keepAlive = false,
-                 relayMessages = true) {.gcsafe.} =
+                 relayMessages = true,
+                 triggerSelf = true) {.gcsafe.} =
   let wakuRelay = WakuRelay.init(
     switch = node.switch,
     # Use default
     #msgIdProvider = msgIdProvider,
-    triggerSelf = true,
+    triggerSelf = triggerSelf,
     sign = false,
     verifySignature = false
   )


### PR DESCRIPTION
Minor improvements to `bridge` and `chat2bridge`:

1. Sets the `relay` property `triggerSelf` to `false`, to avoid the bridge triggering a callback for a message it has just bridged to Waku v2. Also see https://github.com/status-im/nim-waku/issues/562.
2. Lower logs to more realistic levels