### PR TITLE
Update toychat default content topic

### DIFF
--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -190,7 +190,7 @@ type
 
     contentTopic* {.
       desc: "Content topic for chat messages."
-      defaultValue: "/waku/2/huilong/proto"
+      defaultValue: "/toychat/2/huilong/proto"
       name: "content-topic" }: string
 
 # NOTE: Keys are different in nim-libp2p

--- a/examples/v2/matterbridge/config_chat2bridge.nim
+++ b/examples/v2/matterbridge/config_chat2bridge.nim
@@ -126,7 +126,7 @@ type
 
     contentTopic* {.
       desc: "Content topic to bridge chat messages to."
-      defaultValue: "/waku/2/huilong/proto"
+      defaultValue: "/toychat/2/huilong/proto"
       name: "content-topic" }: string
 
 proc parseCmdArg*(T: type keys.KeyPair, p: TaintedString): T =


### PR DESCRIPTION
This updates the `toychat` (`chat2`) default content topic to match the topic recommendation as decided upon in https://github.com/vacp2p/rfc/pull/383.

For the upcoming testnet, the content topic is set to `/toychat/2/huilong/proto` (updated from `/waku/2/huilong/proto`).

cc @D4nte for parallel changes in js-waku.