### PR TITLE
Fix keepalive for connected peers

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -248,9 +248,11 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   await node.start()
 
   if conf.filternode != "":
-    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = conf.rlnRelay, keepAlive = conf.keepAlive)
+    node.mountRelay(conf.topics.split(" "), rlnRelayEnabled = conf.rlnRelay)
   else:
-    node.mountRelay(@[], rlnRelayEnabled = conf.rlnRelay, keepAlive = conf.keepAlive)
+    node.mountRelay(@[], rlnRelayEnabled = conf.rlnRelay)
+  
+  node.mountKeepalive()
   
   let nick = await readNick(transp)
   echo "Welcome, " & nick & "!"
@@ -376,6 +378,9 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   node.subscribe(topic, handler)
 
   await chat.readWriteLoop()
+
+  if conf.keepAlive:
+    node.startKeepalive()
 
   runForever()
   #await allFuturesThrowing(libp2pFuts)

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -14,7 +14,8 @@ import
   ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
   ./v2/test_waku_rln_relay,
   ./v2/test_waku_bridge,
-  ./v2/test_peer_storage
+  ./v2/test_peer_storage,
+  ./v2/test_waku_keepalive
 
 # TODO Only enable this once swap module is integrated more nicely as a dependency, i.e. as submodule with CI etc
 # For PoC execute it manually and run separate module here: https://github.com/vacp2p/swap-contracts-module

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -1,0 +1,52 @@
+{.used.}
+
+import
+  std/[options, tables, sets],
+  testutils/unittests, chronos, chronicles,
+  stew/shims/net as stewNet,
+  libp2p/switch,
+  libp2p/protobuf/minprotobuf,
+  libp2p/stream/[bufferstream, connection],
+  libp2p/crypto/crypto,
+  libp2p/multistream,
+  ../../waku/v2/node/wakunode2,
+  ../../waku/v2/protocol/waku_keepalive/waku_keepalive,
+  ../test_helpers, ./utils
+
+procSuite "Waku Keepalive":
+
+  asyncTest "handle keepalive":
+    let
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+
+    await node1.start()
+    node1.mountRelay()
+    node1.mountKeepalive()
+
+    await node2.start()
+    node2.mountRelay()
+    node2.mountKeepalive()
+
+    await node1.connectToNodes(@[node2.peerInfo])
+
+    var completionFut = newFuture[bool]()
+
+    proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+      debug "WakuKeepalive message received"
+      
+      check:
+        proto == waku_keepalive.WakuKeepaliveCodec
+      
+      completionFut.complete(true)
+    
+    node2.wakuKeepalive.handler = handle
+
+    node1.startKeepalive()
+
+    check:
+      (await completionFut.withTimeout(5.seconds)) == true
+
+    await allFutures([node1.stop(), node2.stop()])

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -27,7 +27,7 @@ let
 # Helper functions #
 ####################
 
-proc toPeerInfo(storedInfo: StoredInfo): PeerInfo =
+proc toPeerInfo*(storedInfo: StoredInfo): PeerInfo =
   PeerInfo.init(peerId = storedInfo.peerId,
                 addrs = toSeq(storedInfo.addrs),
                 protocols = toSeq(storedInfo.protos))

--- a/waku/v2/protocol/waku_keepalive/waku_keepalive.nim
+++ b/waku/v2/protocol/waku_keepalive/waku_keepalive.nim
@@ -39,7 +39,6 @@ proc encode*(msg: KeepaliveMessage): ProtoBuffer =
   return pb
 
 proc init*(T: type KeepaliveMessage, buffer: seq[byte]): ProtoResult[T] =
-  #var rpc = PushRequest(pubSubTopic: "", message: WakuMessage())
   var msg = KeepaliveMessage()
   let pb = initProtoBuffer(buffer)
 

--- a/waku/v2/protocol/waku_keepalive/waku_keepalive.nim
+++ b/waku/v2/protocol/waku_keepalive/waku_keepalive.nim
@@ -1,0 +1,86 @@
+import
+  std/[tables, sequtils, options],
+  bearssl,
+  chronos, chronicles, metrics, stew/results,
+  libp2p/protocols/pubsub/pubsubpeer,
+  libp2p/protocols/pubsub/floodsub,
+  libp2p/protocols/pubsub/gossipsub,
+  libp2p/protocols/protocol,
+  libp2p/protobuf/minprotobuf,
+  libp2p/stream/connection,
+  libp2p/crypto/crypto,
+  ../../utils/requests,
+  ../../node/peer_manager/peer_manager,
+  ../message_notifier,
+  ../waku_relay,
+  waku_keepalive_types
+
+export waku_keepalive_types
+
+declarePublicGauge waku_keepalive_count, "number of keepalives received"
+declarePublicGauge waku_keepalive_errors, "number of keepalive protocol errors", ["type"]
+
+logScope:
+  topics = "wakukeepalive"
+
+const
+  WakuKeepaliveCodec* = "/vac/waku/keepalive/2.0.0-alpha1"
+
+# Error types (metric label values)
+const
+  dialFailure = "dial_failure"
+
+# Encoding and decoding -------------------------------------------------------
+proc encode*(msg: KeepaliveMessage): ProtoBuffer =
+  var pb = initProtoBuffer()
+
+  # @TODO: Currently no fields defined for a KeepaliveMessage
+
+  return pb
+
+proc init*(T: type KeepaliveMessage, buffer: seq[byte]): ProtoResult[T] =
+  #var rpc = PushRequest(pubSubTopic: "", message: WakuMessage())
+  var msg = KeepaliveMessage()
+  let pb = initProtoBuffer(buffer)
+
+  # @TODO: Currently no fields defined for a KeepaliveMessage
+
+  ok(msg)
+
+# Protocol -------------------------------------------------------
+proc new*(T: type WakuKeepalive, peerManager: PeerManager, rng: ref BrHmacDrbgContext): T =
+  debug "new WakuKeepalive"
+  var wk: WakuKeepalive
+  new wk
+
+  wk.rng = crypto.newRng()
+  wk.peerManager = peerManager
+  
+  wk.init()
+
+  return wk
+
+method init*(wk: WakuKeepalive) =
+  debug "init WakuKeepalive"
+
+  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+    info "WakuKeepalive message received"
+    waku_keepalive_count.inc()
+
+  wk.handler = handle
+  wk.codec = WakuKeepaliveCodec
+
+proc keepAllAlive*(wk: WakuKeepalive) {.async, gcsafe.} =
+  # Send keepalive message to all managed and connected peers
+  let peers = wk.peerManager.peers().filterIt(wk.peerManager.connectedness(it.peerId) == Connected).mapIt(it.toPeerInfo())
+
+  for peer in peers:
+    let connOpt = await wk.peerManager.dialPeer(peer, WakuKeepaliveCodec)
+
+    if connOpt.isNone():
+      # @TODO more sophisticated error handling here
+      error "failed to connect to remote peer"
+      waku_keepalive_errors.inc(labelValues = [dialFailure])
+      return
+
+    await connOpt.get().writeLP(KeepaliveMessage().encode().buffer)  # Send keep-alive on connection

--- a/waku/v2/protocol/waku_keepalive/waku_keepalive_types.nim
+++ b/waku/v2/protocol/waku_keepalive/waku_keepalive_types.nim
@@ -1,0 +1,12 @@
+import
+  bearssl,
+  libp2p/protocols/protocol,
+  ../../node/peer_manager/peer_manager
+
+type
+  KeepaliveMessage* = object
+    # Currently no fields for a keepalive message
+
+  WakuKeepalive* = ref object of LPProtocol
+    rng*: ref BrHmacDrbgContext
+    peerManager*: PeerManager


### PR DESCRIPTION
This PR fixes #586

## Description

It does so by introducing a simple (and optional) ping-like protocol for `nim-waku` that periodically sends an empty message to connected peers. This a temporary workaround until `libp2p` ping protocol has been implemented, as set out in https://github.com/status-im/nim-libp2p/issues/567. Ping protocol is currently prioritised on the nim-libp2p side, but will likely not be finished before the [planned testnet](https://github.com/status-im/nim-waku/issues/555) for `nim-waku`. Waku v2 dogfooding has also commenced and some `keepalive` mechanism is necessary to maintain stable fleet connections and bridge `toy-chat` messages to Discord.

## How is this different from [the `libp2p` ping protocol](https://docs.libp2p.io/concepts/protocols/#ping)?
It is simpler in at least two ways:
- the keepalive messages do not carry any payload (as opposed to 32-byte ping messages), and
- it does not provide or expect any response. It is therefore simply a best effort to ensure there is minimal activity on open connections.

## Limitations of this approach:
- it is temporary, though implemented in such a way that it can easily be replaced by ping protocol, once available.
- it is not interoperable with non-nim implemenations of Waku. Inter-client `keepalive` will likely only be available once ping protocol is implemented.