### PR TITLE
Mount keepalive on chat2bridge and bridge

### DIFF
--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -95,6 +95,11 @@ proc toMatterbridge(cmb: Chat2MatterBridge, msg: WakuMessage) {.gcsafe.} =
     chat2_mb_dropped.inc(labelValues = ["duplicate"])
     return
 
+  if msg.contentTopic != cmb.contentTopic:
+    # Only bridge messages on the configured content topic
+    chat2_mb_dropped.inc(labelValues = ["filtered"])
+    return
+
   trace "Post chat2 message to Matterbridge"
 
   chat2_mb_transfers.inc(labelValues = ["chat2_to_mb"])
@@ -249,6 +254,8 @@ when isMainModule:
 
   # Now load rest of config
   # Mount configured Waku v2 protocols
+  mountKeepalive(bridge.nodev2)
+
   if conf.store:
     mountStore(bridge.nodev2)
 

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -254,6 +254,8 @@ when isMainModule:
   elif conf.fleetV1 == test: connectToNodes(bridge.nodev1, WhisperNodesTest)
 
   # Mount configured Waku v2 protocols
+  mountKeepalive(bridge.nodev2)
+  
   if conf.store:
     mountStore(bridge.nodev2, persistMessages = false)  # Bridge does not persist messages
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -642,7 +642,10 @@ when isMainModule:
 
   proc startMetricsServer(serverIp: ValidIpAddress, serverPort: Port) =
       info "Starting metrics HTTP server", serverIp, serverPort
+      
       metrics.startHttpServer($serverIp, serverPort)
+
+      info "Metrics HTTP server started", serverIp, serverPort
 
   proc startMetricsLog() =
     # https://github.com/nim-lang/Nim/issues/17369


### PR DESCRIPTION
Mounts new keepalive protocol on `bridge` and `chat2bridge`.

This has now been extensively tested locally and is ready for deployment to `prod`.