### PR TITLE
Persist waku message timestamp & convert receiver timestamp data type to float64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This release contains the following:
 #### General refactoring
 #### Docs
 #### Schema
+- Updates the `Message` table of the persistent message store:
+  - Adds `senderTimestamp` column.
+  - Renames the `timestamp` column to `receiverTimestamp` .
 #### API
 - [JSON-RPC Store API](https://rfc.vac.dev/spec/16): Added an optional time-based query to filter historical messages.
 - [Nim API](https://github.com/status-im/nim-waku/blob/master/docs/api/v2/node.md): Added `resume` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release contains the following:
 #### Schema
 - Updates the `Message` table of the persistent message store:
   - Adds `senderTimestamp` column.
-  - Renames the `timestamp` column to `receiverTimestamp` .
+  - Renames the `timestamp` column to `receiverTimestamp` and changes its type to `BLOB`.
 #### API
 - [JSON-RPC Store API](https://rfc.vac.dev/spec/16): Added an optional time-based query to filter historical messages.
 - [Nim API](https://github.com/status-im/nim-waku/blob/master/docs/api/v2/node.md): Added `resume` method.

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -60,7 +60,6 @@ suite "Message Store":
       t1Flag == true
       t2Flag == true
       t3Flag == true
-
       v0Flag == true
       v1Flag == true
       vMaxFlag == true

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -33,8 +33,7 @@ suite "Message Store":
     var v0Flag, v1Flag, vMaxFlag: bool = false
     var t1Flag, t2Flag, t3Flag: bool = false
     var responseCount = 0
-    proc data(timestamp: uint64, msg: WakuMessage, psTopic: string) =
-      echo $msg
+    proc data(timestamp: float64, msg: WakuMessage, psTopic: string) =
       responseCount += 1
       check msg in msgs
       check psTopic == pubsubTopic

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -56,12 +56,11 @@ suite "Message Store":
     check:
       res.isErr == false
       responseCount == 3
-      # await allFutures(times)
-      t1Flag == true
-      t2Flag == true
-      t3Flag == true
       v0Flag == true
       v1Flag == true
       vMaxFlag == true
+      t1Flag == true
+      t2Flag == true
+      t3Flag == true
 
 

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -30,8 +30,9 @@ suite "Message Store":
     for msg in msgs:
       var index = computeIndex(msg)
       let output = store.put(index, msg, pubsubTopic)
-      indexes.add(index)
       check output.isOk
+      indexes.add(index)
+
 
     # flags for version
     var v0Flag, v1Flag, vMaxFlag: bool = false

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -33,8 +33,11 @@ suite "Message Store":
       indexes.add(index)
       check output.isOk
 
+    # flags for version
     var v0Flag, v1Flag, vMaxFlag: bool = false
+    # flags for sender timestamp
     var t1Flag, t2Flag, t3Flag: bool = false
+    # flags for receiver timestamp
     var rt1Flag, rt2Flag, rt3Flag: bool = false
 
     var responseCount = 0

--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/[unittest, options, tables, sets],
+  std/[unittest, options, tables, sets, times],
   chronos, chronicles,
   ../../waku/v2/node/storage/message/waku_message_store,
   ../../waku/v2/protocol/waku_store/waku_store,
@@ -15,10 +15,13 @@ suite "Message Store":
       topic = ContentTopic("/waku/2/default-content/proto")
       pubsubTopic =  "/waku/2/default-waku/proto"
 
+      t1 = epochTime()
+      t2 = epochTime()
+      t3 = high(float64)
     var msgs = @[
-      WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic, version: uint32(0)),
-      WakuMessage(payload: @[byte 1, 2, 3, 4], contentTopic: topic, version: uint32(1)),
-      WakuMessage(payload: @[byte 1, 2, 3, 4, 5], contentTopic: topic, version: high(uint32)),
+      WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic, version: uint32(0), timestamp: t1),
+      WakuMessage(payload: @[byte 1, 2, 3, 4], contentTopic: topic, version: uint32(1), timestamp: t2),
+      WakuMessage(payload: @[byte 1, 2, 3, 4, 5], contentTopic: topic, version: high(uint32), timestamp: t3),
     ]
 
     defer: store.close()
@@ -28,16 +31,24 @@ suite "Message Store":
       check output.isOk
 
     var v0Flag, v1Flag, vMaxFlag: bool = false
+    var t1Flag, t2Flag, t3Flag: bool = false
     var responseCount = 0
     proc data(timestamp: uint64, msg: WakuMessage, psTopic: string) =
+      echo $msg
       responseCount += 1
       check msg in msgs
       check psTopic == pubsubTopic
+
       # check the correct retrieval of versions
       if msg.version == uint32(0): v0Flag = true
       if msg.version == uint32(1): v1Flag = true
       # high(uint32) is the largest value that fits in uint32, this is to make sure there is no overflow in the storage
       if msg.version == high(uint32): vMaxFlag = true
+
+      # check correct retrieval of timestamps
+      if msg.timestamp == t1: t1Flag = true
+      if msg.timestamp == t2: t2Flag = true
+      if msg.timestamp == t3: t3Flag = true
 
 
     let res = store.getAll(data)
@@ -45,6 +56,11 @@ suite "Message Store":
     check:
       res.isErr == false
       responseCount == 3
+      # await allFutures(times)
+      t1Flag == true
+      t2Flag == true
+      t3Flag == true
+
       v0Flag == true
       v1Flag == true
       vMaxFlag == true

--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -8,7 +8,7 @@ import
 ## retrieve historical messages
 
 type
-  DataProc* = proc(timestamp: uint64, msg: WakuMessage, pubsubTopic: string) {.closure.}
+  DataProc* = proc(timestamp: float64, msg: WakuMessage, pubsubTopic: string) {.closure.}
 
   MessageStoreResult*[T] = Result[T, string]
 

--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -23,6 +23,20 @@ type
   WakuMessageStore* = ref object of MessageStore
     database*: SqliteDatabase
 
+proc toBytes(x: float64): seq[byte] =
+  let xbytes =  cast[array[0..7, byte]](x)
+  return @xbytes
+
+proc fromBytes(T: type float64, bytes: seq[byte]): T =
+  var arr: array[0..7, byte]
+  var i = 0
+  for b in bytes:
+    arr[i] = b
+    i = i+1
+    if i == 8: break
+  let x = cast[float64](arr)
+  return x
+  
 proc init*(T: type WakuMessageStore, db: SqliteDatabase): MessageStoreResult[T] =
   ## Table is the SQL query for creating the messages Table.
   ## It contains:
@@ -36,7 +50,7 @@ proc init*(T: type WakuMessageStore, db: SqliteDatabase): MessageStoreResult[T] 
         pubsubTopic BLOB NOT NULL,
         payload BLOB,
         version INTEGER NOT NULL,
-        senderTimestamp INTEGER NOT NULL
+        senderTimestamp BLOB NOT NULL
     ) WITHOUT ROWID;
     """, NoParams, void)
 
@@ -60,15 +74,15 @@ method put*(db: WakuMessageStore, cursor: Index, message: WakuMessage, pubsubTop
   ##     echo "error"
   ## 
   let prepare = db.database.prepareStmt(
-    "INSERT INTO " & TABLE_TITLE & " (id, receiverTimestamp, contentTopic, payload, pubsubTopic, version, senderTimestamp) VALUES (?, ?, ?, ?, ?, ?);",
-    (seq[byte], int64, seq[byte], seq[byte], seq[byte], int64, int64),
+    "INSERT INTO " & TABLE_TITLE & " (id, receiverTimestamp, contentTopic, payload, pubsubTopic, version, senderTimestamp) VALUES (?, ?, ?, ?, ?, ?, ?);",
+    (seq[byte], int64, seq[byte], seq[byte], seq[byte], int64, seq[byte]),
     void
   )
 
   if prepare.isErr:
     return err("failed to prepare")
 
-  let res = prepare.value.exec((@(cursor.digest.data), int64(cursor.receivedTime), message.contentTopic.toBytes(), message.payload, pubsubTopic.toBytes(), int64(message.version), int64(message.timestamp)))
+  let res = prepare.value.exec((@(cursor.digest.data), int64(cursor.receivedTime), message.contentTopic.toBytes(), message.payload, pubsubTopic.toBytes(), int64(message.version), message.timestamp.toBytes()))
   if res.isErr:
     return err("failed")
 
@@ -98,12 +112,17 @@ method getAll*(db: WakuMessageStore, onData: message_store.DataProc): MessageSto
       pubsubTopic = cast[ptr UncheckedArray[byte]](sqlite3_column_blob(s, 3))
       pubsubTopicL = sqlite3_column_bytes(s,3)
       version = sqlite3_column_int64(s, 4)
-      senderTimestamp = sqlite3_column_int64(s,5)
+      # senderTimestamp = sqlite3_column_double(s,5)
+      senderTimestampPointer = cast[ptr UncheckedArray[byte]](sqlite3_column_blob(s, 5))
+      senderTimestampL = sqlite3_column_bytes(s,5)
+      senderTimestampBytes = @(toOpenArray(senderTimestampPointer, 0, senderTimestampL-1))
+      senderTimestamp = float64.fromBytes(senderTimestampBytes)
 
       # TODO retrieve the version number
     onData(uint64(receiverTimestamp),
            WakuMessage(contentTopic: ContentTopic(string.fromBytes(@(toOpenArray(topic, 0, topicL-1)))),
-                       payload: @(toOpenArray(p, 0, l-1)), version: uint32(version), timestamp: float64(senderTimestamp)), 
+                       payload: @(toOpenArray(p, 0, l-1)), version: uint32(version), 
+                       timestamp: senderTimestamp), 
                        string.fromBytes(@(toOpenArray(pubsubTopic, 0, pubsubTopicL-1))))
 
   let res = db.database.query("SELECT receiverTimestamp, contentTopic, payload, pubsubTopic, version, senderTimestamp FROM " & TABLE_TITLE & " ORDER BY receiverTimestamp ASC", msg)

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -375,7 +375,7 @@ method init*(ws: WakuStore) =
   if ws.store.isNil:
     return
 
-  proc onData(timestamp: uint64, msg: WakuMessage, pubsubTopic:  string) =
+  proc onData(timestamp: float64, msg: WakuMessage, pubsubTopic:  string) =
     # TODO index should not be recalculated
     ws.messages.add(IndexedWakuMessage(msg: msg, index: msg.computeIndex(), pubsubTopic: pubsubTopic))
 


### PR DESCRIPTION
This PR closes https://github.com/status-im/nim-waku/issues/596
- I also sneaked in and fixed an issue regarding the data type of receiver timestamp. This issue is that the db column holding receiver timestamp is set to `INTEGER` type, while timestamp is a `float64` value. Due to this, we would lose data precision during the insertion to  and reading from the db. The type now is changed to `float64` (the db column holds it as a seq of bytes and proper conversion takes place while reading and writing).
- The db column names are updated to better reflect the origin of the timestamps (two types exist, one for the sender and one for the receiver)
