### PR TITLE
A quick fix to the master issue

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -713,7 +713,7 @@ when isMainModule:
              relayMessages = conf.relay) # Indicates if node is capable to relay messages
   
   # Resume historical messages, this has to be called after the relay setup           
-  if conf.persistMessages:
+  if conf.store and conf.persistMessages:
     waitFor node.resume()
 
   if conf.staticnodes.len > 0:

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -703,8 +703,6 @@ when isMainModule:
     if conf.storenode != "":
       setStorePeer(node, conf.storenode)
     
-    if conf.persistMessages:
-      waitFor node.resume()
 
 
   # Relay setup
@@ -713,6 +711,10 @@ when isMainModule:
              rlnRelayEnabled = conf.rlnRelay,
              keepAlive = conf.keepAlive,
              relayMessages = conf.relay) # Indicates if node is capable to relay messages
+  
+  # Resume historical messages, this has to be called after the relay setup           
+  if conf.persistMessages:
+    waitFor node.resume()
 
   if conf.staticnodes.len > 0:
     waitFor connectToNodes(node, conf.staticnodes)


### PR DESCRIPTION
This is just a temporary patch for the current issue in the master branch https://github.com/status-im/nim-waku/issues/577. 
The cause of the issue as explained by @jm-clius is: 
> The issue here is that `relay` is not yet mounted when `store` attempts to resume during [`wakunode2` startup procedures](https://github.com/status-im/nim-waku/blob/master/waku/v2/node/wakunode2.nim#L707) (and in order to dial you need to have `relay` mounted first). You could move the resume functionality till after you've mounted `relay`, but that would (currently) mean that you start relaying messages before you've properly resumed your history, which is not ideal. To delay starting `relay` until you've finished resuming history is also not an option as it stands, since this is tied in with starting the switch which you need to do before the `resume`.
In other words, our protocol mounting behaviour (passive i.t.o. network participation, e.g. initialise and mount protocol on `switch`) and protocol starting behaviour (often active, e.g. resume history, subscribe to default topics, etc.) needs to be untangled.

~The long-term solution is to split the mount relay proc logic into two parts: 1-the initialization phase that includes e.g.,  mounting protocol on the switch 2- starting phase where the node actually starts relaying messages~