### PR TITLE
Make rln optional (dependencies and compilation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,10 @@ installganache:
 	npm install ganache-cli; npx ganache-cli -p	8540	-g	0	-l	3000000000000&
 
 rlnlib:
+ifdef rlndep
 	cargo build --manifest-path vendor/rln/Cargo.toml
-
+endif
+	
 test2: | build deps installganache
 	echo -e $(BUILD_MSG) "build/$@" && \
 		$(ENV_SCRIPT) nim test2 $(NIM_PARAMS) waku.nims

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ else
 NIM_PARAMS := $(NIM_PARAMS) -d:release
 endif
 
+ifeq ($(RLN), true)
+NIM_PARAMS := $(NIM_PARAMS) -d:rln 
+endif
+
 deps: | deps-common nat-libs waku.nims rlnlib
 ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace
@@ -116,10 +120,12 @@ else
 endif
 
 installganache: 
+ifeq ($(RLN), true)
 	npm install ganache-cli; npx ganache-cli -p	8540	-g	0	-l	3000000000000&
+endif
 
 rlnlib:
-ifdef rlndep
+ifeq ($(RLN), true)
 	cargo build --manifest-path vendor/rln/Cargo.toml
 endif
 	

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -17,7 +17,7 @@ import
   ./v2/test_waku_keepalive
 
 when defined(rln):
-  ./v2/test_waku_rln_relay
+  import ./v2/test_waku_rln_relay
 
 
 # TODO Only enable this once swap module is integrated more nicely as a dependency, i.e. as submodule with CI etc

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -12,10 +12,13 @@ import
   ./v2/test_jsonrpc_waku,
   ./v2/test_peer_manager,
   ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  ./v2/test_waku_rln_relay,
   ./v2/test_waku_bridge,
   ./v2/test_peer_storage,
   ./v2/test_waku_keepalive
+
+when defined(rln):
+  ./v2/test_waku_rln_relay
+
 
 # TODO Only enable this once swap module is integrated more nicely as a dependency, i.e. as submodule with CI etc
 # For PoC execute it manually and run separate module here: https://github.com/vacp2p/swap-contracts-module

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,560 +1,559 @@
-{.used.}
+when defined(rln):
+  {.used.}
 
-import
-  std/options,
-  testutils/unittests, chronos, chronicles, stint, web3,
-  stew/byteutils, stew/shims/net as stewNet,
-  libp2p/crypto/crypto,
-  ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
-  ../../waku/v2/node/wakunode2,
-  ../test_helpers,
-  ./test_utils
-
-# the address of Ethereum client (ganache-cli for now)
-# TODO this address in hardcoded in the code, we may need to take it as input from the user
-const EthClient = "ws://localhost:8540/"
-
-# poseidonHasherCode holds the bytecode of Poseidon hasher solidity smart contract: 
-# https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/crypto/PoseidonHasher.sol 
-# the solidity contract is compiled separately and the resultant bytecode is copied here
-const poseidonHasherCode = readFile("tests/v2/poseidonHasher.txt")
-# membershipContractCode contains the bytecode of the membership solidity smart contract:
-# https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/RLN.sol
-# the solidity contract is compiled separately and the resultant bytecode is copied here
-const membershipContractCode = readFile("tests/v2/membershipContract.txt")
-
-# the membership contract code in solidity
-# uint256 public immutable MEMBERSHIP_DEPOSIT;
-# 	uint256 public immutable DEPTH;
-# 	uint256 public immutable SET_SIZE;
-# 	uint256 public pubkeyIndex = 0;
-# 	mapping(uint256 => uint256) public members;
-# 	IPoseidonHasher public poseidonHasher;
-
-# 	event MemberRegistered(uint256 indexed pubkey, uint256 indexed index);
-# 	event MemberWithdrawn(uint256 indexed pubkey, uint256 indexed index);
-
-# 	constructor(
-# 		uint256 membershipDeposit,
-# 		uint256 depth,
-# 		address _poseidonHasher
-# 	) public {
-# 		MEMBERSHIP_DEPOSIT = membershipDeposit;
-# 		DEPTH = depth;
-# 		SET_SIZE = 1 << depth;
-# 		poseidonHasher = IPoseidonHasher(_poseidonHasher);
-# 	}
-
-# 	function register(uint256 pubkey) external payable {
-# 		require(pubkeyIndex < SET_SIZE, "RLN, register: set is full");
-# 		require(msg.value == MEMBERSHIP_DEPOSIT, "RLN, register: membership deposit is not satisfied");
-# 		_register(pubkey);
-# 	}
-
-# 	function registerBatch(uint256[] calldata pubkeys) external payable {
-# 		require(pubkeyIndex + pubkeys.length <= SET_SIZE, "RLN, registerBatch: set is full");
-# 		require(msg.value == MEMBERSHIP_DEPOSIT * pubkeys.length, "RLN, registerBatch: membership deposit is not satisfied");
-# 		for (uint256 i = 0; i < pubkeys.length; i++) {
-# 			_register(pubkeys[i]);
-# 		}
-# 	}
-
-# 	function withdrawBatch(
-# 		uint256[] calldata secrets,
-# 		uint256[] calldata pubkeyIndexes,
-# 		address payable[] calldata receivers
-# 	) external {
-# 		uint256 batchSize = secrets.length;
-# 		require(batchSize != 0, "RLN, withdrawBatch: batch size zero");
-# 		require(batchSize == pubkeyIndexes.length, "RLN, withdrawBatch: batch size mismatch pubkey indexes");
-# 		require(batchSize == receivers.length, "RLN, withdrawBatch: batch size mismatch receivers");
-# 		for (uint256 i = 0; i < batchSize; i++) {
-# 			_withdraw(secrets[i], pubkeyIndexes[i], receivers[i]);
-# 		}
-# 	}
-
-# 	function withdraw(
-# 		uint256 secret,
-# 		uint256 _pubkeyIndex,
-# 		address payable receiver
-# 	) external {
-# 		_withdraw(secret, _pubkeyIndex, receiver);
-# 	}
-
-contract(MembershipContract):
-  proc register(pubkey: Uint256) # external payable
-  # proc registerBatch(pubkeys: seq[Uint256]) # external payable
-  # TODO will add withdraw function after integrating the keyGeneration function (required to compute public keys from secret keys)
-  # proc withdraw(secret: Uint256, pubkeyIndex: Uint256, receiver: Address)
-  # proc withdrawBatch( secrets: seq[Uint256], pubkeyIndex: seq[Uint256], receiver: seq[Address])
-
-proc uploadContract(ethClientAddress: string): Future[Address] {.async.} =
-  let web3 = await newWeb3(ethClientAddress)
-  debug "web3 connected to", ethClientAddress
-
-  # fetch the list of registered accounts
-  let accounts = await web3.provider.eth_accounts()
-  web3.defaultAccount = accounts[1]
-  let add =web3.defaultAccount 
-  debug "contract deployer account address ", add
-
-  var balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-  debug "Initial account balance: ", balance
-
-  # deploy the poseidon hash first
-  let 
-    hasherReceipt = await web3.deployContract(poseidonHasherCode)
-    hasherAddress = hasherReceipt.contractAddress.get
-  debug "hasher address: ", hasherAddress
-  
-
-  # encode membership contract inputs to 32 bytes zero-padded
-  let 
-    membershipFeeEncoded = encode(MembershipFee).data 
-    depthEncoded = encode(Depth).data 
-    hasherAddressEncoded = encode(hasherAddress).data
-    # this is the contract constructor input
-    contractInput = membershipFeeEncoded & depthEncoded & hasherAddressEncoded
+  import
+    std/options,
+    testutils/unittests, chronos, chronicles, stint, web3,
+    stew/byteutils, stew/shims/net as stewNet,
+    libp2p/crypto/crypto,
+    ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
+    ../../waku/v2/node/wakunode2,
+    ../test_helpers,
+    ./test_utils
 
 
-  debug "encoded membership fee: ", membershipFeeEncoded
-  debug "encoded depth: ", depthEncoded
-  debug "encoded hasher address: ", hasherAddressEncoded
-  debug "encoded contract input:" , contractInput
+  # the address of Ethereum client (ganache-cli for now)
+  # TODO this address in hardcoded in the code, we may need to take it as input from the user
+  const EthClient = "ws://localhost:8540/"
 
-  # deploy membership contract with its constructor inputs
-  let receipt = await web3.deployContract(membershipContractCode, contractInput = contractInput)
-  var contractAddress = receipt.contractAddress.get
-  debug "Address of the deployed membership contract: ", contractAddress
+  # poseidonHasherCode holds the bytecode of Poseidon hasher solidity smart contract: 
+  # https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/crypto/PoseidonHasher.sol 
+  # the solidity contract is compiled separately and the resultant bytecode is copied here
+  const poseidonHasherCode = readFile("tests/v2/poseidonHasher.txt")
+  # membershipContractCode contains the bytecode of the membership solidity smart contract:
+  # https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/RLN.sol
+  # the solidity contract is compiled separately and the resultant bytecode is copied here
+  const membershipContractCode = readFile("tests/v2/membershipContract.txt")
 
-  # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-  # debug "Account balance after the contract deployment: ", balance
+  # the membership contract code in solidity
+  # uint256 public immutable MEMBERSHIP_DEPOSIT;
+  # 	uint256 public immutable DEPTH;
+  # 	uint256 public immutable SET_SIZE;
+  # 	uint256 public pubkeyIndex = 0;
+  # 	mapping(uint256 => uint256) public members;
+  # 	IPoseidonHasher public poseidonHasher;
 
-  await web3.close()
-  debug "disconnected from ", ethClientAddress
+  # 	event MemberRegistered(uint256 indexed pubkey, uint256 indexed index);
+  # 	event MemberWithdrawn(uint256 indexed pubkey, uint256 indexed index);
 
-  return contractAddress
+  # 	constructor(
+  # 		uint256 membershipDeposit,
+  # 		uint256 depth,
+  # 		address _poseidonHasher
+  # 	) public {
+  # 		MEMBERSHIP_DEPOSIT = membershipDeposit;
+  # 		DEPTH = depth;
+  # 		SET_SIZE = 1 << depth;
+  # 		poseidonHasher = IPoseidonHasher(_poseidonHasher);
+  # 	}
 
-procSuite "Waku rln relay":
-  asyncTest  "contract membership":
-    let contractAddress = await uploadContract(EthClient)
-    # connect to the eth client
-    let web3 = await newWeb3(EthClient)
-    debug "web3 connected to", EthClient
+  # 	function register(uint256 pubkey) external payable {
+  # 		require(pubkeyIndex < SET_SIZE, "RLN, register: set is full");
+  # 		require(msg.value == MEMBERSHIP_DEPOSIT, "RLN, register: membership deposit is not satisfied");
+  # 		_register(pubkey);
+  # 	}
+
+  # 	function registerBatch(uint256[] calldata pubkeys) external payable {
+  # 		require(pubkeyIndex + pubkeys.length <= SET_SIZE, "RLN, registerBatch: set is full");
+  # 		require(msg.value == MEMBERSHIP_DEPOSIT * pubkeys.length, "RLN, registerBatch: membership deposit is not satisfied");
+  # 		for (uint256 i = 0; i < pubkeys.length; i++) {
+  # 			_register(pubkeys[i]);
+  # 		}
+  # 	}
+
+  # 	function withdrawBatch(
+  # 		uint256[] calldata secrets,
+  # 		uint256[] calldata pubkeyIndexes,
+  # 		address payable[] calldata receivers
+  # 	) external {
+  # 		uint256 batchSize = secrets.length;
+  # 		require(batchSize != 0, "RLN, withdrawBatch: batch size zero");
+  # 		require(batchSize == pubkeyIndexes.length, "RLN, withdrawBatch: batch size mismatch pubkey indexes");
+  # 		require(batchSize == receivers.length, "RLN, withdrawBatch: batch size mismatch receivers");
+  # 		for (uint256 i = 0; i < batchSize; i++) {
+  # 			_withdraw(secrets[i], pubkeyIndexes[i], receivers[i]);
+  # 		}
+  # 	}
+
+  # 	function withdraw(
+  # 		uint256 secret,
+  # 		uint256 _pubkeyIndex,
+  # 		address payable receiver
+  # 	) external {
+  # 		_withdraw(secret, _pubkeyIndex, receiver);
+  # 	}
+
+  contract(MembershipContract):
+    proc register(pubkey: Uint256) # external payable
+    # proc registerBatch(pubkeys: seq[Uint256]) # external payable
+    # TODO will add withdraw function after integrating the keyGeneration function (required to compute public keys from secret keys)
+    # proc withdraw(secret: Uint256, pubkeyIndex: Uint256, receiver: Address)
+    # proc withdrawBatch( secrets: seq[Uint256], pubkeyIndex: seq[Uint256], receiver: seq[Address])
+
+  proc uploadContract(ethClientAddress: string): Future[Address] {.async.} =
+    let web3 = await newWeb3(ethClientAddress)
+    debug "web3 connected to", ethClientAddress
 
     # fetch the list of registered accounts
     let accounts = await web3.provider.eth_accounts()
     web3.defaultAccount = accounts[1]
-    let add = web3.defaultAccount 
+    let add =web3.defaultAccount 
     debug "contract deployer account address ", add
 
-    # prepare a contract sender to interact with it
-    var sender = web3.contractSender(MembershipContract, contractAddress) # creates a Sender object with a web3 field and contract address of type Address
+    var balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
+    debug "Initial account balance: ", balance
 
-    # send takes three parameters, c: ContractCallBase, value = 0.u256, gas = 3000000'u64 gasPrice = 0 
-    # should use send proc for the contract functions that update the state of the contract
-    let tx = await sender.register(20.u256).send(value = MembershipFee)
-    debug "The hash of registration tx: ", tx # value is the membership fee
+    # deploy the poseidon hash first
+    let 
+      hasherReceipt = await web3.deployContract(poseidonHasherCode)
+      hasherAddress = hasherReceipt.contractAddress.get
+    debug "hasher address: ", hasherAddress
+    
 
-    # var members: array[2, uint256] = [20.u256, 21.u256]
-    # debug "This is the batch registration result ", await sender.registerBatch(members).send(value = (members.len * membershipFee)) # value is the membership fee
+    # encode membership contract inputs to 32 bytes zero-padded
+    let 
+      membershipFeeEncoded = encode(MembershipFee).data 
+      depthEncoded = encode(Depth).data 
+      hasherAddressEncoded = encode(hasherAddress).data
+      # this is the contract constructor input
+      contractInput = membershipFeeEncoded & depthEncoded & hasherAddressEncoded
+
+
+    debug "encoded membership fee: ", membershipFeeEncoded
+    debug "encoded depth: ", depthEncoded
+    debug "encoded hasher address: ", hasherAddressEncoded
+    debug "encoded contract input:" , contractInput
+
+    # deploy membership contract with its constructor inputs
+    let receipt = await web3.deployContract(membershipContractCode, contractInput = contractInput)
+    var contractAddress = receipt.contractAddress.get
+    debug "Address of the deployed membership contract: ", contractAddress
 
     # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-    # debug "Balance after registration: ", balance
+    # debug "Account balance after the contract deployment: ", balance
 
     await web3.close()
-    debug "disconnected from", EthClient
+    debug "disconnected from ", ethClientAddress
 
-  asyncTest "registration procedure":
-    # deploy the contract
-    let contractAddress = await uploadContract(EthClient)
+    return contractAddress
 
-    # prepare rln-relay peer inputs
-    let 
-      web3 = await newWeb3(EthClient)
-      accounts = await web3.provider.eth_accounts()
-      # choose one of the existing accounts for the rln-relay peer  
-      ethAccountAddress = accounts[9]
-    await web3.close()
+  procSuite "Waku rln relay":
+    asyncTest  "contract membership":
+      let contractAddress = await uploadContract(EthClient)
+      # connect to the eth client
+      let web3 = await newWeb3(EthClient)
+      debug "web3 connected to", EthClient
 
-    # create an RLN instance
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+      # fetch the list of registered accounts
+      let accounts = await web3.provider.eth_accounts()
+      web3.defaultAccount = accounts[1]
+      let add = web3.defaultAccount 
+      debug "contract deployer account address ", add
 
-    # generate the membership keys
-    let membershipKeyPair = membershipKeyGen(ctxPtr)
-    
-    check:
-      membershipKeyPair.isSome
+      # prepare a contract sender to interact with it
+      var sender = web3.contractSender(MembershipContract, contractAddress) # creates a Sender object with a web3 field and contract address of type Address
 
-    # initialize the WakuRLNRelay 
-    var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
-      ethClientAddress: EthClient,
-      ethAccountAddress: ethAccountAddress,
-      membershipContractAddress: contractAddress)
-    
-    # register the rln-relay peer to the membership contract
-    let is_successful = await rlnPeer.register()
-    check:
-      is_successful
-  asyncTest "mounting waku rln relay":
-    let
-      nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
-        Port(60000))
-    await node.start()
+      # send takes three parameters, c: ContractCallBase, value = 0.u256, gas = 3000000'u64 gasPrice = 0 
+      # should use send proc for the contract functions that update the state of the contract
+      let tx = await sender.register(20.u256).send(value = MembershipFee)
+      debug "The hash of registration tx: ", tx # value is the membership fee
 
-    # deploy the contract
-    let membershipContractAddress = await uploadContract(EthClient)
+      # var members: array[2, uint256] = [20.u256, 21.u256]
+      # debug "This is the batch registration result ", await sender.registerBatch(members).send(value = (members.len * membershipFee)) # value is the membership fee
 
-    # prepare rln-relay inputs
-    let 
-      web3 = await newWeb3(EthClient)
-      accounts = await web3.provider.eth_accounts()
-      # choose one of the existing account for the rln-relay peer  
-      ethAccountAddress = accounts[9]
-    await web3.close()
+      # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
+      # debug "Balance after registration: ", balance
 
-    # start rln-relay
-    await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
+      await web3.close()
+      debug "disconnected from", EthClient
 
-    await node.stop()
+    asyncTest "registration procedure":
+      # deploy the contract
+      let contractAddress = await uploadContract(EthClient)
 
+      # prepare rln-relay peer inputs
+      let 
+        web3 = await newWeb3(EthClient)
+        accounts = await web3.provider.eth_accounts()
+        # choose one of the existing accounts for the rln-relay peer  
+        ethAccountAddress = accounts[9]
+      await web3.close()
 
-suite "Waku rln relay":
-  test "key_gen Nim Wrappers":
-    var 
-      merkleDepth: csize_t = 32
-      # parameters.key contains the parameters related to the Poseidon hasher
-      # to generate this file, clone this repo https://github.com/kilic/rln 
-      # and run the following command in the root directory of the cloned project
-      # cargo run --example export_test_keys
-      # the file is generated separately and copied here
-      parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-      pbytes = parameters.toBytes()
-      len : csize_t = uint(pbytes.len)
-      parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
-    check:
-      # check the parameters.key is not empty
-      pbytes.len != 0
+      # create an RLN instance
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    # ctx holds the information that is going to be used for  the key generation
-    var 
-      obj = RLN[Bn256]()
-      objPtr = addr(obj)
-      objptrptr = addr(objPtr)
-      ctx = objptrptr
-    let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctx)
-    check:
-      # check whether the circuit parameters are generated successfully
-      res == true
-
-    # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
-    var 
-      keysBuffer : Buffer
-      keysBufferPtr = addr(keysBuffer)
-      done = key_gen(ctx[], keysBufferPtr) 
-    check:
-      # check whether the keys are generated successfully
-      done == true
-
-    if done:
-      var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
+      # generate the membership keys
+      let membershipKeyPair = membershipKeyGen(ctxPtr)
+      
       check:
-        # the public and secret keys together are 64 bytes
-        generatedKeys.len == 64
-      debug "generated keys: ", generatedKeys 
+        membershipKeyPair.isSome
+
+      # initialize the WakuRLNRelay 
+      var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
+        ethClientAddress: EthClient,
+        ethAccountAddress: ethAccountAddress,
+        membershipContractAddress: contractAddress)
       
-  test "membership Key Gen":
-    # create an RLN instance
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+      # register the rln-relay peer to the membership contract
+      let is_successful = await rlnPeer.register()
+      check:
+        is_successful
+    asyncTest "mounting waku rln relay":
+      let
+        nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+        node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
+          Port(60000))
+      await node.start()
 
-    var key = membershipKeyGen(ctxPtr)
-    var empty : array[32,byte]
-    check:
-      key.isSome
-      key.get().secretKey.len == 32
-      key.get().publicKey.len == 32
-      key.get().secretKey != empty
-      key.get().publicKey != empty
-    
-    debug "the generated membership key pair: ", key 
-  
-  test "get_root Nim binding":
-    # create an RLN instance which also includes an empty Merkle tree
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+      # deploy the contract
+      let membershipContractAddress = await uploadContract(EthClient)
 
-    # read the Merkle Tree root
-    var 
-      root1 {.noinit.} : Buffer = Buffer()
-      rootPtr1 = addr(root1)
-      get_root_successful1 = get_root(ctxPtr, rootPtr1)
-    doAssert(get_root_successful1)
-    doAssert(root1.len == 32)
+      # prepare rln-relay inputs
+      let 
+        web3 = await newWeb3(EthClient)
+        accounts = await web3.provider.eth_accounts()
+        # choose one of the existing account for the rln-relay peer  
+        ethAccountAddress = accounts[9]
+      await web3.close()
 
-    # read the Merkle Tree root
-    var 
-      root2 {.noinit.} : Buffer = Buffer()
-      rootPtr2 = addr(root2)
-      get_root_successful2 = get_root(ctxPtr, rootPtr2)
-    doAssert(get_root_successful2)
-    doAssert(root2.len == 32)
+      # start rln-relay
+      await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
-    var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
-    let rootHex1 = rootValue1[].toHex
+      await node.stop()
 
-    var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
-    let rootHex2 = rootValue2[].toHex
 
-    # the two roots must be identical
-    doAssert(rootHex1 == rootHex2)
+  suite "Waku rln relay":
+    test "key_gen Nim Wrappers":
+      var 
+        merkleDepth: csize_t = 32
+        # parameters.key contains the parameters related to the Poseidon hasher
+        # to generate this file, clone this repo https://github.com/kilic/rln 
+        # and run the following command in the root directory of the cloned project
+        # cargo run --example export_test_keys
+        # the file is generated separately and copied here
+        parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+        pbytes = parameters.toBytes()
+        len : csize_t = uint(pbytes.len)
+        parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
+      check:
+        # check the parameters.key is not empty
+        pbytes.len != 0
 
-  test "update_next_member Nim Wrapper":
-    # create an RLN instance which also includes an empty Merkle tree
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+      # ctx holds the information that is going to be used for  the key generation
+      var 
+        obj = RLN[Bn256]()
+        objPtr = addr(obj)
+        objptrptr = addr(objPtr)
+        ctx = objptrptr
+      let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctx)
+      check:
+        # check whether the circuit parameters are generated successfully
+        res == true
 
-    # generate a key pair
-    var keypair = membershipKeyGen(ctxPtr)
-    doAssert(keypair.isSome())
-    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
-    let pkBufferPtr = addr pkBuffer
+      # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
+      var 
+        keysBuffer : Buffer
+        keysBufferPtr = addr(keysBuffer)
+        done = key_gen(ctx[], keysBufferPtr) 
+      check:
+        # check whether the keys are generated successfully
+        done == true
 
-    # add the member to the tree
-    var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
-    check:
-      member_is_added == true
+      if done:
+        var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
+        check:
+          # the public and secret keys together are 64 bytes
+          generatedKeys.len == 64
+        debug "generated keys: ", generatedKeys 
       
-  test "delete_member Nim wrapper":
-    # create an RLN instance which also includes an empty Merkle tree
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+    test "membership Key Gen":
+      # create an RLN instance
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    # delete the first member 
-    var deleted_member_index = uint(0)
-    let deletion_success = delete_member(ctxPtr, deleted_member_index)
-    doAssert(deletion_success)
+      var key = membershipKeyGen(ctxPtr)
+      var empty : array[32,byte]
+      check:
+        key.isSome
+        key.get().secretKey.len == 32
+        key.get().publicKey.len == 32
+        key.get().secretKey != empty
+        key.get().publicKey != empty
+      
+      debug "the generated membership key pair: ", key 
   
-  test "Merkle tree consistency check between deletion and insertion":
-    # create an RLN instance
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(32, ctxPtr))
+    test "get_root Nim binding":
+      # create an RLN instance which also includes an empty Merkle tree
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    # read the Merkle Tree root
-    var 
-      root1 {.noinit.} : Buffer = Buffer()
-      rootPtr1 = addr(root1)
-      get_root_successful1 = get_root(ctxPtr, rootPtr1)
-    doAssert(get_root_successful1)
-    doAssert(root1.len == 32)
-    
-    # generate a key pair
-    var keypair = membershipKeyGen(ctxPtr)
-    doAssert(keypair.isSome())
-    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
-    let pkBufferPtr = addr pkBuffer
+      # read the Merkle Tree root
+      var 
+        root1 {.noinit.} : Buffer = Buffer()
+        rootPtr1 = addr(root1)
+        get_root_successful1 = get_root(ctxPtr, rootPtr1)
+      doAssert(get_root_successful1)
+      doAssert(root1.len == 32)
 
-    # add the member to the tree
-    var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
-    doAssert(member_is_added)
+      # read the Merkle Tree root
+      var 
+        root2 {.noinit.} : Buffer = Buffer()
+        rootPtr2 = addr(root2)
+        get_root_successful2 = get_root(ctxPtr, rootPtr2)
+      doAssert(get_root_successful2)
+      doAssert(root2.len == 32)
 
-    # read the Merkle Tree root after insertion
-    var 
-      root2 {.noinit.} : Buffer = Buffer()
-      rootPtr2 = addr(root2)
-      get_root_successful2 = get_root(ctxPtr, rootPtr2)
-    doAssert(get_root_successful2)
-    doAssert(root2.len == 32)
+      var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
+      let rootHex1 = rootValue1[].toHex
 
-    # delete the first member 
-    var deleted_member_index = uint(0)
-    let deletion_success = delete_member(ctxPtr, deleted_member_index)
-    doAssert(deletion_success)
+      var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
+      let rootHex2 = rootValue2[].toHex
 
-    # read the Merkle Tree root after the deletion
-    var 
-      root3 {.noinit.} : Buffer = Buffer()
-      rootPtr3 = addr(root3)
-      get_root_successful3 = get_root(ctxPtr, rootPtr3)
-    doAssert(get_root_successful3)
-    doAssert(root3.len == 32)
+      # the two roots must be identical
+      doAssert(rootHex1 == rootHex2)
 
-    var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
-    let rootHex1 = rootValue1[].toHex
-    debug "The initial root", rootHex1
+    test "update_next_member Nim Wrapper":
+      # create an RLN instance which also includes an empty Merkle tree
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
-    let rootHex2 = rootValue2[].toHex
-    debug "The root after insertion", rootHex2
+      # generate a key pair
+      var keypair = membershipKeyGen(ctxPtr)
+      doAssert(keypair.isSome())
+      var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+      let pkBufferPtr = addr pkBuffer
 
-    var rootValue3 = cast[ptr array[32,byte]] (root3.`ptr`)
-    let rootHex3 = rootValue3[].toHex
-    debug "The root after deletion", rootHex3
+      # add the member to the tree
+      var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
+      check:
+        member_is_added == true
+      
+    test "delete_member Nim wrapper":
+      # create an RLN instance which also includes an empty Merkle tree
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    # the root must change after the insertion
-    doAssert(not(rootHex1 == rootHex2))
+      # delete the first member 
+      var deleted_member_index = uint(0)
+      let deletion_success = delete_member(ctxPtr, deleted_member_index)
+      doAssert(deletion_success)
+  
+    test "Merkle tree consistency check between deletion and insertion":
+      # create an RLN instance
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(32, ctxPtr))
 
-    ## The initial root of the tree (empty tree) must be identical to 
-    ## the root of the tree after one insertion followed by a deletion
-    doAssert(rootHex1 == rootHex3)
-  test "hash Nim Wrappers":
-    # create an RLN instance
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-    doAssert(createRLNInstance(30, ctxPtr))
+      # read the Merkle Tree root
+      var 
+        root1 {.noinit.} : Buffer = Buffer()
+        rootPtr1 = addr(root1)
+        get_root_successful1 = get_root(ctxPtr, rootPtr1)
+      doAssert(get_root_successful1)
+      doAssert(root1.len == 32)
+      
+      # generate a key pair
+      var keypair = membershipKeyGen(ctxPtr)
+      doAssert(keypair.isSome())
+      var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+      let pkBufferPtr = addr pkBuffer
 
-    # prepare the input
-    var
-      hashInput : array[32, byte]
-    for x in hashInput.mitems: x= 1
-    var 
-      hashInputHex = hashInput.toHex()
-      hashInputBuffer = Buffer(`ptr`: addr hashInput[0], len: 32 ) 
-
-    debug "sample_hash_input_bytes", hashInputHex
-
-    # prepare other inputs to the hash function
-    var 
-      outputBuffer: Buffer
-      numOfInputs = 1.uint # the number of hash inputs that can be 1 or 2
-    
-    let hashSuccess = hash(ctxPtr, addr hashInputBuffer, numOfInputs, addr outputBuffer)
-    doAssert(hashSuccess)
-    let outputArr = cast[ptr array[32,byte]](outputBuffer.`ptr`)[]
-    doAssert("53a6338cdbf02f0563cec1898e354d0d272c8f98b606c538945c6f41ef101828" == outputArr.toHex())
-
-    var 
-      hashOutput = cast[ptr array[32,byte]] (outputBuffer.`ptr`)[]
-      hashOutputHex = hashOutput.toHex()
-
-    debug "hash output", hashOutputHex
-
-  test "generate_proof and verify Nim Wrappers":
-    # create an RLN instance
-    var 
-      ctx = RLN[Bn256]()
-      ctxPtr = addr(ctx)
-
-    # check if the rln instance is created successfully 
-    doAssert(createRLNInstance(32, ctxPtr))
-
-    # create the membership key
-    var auth = membershipKeyGen(ctxPtr)
-    var skBuffer = Buffer(`ptr`: addr(auth.get().secretKey[0]), len: 32)
-
-    # peer's index in the Merkle Tree
-    var index = 5
-
-    # prepare the authentication object with peer's index and sk
-    var authObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(index))
-
-    # Create a Merkle tree with random members 
-    for i in 0..10:
-      var member_is_added: bool = false
-      if (i == index):
-        #  insert the current peer's pk
-        var pkBuffer = Buffer(`ptr`: addr(auth.get().publicKey[0]), len: 32)
-        member_is_added = update_next_member(ctxPtr, addr pkBuffer)
-      else:
-        var memberKeys = membershipKeyGen(ctxPtr)
-        var pkBuffer = Buffer(`ptr`: addr(memberKeys.get().publicKey[0]), len: 32)
-        member_is_added = update_next_member(ctxPtr, addr pkBuffer)
-      # check the member is added
+      # add the member to the tree
+      var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
       doAssert(member_is_added)
 
-    # prepare the message
-    var messageBytes {.noinit.}: array[32, byte]
-    for x in messageBytes.mitems: x = 1
-    var messageHex = messageBytes.toHex()
-    debug "message", messageHex
+      # read the Merkle Tree root after insertion
+      var 
+        root2 {.noinit.} : Buffer = Buffer()
+        rootPtr2 = addr(root2)
+        get_root_successful2 = get_root(ctxPtr, rootPtr2)
+      doAssert(get_root_successful2)
+      doAssert(root2.len == 32)
 
-    # prepare the epoch
-    var  epochBytes : array[32,byte]
-    for x in epochBytes.mitems : x = 0
-    var epochHex = epochBytes.toHex()
-    debug "epoch in bytes", epochHex
+      # delete the first member 
+      var deleted_member_index = uint(0)
+      let deletion_success = delete_member(ctxPtr, deleted_member_index)
+      doAssert(deletion_success)
+
+      # read the Merkle Tree root after the deletion
+      var 
+        root3 {.noinit.} : Buffer = Buffer()
+        rootPtr3 = addr(root3)
+        get_root_successful3 = get_root(ctxPtr, rootPtr3)
+      doAssert(get_root_successful3)
+      doAssert(root3.len == 32)
+
+      var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
+      let rootHex1 = rootValue1[].toHex
+      debug "The initial root", rootHex1
+
+      var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
+      let rootHex2 = rootValue2[].toHex
+      debug "The root after insertion", rootHex2
+
+      var rootValue3 = cast[ptr array[32,byte]] (root3.`ptr`)
+      let rootHex3 = rootValue3[].toHex
+      debug "The root after deletion", rootHex3
+
+      # the root must change after the insertion
+      doAssert(not(rootHex1 == rootHex2))
+
+      ## The initial root of the tree (empty tree) must be identical to 
+      ## the root of the tree after one insertion followed by a deletion
+      doAssert(rootHex1 == rootHex3)
+    test "hash Nim Wrappers":
+      # create an RLN instance
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+      doAssert(createRLNInstance(30, ctxPtr))
+
+      # prepare the input
+      var
+        hashInput : array[32, byte]
+      for x in hashInput.mitems: x= 1
+      var 
+        hashInputHex = hashInput.toHex()
+        hashInputBuffer = Buffer(`ptr`: addr hashInput[0], len: 32 ) 
+
+      debug "sample_hash_input_bytes", hashInputHex
+
+      # prepare other inputs to the hash function
+      var 
+        outputBuffer: Buffer
+        numOfInputs = 1.uint # the number of hash inputs that can be 1 or 2
+      
+      let hashSuccess = hash(ctxPtr, addr hashInputBuffer, numOfInputs, addr outputBuffer)
+      doAssert(hashSuccess)
+      let outputArr = cast[ptr array[32,byte]](outputBuffer.`ptr`)[]
+      doAssert("53a6338cdbf02f0563cec1898e354d0d272c8f98b606c538945c6f41ef101828" == outputArr.toHex())
+
+      var 
+        hashOutput = cast[ptr array[32,byte]] (outputBuffer.`ptr`)[]
+        hashOutputHex = hashOutput.toHex()
+
+      debug "hash output", hashOutputHex
+
+    test "generate_proof and verify Nim Wrappers":
+      # create an RLN instance
+      var 
+        ctx = RLN[Bn256]()
+        ctxPtr = addr(ctx)
+
+      # check if the rln instance is created successfully 
+      doAssert(createRLNInstance(32, ctxPtr))
+
+      # create the membership key
+      var auth = membershipKeyGen(ctxPtr)
+      var skBuffer = Buffer(`ptr`: addr(auth.get().secretKey[0]), len: 32)
+
+      # peer's index in the Merkle Tree
+      var index = 5
+
+      # prepare the authentication object with peer's index and sk
+      var authObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(index))
+
+      # Create a Merkle tree with random members 
+      for i in 0..10:
+        var member_is_added: bool = false
+        if (i == index):
+          #  insert the current peer's pk
+          var pkBuffer = Buffer(`ptr`: addr(auth.get().publicKey[0]), len: 32)
+          member_is_added = update_next_member(ctxPtr, addr pkBuffer)
+        else:
+          var memberKeys = membershipKeyGen(ctxPtr)
+          var pkBuffer = Buffer(`ptr`: addr(memberKeys.get().publicKey[0]), len: 32)
+          member_is_added = update_next_member(ctxPtr, addr pkBuffer)
+        # check the member is added
+        doAssert(member_is_added)
+
+      # prepare the message
+      var messageBytes {.noinit.}: array[32, byte]
+      for x in messageBytes.mitems: x = 1
+      var messageHex = messageBytes.toHex()
+      debug "message", messageHex
+
+      # prepare the epoch
+      var  epochBytes : array[32,byte]
+      for x in epochBytes.mitems : x = 0
+      var epochHex = epochBytes.toHex()
+      debug "epoch in bytes", epochHex
 
 
-    # serialize message and epoch 
-    # TODO add a proc for serializing
-    var epochMessage = @epochBytes & @messageBytes
-    doAssert(epochMessage.len == 64)
-    var inputBytes{.noinit.}: array[64, byte] # holds epoch||Message 
-    for (i, x) in inputBytes.mpairs: x = epochMessage[i]
-    var inputHex = inputBytes.toHex()
-    debug "serialized epoch and message ", inputHex
-    # put the serialized epoch||message into a buffer
-    var inputBuffer = Buffer(`ptr`: addr(inputBytes[0]), len: 64)
+      # serialize message and epoch 
+      # TODO add a proc for serializing
+      var epochMessage = @epochBytes & @messageBytes
+      doAssert(epochMessage.len == 64)
+      var inputBytes{.noinit.}: array[64, byte] # holds epoch||Message 
+      for (i, x) in inputBytes.mpairs: x = epochMessage[i]
+      var inputHex = inputBytes.toHex()
+      debug "serialized epoch and message ", inputHex
+      # put the serialized epoch||message into a buffer
+      var inputBuffer = Buffer(`ptr`: addr(inputBytes[0]), len: 64)
 
-    # generate the proof
-    var proof: Buffer
-    let proofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr authObj, addr proof)
-    # check whether the generate_proof call is done successfully
-    doAssert(proofIsSuccessful)
-    var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
-    let proofHex = proofValue[].toHex
-    debug "proof content", proofHex
+      # generate the proof
+      var proof: Buffer
+      let proofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr authObj, addr proof)
+      # check whether the generate_proof call is done successfully
+      doAssert(proofIsSuccessful)
+      var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
+      let proofHex = proofValue[].toHex
+      debug "proof content", proofHex
 
-    # display the proof breakdown
-    var 
-      zkSNARK = proofHex[0..511]
-      proofRoot = proofHex[512..575] 
-      proofEpoch = proofHex[576..639]
-      shareX = proofHex[640..703]
-      shareY = proofHex[704..767]
-      nullifier = proofHex[768..831]
+      # display the proof breakdown
+      var 
+        zkSNARK = proofHex[0..511]
+        proofRoot = proofHex[512..575] 
+        proofEpoch = proofHex[576..639]
+        shareX = proofHex[640..703]
+        shareY = proofHex[704..767]
+        nullifier = proofHex[768..831]
 
-    doAssert(zkSNARK.len == 512)
-    doAssert(proofRoot.len == 64)
-    doAssert(proofEpoch.len == 64)
-    doAssert(epochHex == proofEpoch)
-    doAssert(shareX.len == 64)
-    doAssert(shareY.len == 64)
-    doAssert(nullifier.len == 64)
+      doAssert(zkSNARK.len == 512)
+      doAssert(proofRoot.len == 64)
+      doAssert(proofEpoch.len == 64)
+      doAssert(epochHex == proofEpoch)
+      doAssert(shareX.len == 64)
+      doAssert(shareY.len == 64)
+      doAssert(nullifier.len == 64)
 
-    debug "zkSNARK ", zkSNARK
-    debug "root ", proofRoot
-    debug "epoch ", proofEpoch
-    debug "shareX", shareX
-    debug "shareY", shareY
-    debug "nullifier", nullifier
+      debug "zkSNARK ", zkSNARK
+      debug "root ", proofRoot
+      debug "epoch ", proofEpoch
+      debug "shareX", shareX
+      debug "shareY", shareY
+      debug "nullifier", nullifier
 
+      var f = 0.uint32
+      let verifyIsSuccessful = verify(ctxPtr, addr proof, addr f)
+      doAssert(verifyIsSuccessful)
+      # f = 0 means the proof is verified
+      doAssert(f == 0)
 
-    var f = 0.uint32
-    let verifyIsSuccessful = verify(ctxPtr, addr proof, addr f)
-    doAssert(verifyIsSuccessful)
-    # f = 0 means the proof is verified
-    doAssert(f == 0)
+      # create and test a bad proof
+      # prepare a bad authentication object with a wrong peer's index
+      var badIndex = 8
+      var badAuthObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(badIndex))
+      var badProof: Buffer
+      let badProofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr badAuthObj, addr badProof)
+      # check whether the generate_proof call is done successfully
+      doAssert(badProofIsSuccessful)
 
-
-
-    # create and test a bad proof
-    # prepare a bad authentication object with a wrong peer's index
-    var badIndex = 8
-    var badAuthObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(badIndex))
-    var badProof: Buffer
-    let badProofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr badAuthObj, addr badProof)
-    # check whether the generate_proof call is done successfully
-    doAssert(badProofIsSuccessful)
-
-    var badF = 0.uint32
-    let badVerifyIsSuccessful = verify(ctxPtr, addr badProof, addr badF)
-    doAssert(badVerifyIsSuccessful)
-    # badF=1 means the proof is not verified
-    # verification of the bad proof should fail
-    doAssert(badF == 1)
+      var badF = 0.uint32
+      let badVerifyIsSuccessful = verify(ctxPtr, addr badProof, addr badF)
+      doAssert(badVerifyIsSuccessful)
+      # badF=1 means the proof is not verified
+      # verification of the bad proof should fail
+      doAssert(badF == 1)

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -1,559 +1,559 @@
-when defined(rln):
-  {.used.}
 
-  import
-    std/options,
-    testutils/unittests, chronos, chronicles, stint, web3,
-    stew/byteutils, stew/shims/net as stewNet,
-    libp2p/crypto/crypto,
-    ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
-    ../../waku/v2/node/wakunode2,
-    ../test_helpers,
-    ./test_utils
+{.used.}
+
+import
+  std/options,
+  testutils/unittests, chronos, chronicles, stint, web3,
+  stew/byteutils, stew/shims/net as stewNet,
+  libp2p/crypto/crypto,
+  ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
+  ../../waku/v2/node/wakunode2,
+  ../test_helpers,
+  ./test_utils
 
 
-  # the address of Ethereum client (ganache-cli for now)
-  # TODO this address in hardcoded in the code, we may need to take it as input from the user
-  const EthClient = "ws://localhost:8540/"
+# the address of Ethereum client (ganache-cli for now)
+# TODO this address in hardcoded in the code, we may need to take it as input from the user
+const EthClient = "ws://localhost:8540/"
 
-  # poseidonHasherCode holds the bytecode of Poseidon hasher solidity smart contract: 
-  # https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/crypto/PoseidonHasher.sol 
-  # the solidity contract is compiled separately and the resultant bytecode is copied here
-  const poseidonHasherCode = readFile("tests/v2/poseidonHasher.txt")
-  # membershipContractCode contains the bytecode of the membership solidity smart contract:
-  # https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/RLN.sol
-  # the solidity contract is compiled separately and the resultant bytecode is copied here
-  const membershipContractCode = readFile("tests/v2/membershipContract.txt")
+# poseidonHasherCode holds the bytecode of Poseidon hasher solidity smart contract: 
+# https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/crypto/PoseidonHasher.sol 
+# the solidity contract is compiled separately and the resultant bytecode is copied here
+const poseidonHasherCode = readFile("tests/v2/poseidonHasher.txt")
+# membershipContractCode contains the bytecode of the membership solidity smart contract:
+# https://github.com/kilic/rlnapp/blob/master/packages/contracts/contracts/RLN.sol
+# the solidity contract is compiled separately and the resultant bytecode is copied here
+const membershipContractCode = readFile("tests/v2/membershipContract.txt")
 
-  # the membership contract code in solidity
-  # uint256 public immutable MEMBERSHIP_DEPOSIT;
-  # 	uint256 public immutable DEPTH;
-  # 	uint256 public immutable SET_SIZE;
-  # 	uint256 public pubkeyIndex = 0;
-  # 	mapping(uint256 => uint256) public members;
-  # 	IPoseidonHasher public poseidonHasher;
+# the membership contract code in solidity
+# uint256 public immutable MEMBERSHIP_DEPOSIT;
+# 	uint256 public immutable DEPTH;
+# 	uint256 public immutable SET_SIZE;
+# 	uint256 public pubkeyIndex = 0;
+# 	mapping(uint256 => uint256) public members;
+# 	IPoseidonHasher public poseidonHasher;
 
-  # 	event MemberRegistered(uint256 indexed pubkey, uint256 indexed index);
-  # 	event MemberWithdrawn(uint256 indexed pubkey, uint256 indexed index);
+# 	event MemberRegistered(uint256 indexed pubkey, uint256 indexed index);
+# 	event MemberWithdrawn(uint256 indexed pubkey, uint256 indexed index);
 
-  # 	constructor(
-  # 		uint256 membershipDeposit,
-  # 		uint256 depth,
-  # 		address _poseidonHasher
-  # 	) public {
-  # 		MEMBERSHIP_DEPOSIT = membershipDeposit;
-  # 		DEPTH = depth;
-  # 		SET_SIZE = 1 << depth;
-  # 		poseidonHasher = IPoseidonHasher(_poseidonHasher);
-  # 	}
+# 	constructor(
+# 		uint256 membershipDeposit,
+# 		uint256 depth,
+# 		address _poseidonHasher
+# 	) public {
+# 		MEMBERSHIP_DEPOSIT = membershipDeposit;
+# 		DEPTH = depth;
+# 		SET_SIZE = 1 << depth;
+# 		poseidonHasher = IPoseidonHasher(_poseidonHasher);
+# 	}
 
-  # 	function register(uint256 pubkey) external payable {
-  # 		require(pubkeyIndex < SET_SIZE, "RLN, register: set is full");
-  # 		require(msg.value == MEMBERSHIP_DEPOSIT, "RLN, register: membership deposit is not satisfied");
-  # 		_register(pubkey);
-  # 	}
+# 	function register(uint256 pubkey) external payable {
+# 		require(pubkeyIndex < SET_SIZE, "RLN, register: set is full");
+# 		require(msg.value == MEMBERSHIP_DEPOSIT, "RLN, register: membership deposit is not satisfied");
+# 		_register(pubkey);
+# 	}
 
-  # 	function registerBatch(uint256[] calldata pubkeys) external payable {
-  # 		require(pubkeyIndex + pubkeys.length <= SET_SIZE, "RLN, registerBatch: set is full");
-  # 		require(msg.value == MEMBERSHIP_DEPOSIT * pubkeys.length, "RLN, registerBatch: membership deposit is not satisfied");
-  # 		for (uint256 i = 0; i < pubkeys.length; i++) {
-  # 			_register(pubkeys[i]);
-  # 		}
-  # 	}
+# 	function registerBatch(uint256[] calldata pubkeys) external payable {
+# 		require(pubkeyIndex + pubkeys.length <= SET_SIZE, "RLN, registerBatch: set is full");
+# 		require(msg.value == MEMBERSHIP_DEPOSIT * pubkeys.length, "RLN, registerBatch: membership deposit is not satisfied");
+# 		for (uint256 i = 0; i < pubkeys.length; i++) {
+# 			_register(pubkeys[i]);
+# 		}
+# 	}
 
-  # 	function withdrawBatch(
-  # 		uint256[] calldata secrets,
-  # 		uint256[] calldata pubkeyIndexes,
-  # 		address payable[] calldata receivers
-  # 	) external {
-  # 		uint256 batchSize = secrets.length;
-  # 		require(batchSize != 0, "RLN, withdrawBatch: batch size zero");
-  # 		require(batchSize == pubkeyIndexes.length, "RLN, withdrawBatch: batch size mismatch pubkey indexes");
-  # 		require(batchSize == receivers.length, "RLN, withdrawBatch: batch size mismatch receivers");
-  # 		for (uint256 i = 0; i < batchSize; i++) {
-  # 			_withdraw(secrets[i], pubkeyIndexes[i], receivers[i]);
-  # 		}
-  # 	}
+# 	function withdrawBatch(
+# 		uint256[] calldata secrets,
+# 		uint256[] calldata pubkeyIndexes,
+# 		address payable[] calldata receivers
+# 	) external {
+# 		uint256 batchSize = secrets.length;
+# 		require(batchSize != 0, "RLN, withdrawBatch: batch size zero");
+# 		require(batchSize == pubkeyIndexes.length, "RLN, withdrawBatch: batch size mismatch pubkey indexes");
+# 		require(batchSize == receivers.length, "RLN, withdrawBatch: batch size mismatch receivers");
+# 		for (uint256 i = 0; i < batchSize; i++) {
+# 			_withdraw(secrets[i], pubkeyIndexes[i], receivers[i]);
+# 		}
+# 	}
 
-  # 	function withdraw(
-  # 		uint256 secret,
-  # 		uint256 _pubkeyIndex,
-  # 		address payable receiver
-  # 	) external {
-  # 		_withdraw(secret, _pubkeyIndex, receiver);
-  # 	}
+# 	function withdraw(
+# 		uint256 secret,
+# 		uint256 _pubkeyIndex,
+# 		address payable receiver
+# 	) external {
+# 		_withdraw(secret, _pubkeyIndex, receiver);
+# 	}
 
-  contract(MembershipContract):
-    proc register(pubkey: Uint256) # external payable
-    # proc registerBatch(pubkeys: seq[Uint256]) # external payable
-    # TODO will add withdraw function after integrating the keyGeneration function (required to compute public keys from secret keys)
-    # proc withdraw(secret: Uint256, pubkeyIndex: Uint256, receiver: Address)
-    # proc withdrawBatch( secrets: seq[Uint256], pubkeyIndex: seq[Uint256], receiver: seq[Address])
+contract(MembershipContract):
+  proc register(pubkey: Uint256) # external payable
+  # proc registerBatch(pubkeys: seq[Uint256]) # external payable
+  # TODO will add withdraw function after integrating the keyGeneration function (required to compute public keys from secret keys)
+  # proc withdraw(secret: Uint256, pubkeyIndex: Uint256, receiver: Address)
+  # proc withdrawBatch( secrets: seq[Uint256], pubkeyIndex: seq[Uint256], receiver: seq[Address])
 
-  proc uploadContract(ethClientAddress: string): Future[Address] {.async.} =
-    let web3 = await newWeb3(ethClientAddress)
-    debug "web3 connected to", ethClientAddress
+proc uploadContract(ethClientAddress: string): Future[Address] {.async.} =
+  let web3 = await newWeb3(ethClientAddress)
+  debug "web3 connected to", ethClientAddress
+
+  # fetch the list of registered accounts
+  let accounts = await web3.provider.eth_accounts()
+  web3.defaultAccount = accounts[1]
+  let add =web3.defaultAccount 
+  debug "contract deployer account address ", add
+
+  var balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
+  debug "Initial account balance: ", balance
+
+  # deploy the poseidon hash first
+  let 
+    hasherReceipt = await web3.deployContract(poseidonHasherCode)
+    hasherAddress = hasherReceipt.contractAddress.get
+  debug "hasher address: ", hasherAddress
+  
+
+  # encode membership contract inputs to 32 bytes zero-padded
+  let 
+    membershipFeeEncoded = encode(MembershipFee).data 
+    depthEncoded = encode(Depth).data 
+    hasherAddressEncoded = encode(hasherAddress).data
+    # this is the contract constructor input
+    contractInput = membershipFeeEncoded & depthEncoded & hasherAddressEncoded
+
+
+  debug "encoded membership fee: ", membershipFeeEncoded
+  debug "encoded depth: ", depthEncoded
+  debug "encoded hasher address: ", hasherAddressEncoded
+  debug "encoded contract input:" , contractInput
+
+  # deploy membership contract with its constructor inputs
+  let receipt = await web3.deployContract(membershipContractCode, contractInput = contractInput)
+  var contractAddress = receipt.contractAddress.get
+  debug "Address of the deployed membership contract: ", contractAddress
+
+  # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
+  # debug "Account balance after the contract deployment: ", balance
+
+  await web3.close()
+  debug "disconnected from ", ethClientAddress
+
+  return contractAddress
+
+procSuite "Waku rln relay":
+  asyncTest  "contract membership":
+    let contractAddress = await uploadContract(EthClient)
+    # connect to the eth client
+    let web3 = await newWeb3(EthClient)
+    debug "web3 connected to", EthClient
 
     # fetch the list of registered accounts
     let accounts = await web3.provider.eth_accounts()
     web3.defaultAccount = accounts[1]
-    let add =web3.defaultAccount 
+    let add = web3.defaultAccount 
     debug "contract deployer account address ", add
 
-    var balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-    debug "Initial account balance: ", balance
+    # prepare a contract sender to interact with it
+    var sender = web3.contractSender(MembershipContract, contractAddress) # creates a Sender object with a web3 field and contract address of type Address
 
-    # deploy the poseidon hash first
-    let 
-      hasherReceipt = await web3.deployContract(poseidonHasherCode)
-      hasherAddress = hasherReceipt.contractAddress.get
-    debug "hasher address: ", hasherAddress
-    
+    # send takes three parameters, c: ContractCallBase, value = 0.u256, gas = 3000000'u64 gasPrice = 0 
+    # should use send proc for the contract functions that update the state of the contract
+    let tx = await sender.register(20.u256).send(value = MembershipFee)
+    debug "The hash of registration tx: ", tx # value is the membership fee
 
-    # encode membership contract inputs to 32 bytes zero-padded
-    let 
-      membershipFeeEncoded = encode(MembershipFee).data 
-      depthEncoded = encode(Depth).data 
-      hasherAddressEncoded = encode(hasherAddress).data
-      # this is the contract constructor input
-      contractInput = membershipFeeEncoded & depthEncoded & hasherAddressEncoded
-
-
-    debug "encoded membership fee: ", membershipFeeEncoded
-    debug "encoded depth: ", depthEncoded
-    debug "encoded hasher address: ", hasherAddressEncoded
-    debug "encoded contract input:" , contractInput
-
-    # deploy membership contract with its constructor inputs
-    let receipt = await web3.deployContract(membershipContractCode, contractInput = contractInput)
-    var contractAddress = receipt.contractAddress.get
-    debug "Address of the deployed membership contract: ", contractAddress
+    # var members: array[2, uint256] = [20.u256, 21.u256]
+    # debug "This is the batch registration result ", await sender.registerBatch(members).send(value = (members.len * membershipFee)) # value is the membership fee
 
     # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-    # debug "Account balance after the contract deployment: ", balance
+    # debug "Balance after registration: ", balance
 
     await web3.close()
-    debug "disconnected from ", ethClientAddress
+    debug "disconnected from", EthClient
 
-    return contractAddress
+  asyncTest "registration procedure":
+    # deploy the contract
+    let contractAddress = await uploadContract(EthClient)
 
-  procSuite "Waku rln relay":
-    asyncTest  "contract membership":
-      let contractAddress = await uploadContract(EthClient)
-      # connect to the eth client
-      let web3 = await newWeb3(EthClient)
-      debug "web3 connected to", EthClient
+    # prepare rln-relay peer inputs
+    let 
+      web3 = await newWeb3(EthClient)
+      accounts = await web3.provider.eth_accounts()
+      # choose one of the existing accounts for the rln-relay peer  
+      ethAccountAddress = accounts[9]
+    await web3.close()
 
-      # fetch the list of registered accounts
-      let accounts = await web3.provider.eth_accounts()
-      web3.defaultAccount = accounts[1]
-      let add = web3.defaultAccount 
-      debug "contract deployer account address ", add
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      # prepare a contract sender to interact with it
-      var sender = web3.contractSender(MembershipContract, contractAddress) # creates a Sender object with a web3 field and contract address of type Address
+    # generate the membership keys
+    let membershipKeyPair = membershipKeyGen(ctxPtr)
+    
+    check:
+      membershipKeyPair.isSome
 
-      # send takes three parameters, c: ContractCallBase, value = 0.u256, gas = 3000000'u64 gasPrice = 0 
-      # should use send proc for the contract functions that update the state of the contract
-      let tx = await sender.register(20.u256).send(value = MembershipFee)
-      debug "The hash of registration tx: ", tx # value is the membership fee
+    # initialize the WakuRLNRelay 
+    var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
+      ethClientAddress: EthClient,
+      ethAccountAddress: ethAccountAddress,
+      membershipContractAddress: contractAddress)
+    
+    # register the rln-relay peer to the membership contract
+    let is_successful = await rlnPeer.register()
+    check:
+      is_successful
+  asyncTest "mounting waku rln relay":
+    let
+      nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
+        Port(60000))
+    await node.start()
 
-      # var members: array[2, uint256] = [20.u256, 21.u256]
-      # debug "This is the batch registration result ", await sender.registerBatch(members).send(value = (members.len * membershipFee)) # value is the membership fee
+    # deploy the contract
+    let membershipContractAddress = await uploadContract(EthClient)
 
-      # balance = await web3.provider.eth_getBalance(web3.defaultAccount , "latest")
-      # debug "Balance after registration: ", balance
+    # prepare rln-relay inputs
+    let 
+      web3 = await newWeb3(EthClient)
+      accounts = await web3.provider.eth_accounts()
+      # choose one of the existing account for the rln-relay peer  
+      ethAccountAddress = accounts[9]
+    await web3.close()
 
-      await web3.close()
-      debug "disconnected from", EthClient
+    # start rln-relay
+    await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
 
-    asyncTest "registration procedure":
-      # deploy the contract
-      let contractAddress = await uploadContract(EthClient)
+    await node.stop()
 
-      # prepare rln-relay peer inputs
-      let 
-        web3 = await newWeb3(EthClient)
-        accounts = await web3.provider.eth_accounts()
-        # choose one of the existing accounts for the rln-relay peer  
-        ethAccountAddress = accounts[9]
-      await web3.close()
 
-      # create an RLN instance
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+suite "Waku rln relay":
+  test "key_gen Nim Wrappers":
+    var 
+      merkleDepth: csize_t = 32
+      # parameters.key contains the parameters related to the Poseidon hasher
+      # to generate this file, clone this repo https://github.com/kilic/rln 
+      # and run the following command in the root directory of the cloned project
+      # cargo run --example export_test_keys
+      # the file is generated separately and copied here
+      parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+      pbytes = parameters.toBytes()
+      len : csize_t = uint(pbytes.len)
+      parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
+    check:
+      # check the parameters.key is not empty
+      pbytes.len != 0
 
-      # generate the membership keys
-      let membershipKeyPair = membershipKeyGen(ctxPtr)
-      
+    # ctx holds the information that is going to be used for  the key generation
+    var 
+      obj = RLN[Bn256]()
+      objPtr = addr(obj)
+      objptrptr = addr(objPtr)
+      ctx = objptrptr
+    let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctx)
+    check:
+      # check whether the circuit parameters are generated successfully
+      res == true
+
+    # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
+    var 
+      keysBuffer : Buffer
+      keysBufferPtr = addr(keysBuffer)
+      done = key_gen(ctx[], keysBufferPtr) 
+    check:
+      # check whether the keys are generated successfully
+      done == true
+
+    if done:
+      var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
       check:
-        membershipKeyPair.isSome
+        # the public and secret keys together are 64 bytes
+        generatedKeys.len == 64
+      debug "generated keys: ", generatedKeys 
+    
+  test "membership Key Gen":
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      # initialize the WakuRLNRelay 
-      var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
-        ethClientAddress: EthClient,
-        ethAccountAddress: ethAccountAddress,
-        membershipContractAddress: contractAddress)
-      
-      # register the rln-relay peer to the membership contract
-      let is_successful = await rlnPeer.register()
-      check:
-        is_successful
-    asyncTest "mounting waku rln relay":
-      let
-        nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
-        node = WakuNode.init(nodeKey, ValidIpAddress.init("0.0.0.0"),
-          Port(60000))
-      await node.start()
+    var key = membershipKeyGen(ctxPtr)
+    var empty : array[32,byte]
+    check:
+      key.isSome
+      key.get().secretKey.len == 32
+      key.get().publicKey.len == 32
+      key.get().secretKey != empty
+      key.get().publicKey != empty
+    
+    debug "the generated membership key pair: ", key 
 
-      # deploy the contract
-      let membershipContractAddress = await uploadContract(EthClient)
+  test "get_root Nim binding":
+    # create an RLN instance which also includes an empty Merkle tree
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      # prepare rln-relay inputs
-      let 
-        web3 = await newWeb3(EthClient)
-        accounts = await web3.provider.eth_accounts()
-        # choose one of the existing account for the rln-relay peer  
-        ethAccountAddress = accounts[9]
-      await web3.close()
+    # read the Merkle Tree root
+    var 
+      root1 {.noinit.} : Buffer = Buffer()
+      rootPtr1 = addr(root1)
+      get_root_successful1 = get_root(ctxPtr, rootPtr1)
+    doAssert(get_root_successful1)
+    doAssert(root1.len == 32)
 
-      # start rln-relay
-      await node.mountRlnRelay(ethClientAddress = some(EthClient), ethAccountAddress =  some(ethAccountAddress), membershipContractAddress =  some(membershipContractAddress))
+    # read the Merkle Tree root
+    var 
+      root2 {.noinit.} : Buffer = Buffer()
+      rootPtr2 = addr(root2)
+      get_root_successful2 = get_root(ctxPtr, rootPtr2)
+    doAssert(get_root_successful2)
+    doAssert(root2.len == 32)
 
-      await node.stop()
+    var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
+    let rootHex1 = rootValue1[].toHex
 
+    var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
+    let rootHex2 = rootValue2[].toHex
 
-  suite "Waku rln relay":
-    test "key_gen Nim Wrappers":
-      var 
-        merkleDepth: csize_t = 32
-        # parameters.key contains the parameters related to the Poseidon hasher
-        # to generate this file, clone this repo https://github.com/kilic/rln 
-        # and run the following command in the root directory of the cloned project
-        # cargo run --example export_test_keys
-        # the file is generated separately and copied here
-        parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-        pbytes = parameters.toBytes()
-        len : csize_t = uint(pbytes.len)
-        parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
-      check:
-        # check the parameters.key is not empty
-        pbytes.len != 0
+    # the two roots must be identical
+    doAssert(rootHex1 == rootHex2)
 
-      # ctx holds the information that is going to be used for  the key generation
-      var 
-        obj = RLN[Bn256]()
-        objPtr = addr(obj)
-        objptrptr = addr(objPtr)
-        ctx = objptrptr
-      let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctx)
-      check:
-        # check whether the circuit parameters are generated successfully
-        res == true
+  test "update_next_member Nim Wrapper":
+    # create an RLN instance which also includes an empty Merkle tree
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
-      var 
-        keysBuffer : Buffer
-        keysBufferPtr = addr(keysBuffer)
-        done = key_gen(ctx[], keysBufferPtr) 
-      check:
-        # check whether the keys are generated successfully
-        done == true
+    # generate a key pair
+    var keypair = membershipKeyGen(ctxPtr)
+    doAssert(keypair.isSome())
+    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+    let pkBufferPtr = addr pkBuffer
 
-      if done:
-        var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
-        check:
-          # the public and secret keys together are 64 bytes
-          generatedKeys.len == 64
-        debug "generated keys: ", generatedKeys 
-      
-    test "membership Key Gen":
-      # create an RLN instance
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+    # add the member to the tree
+    var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
+    check:
+      member_is_added == true
+    
+  test "delete_member Nim wrapper":
+    # create an RLN instance which also includes an empty Merkle tree
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      var key = membershipKeyGen(ctxPtr)
-      var empty : array[32,byte]
-      check:
-        key.isSome
-        key.get().secretKey.len == 32
-        key.get().publicKey.len == 32
-        key.get().secretKey != empty
-        key.get().publicKey != empty
-      
-      debug "the generated membership key pair: ", key 
-  
-    test "get_root Nim binding":
-      # create an RLN instance which also includes an empty Merkle tree
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+    # delete the first member 
+    var deleted_member_index = uint(0)
+    let deletion_success = delete_member(ctxPtr, deleted_member_index)
+    doAssert(deletion_success)
 
-      # read the Merkle Tree root
-      var 
-        root1 {.noinit.} : Buffer = Buffer()
-        rootPtr1 = addr(root1)
-        get_root_successful1 = get_root(ctxPtr, rootPtr1)
-      doAssert(get_root_successful1)
-      doAssert(root1.len == 32)
+  test "Merkle tree consistency check between deletion and insertion":
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-      # read the Merkle Tree root
-      var 
-        root2 {.noinit.} : Buffer = Buffer()
-        rootPtr2 = addr(root2)
-        get_root_successful2 = get_root(ctxPtr, rootPtr2)
-      doAssert(get_root_successful2)
-      doAssert(root2.len == 32)
+    # read the Merkle Tree root
+    var 
+      root1 {.noinit.} : Buffer = Buffer()
+      rootPtr1 = addr(root1)
+      get_root_successful1 = get_root(ctxPtr, rootPtr1)
+    doAssert(get_root_successful1)
+    doAssert(root1.len == 32)
+    
+    # generate a key pair
+    var keypair = membershipKeyGen(ctxPtr)
+    doAssert(keypair.isSome())
+    var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
+    let pkBufferPtr = addr pkBuffer
 
-      var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
-      let rootHex1 = rootValue1[].toHex
+    # add the member to the tree
+    var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
+    doAssert(member_is_added)
 
-      var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
-      let rootHex2 = rootValue2[].toHex
+    # read the Merkle Tree root after insertion
+    var 
+      root2 {.noinit.} : Buffer = Buffer()
+      rootPtr2 = addr(root2)
+      get_root_successful2 = get_root(ctxPtr, rootPtr2)
+    doAssert(get_root_successful2)
+    doAssert(root2.len == 32)
 
-      # the two roots must be identical
-      doAssert(rootHex1 == rootHex2)
+    # delete the first member 
+    var deleted_member_index = uint(0)
+    let deletion_success = delete_member(ctxPtr, deleted_member_index)
+    doAssert(deletion_success)
 
-    test "update_next_member Nim Wrapper":
-      # create an RLN instance which also includes an empty Merkle tree
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+    # read the Merkle Tree root after the deletion
+    var 
+      root3 {.noinit.} : Buffer = Buffer()
+      rootPtr3 = addr(root3)
+      get_root_successful3 = get_root(ctxPtr, rootPtr3)
+    doAssert(get_root_successful3)
+    doAssert(root3.len == 32)
 
-      # generate a key pair
-      var keypair = membershipKeyGen(ctxPtr)
-      doAssert(keypair.isSome())
-      var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
-      let pkBufferPtr = addr pkBuffer
+    var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
+    let rootHex1 = rootValue1[].toHex
+    debug "The initial root", rootHex1
 
-      # add the member to the tree
-      var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
-      check:
-        member_is_added == true
-      
-    test "delete_member Nim wrapper":
-      # create an RLN instance which also includes an empty Merkle tree
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+    var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
+    let rootHex2 = rootValue2[].toHex
+    debug "The root after insertion", rootHex2
 
-      # delete the first member 
-      var deleted_member_index = uint(0)
-      let deletion_success = delete_member(ctxPtr, deleted_member_index)
-      doAssert(deletion_success)
-  
-    test "Merkle tree consistency check between deletion and insertion":
-      # create an RLN instance
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(32, ctxPtr))
+    var rootValue3 = cast[ptr array[32,byte]] (root3.`ptr`)
+    let rootHex3 = rootValue3[].toHex
+    debug "The root after deletion", rootHex3
 
-      # read the Merkle Tree root
-      var 
-        root1 {.noinit.} : Buffer = Buffer()
-        rootPtr1 = addr(root1)
-        get_root_successful1 = get_root(ctxPtr, rootPtr1)
-      doAssert(get_root_successful1)
-      doAssert(root1.len == 32)
-      
-      # generate a key pair
-      var keypair = membershipKeyGen(ctxPtr)
-      doAssert(keypair.isSome())
-      var pkBuffer = Buffer(`ptr`: addr(keypair.get().publicKey[0]), len: 32)
-      let pkBufferPtr = addr pkBuffer
+    # the root must change after the insertion
+    doAssert(not(rootHex1 == rootHex2))
 
-      # add the member to the tree
-      var member_is_added = update_next_member(ctxPtr, pkBufferPtr)
+    ## The initial root of the tree (empty tree) must be identical to 
+    ## the root of the tree after one insertion followed by a deletion
+    doAssert(rootHex1 == rootHex3)
+  test "hash Nim Wrappers":
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(30, ctxPtr))
+
+    # prepare the input
+    var
+      hashInput : array[32, byte]
+    for x in hashInput.mitems: x= 1
+    var 
+      hashInputHex = hashInput.toHex()
+      hashInputBuffer = Buffer(`ptr`: addr hashInput[0], len: 32 ) 
+
+    debug "sample_hash_input_bytes", hashInputHex
+
+    # prepare other inputs to the hash function
+    var 
+      outputBuffer: Buffer
+      numOfInputs = 1.uint # the number of hash inputs that can be 1 or 2
+    
+    let hashSuccess = hash(ctxPtr, addr hashInputBuffer, numOfInputs, addr outputBuffer)
+    doAssert(hashSuccess)
+    let outputArr = cast[ptr array[32,byte]](outputBuffer.`ptr`)[]
+    doAssert("53a6338cdbf02f0563cec1898e354d0d272c8f98b606c538945c6f41ef101828" == outputArr.toHex())
+
+    var 
+      hashOutput = cast[ptr array[32,byte]] (outputBuffer.`ptr`)[]
+      hashOutputHex = hashOutput.toHex()
+
+    debug "hash output", hashOutputHex
+
+  test "generate_proof and verify Nim Wrappers":
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+
+    # check if the rln instance is created successfully 
+    doAssert(createRLNInstance(32, ctxPtr))
+
+    # create the membership key
+    var auth = membershipKeyGen(ctxPtr)
+    var skBuffer = Buffer(`ptr`: addr(auth.get().secretKey[0]), len: 32)
+
+    # peer's index in the Merkle Tree
+    var index = 5
+
+    # prepare the authentication object with peer's index and sk
+    var authObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(index))
+
+    # Create a Merkle tree with random members 
+    for i in 0..10:
+      var member_is_added: bool = false
+      if (i == index):
+        #  insert the current peer's pk
+        var pkBuffer = Buffer(`ptr`: addr(auth.get().publicKey[0]), len: 32)
+        member_is_added = update_next_member(ctxPtr, addr pkBuffer)
+      else:
+        var memberKeys = membershipKeyGen(ctxPtr)
+        var pkBuffer = Buffer(`ptr`: addr(memberKeys.get().publicKey[0]), len: 32)
+        member_is_added = update_next_member(ctxPtr, addr pkBuffer)
+      # check the member is added
       doAssert(member_is_added)
 
-      # read the Merkle Tree root after insertion
-      var 
-        root2 {.noinit.} : Buffer = Buffer()
-        rootPtr2 = addr(root2)
-        get_root_successful2 = get_root(ctxPtr, rootPtr2)
-      doAssert(get_root_successful2)
-      doAssert(root2.len == 32)
+    # prepare the message
+    var messageBytes {.noinit.}: array[32, byte]
+    for x in messageBytes.mitems: x = 1
+    var messageHex = messageBytes.toHex()
+    debug "message", messageHex
 
-      # delete the first member 
-      var deleted_member_index = uint(0)
-      let deletion_success = delete_member(ctxPtr, deleted_member_index)
-      doAssert(deletion_success)
-
-      # read the Merkle Tree root after the deletion
-      var 
-        root3 {.noinit.} : Buffer = Buffer()
-        rootPtr3 = addr(root3)
-        get_root_successful3 = get_root(ctxPtr, rootPtr3)
-      doAssert(get_root_successful3)
-      doAssert(root3.len == 32)
-
-      var rootValue1 = cast[ptr array[32,byte]] (root1.`ptr`)
-      let rootHex1 = rootValue1[].toHex
-      debug "The initial root", rootHex1
-
-      var rootValue2 = cast[ptr array[32,byte]] (root2.`ptr`)
-      let rootHex2 = rootValue2[].toHex
-      debug "The root after insertion", rootHex2
-
-      var rootValue3 = cast[ptr array[32,byte]] (root3.`ptr`)
-      let rootHex3 = rootValue3[].toHex
-      debug "The root after deletion", rootHex3
-
-      # the root must change after the insertion
-      doAssert(not(rootHex1 == rootHex2))
-
-      ## The initial root of the tree (empty tree) must be identical to 
-      ## the root of the tree after one insertion followed by a deletion
-      doAssert(rootHex1 == rootHex3)
-    test "hash Nim Wrappers":
-      # create an RLN instance
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-      doAssert(createRLNInstance(30, ctxPtr))
-
-      # prepare the input
-      var
-        hashInput : array[32, byte]
-      for x in hashInput.mitems: x= 1
-      var 
-        hashInputHex = hashInput.toHex()
-        hashInputBuffer = Buffer(`ptr`: addr hashInput[0], len: 32 ) 
-
-      debug "sample_hash_input_bytes", hashInputHex
-
-      # prepare other inputs to the hash function
-      var 
-        outputBuffer: Buffer
-        numOfInputs = 1.uint # the number of hash inputs that can be 1 or 2
-      
-      let hashSuccess = hash(ctxPtr, addr hashInputBuffer, numOfInputs, addr outputBuffer)
-      doAssert(hashSuccess)
-      let outputArr = cast[ptr array[32,byte]](outputBuffer.`ptr`)[]
-      doAssert("53a6338cdbf02f0563cec1898e354d0d272c8f98b606c538945c6f41ef101828" == outputArr.toHex())
-
-      var 
-        hashOutput = cast[ptr array[32,byte]] (outputBuffer.`ptr`)[]
-        hashOutputHex = hashOutput.toHex()
-
-      debug "hash output", hashOutputHex
-
-    test "generate_proof and verify Nim Wrappers":
-      # create an RLN instance
-      var 
-        ctx = RLN[Bn256]()
-        ctxPtr = addr(ctx)
-
-      # check if the rln instance is created successfully 
-      doAssert(createRLNInstance(32, ctxPtr))
-
-      # create the membership key
-      var auth = membershipKeyGen(ctxPtr)
-      var skBuffer = Buffer(`ptr`: addr(auth.get().secretKey[0]), len: 32)
-
-      # peer's index in the Merkle Tree
-      var index = 5
-
-      # prepare the authentication object with peer's index and sk
-      var authObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(index))
-
-      # Create a Merkle tree with random members 
-      for i in 0..10:
-        var member_is_added: bool = false
-        if (i == index):
-          #  insert the current peer's pk
-          var pkBuffer = Buffer(`ptr`: addr(auth.get().publicKey[0]), len: 32)
-          member_is_added = update_next_member(ctxPtr, addr pkBuffer)
-        else:
-          var memberKeys = membershipKeyGen(ctxPtr)
-          var pkBuffer = Buffer(`ptr`: addr(memberKeys.get().publicKey[0]), len: 32)
-          member_is_added = update_next_member(ctxPtr, addr pkBuffer)
-        # check the member is added
-        doAssert(member_is_added)
-
-      # prepare the message
-      var messageBytes {.noinit.}: array[32, byte]
-      for x in messageBytes.mitems: x = 1
-      var messageHex = messageBytes.toHex()
-      debug "message", messageHex
-
-      # prepare the epoch
-      var  epochBytes : array[32,byte]
-      for x in epochBytes.mitems : x = 0
-      var epochHex = epochBytes.toHex()
-      debug "epoch in bytes", epochHex
+    # prepare the epoch
+    var  epochBytes : array[32,byte]
+    for x in epochBytes.mitems : x = 0
+    var epochHex = epochBytes.toHex()
+    debug "epoch in bytes", epochHex
 
 
-      # serialize message and epoch 
-      # TODO add a proc for serializing
-      var epochMessage = @epochBytes & @messageBytes
-      doAssert(epochMessage.len == 64)
-      var inputBytes{.noinit.}: array[64, byte] # holds epoch||Message 
-      for (i, x) in inputBytes.mpairs: x = epochMessage[i]
-      var inputHex = inputBytes.toHex()
-      debug "serialized epoch and message ", inputHex
-      # put the serialized epoch||message into a buffer
-      var inputBuffer = Buffer(`ptr`: addr(inputBytes[0]), len: 64)
+    # serialize message and epoch 
+    # TODO add a proc for serializing
+    var epochMessage = @epochBytes & @messageBytes
+    doAssert(epochMessage.len == 64)
+    var inputBytes{.noinit.}: array[64, byte] # holds epoch||Message 
+    for (i, x) in inputBytes.mpairs: x = epochMessage[i]
+    var inputHex = inputBytes.toHex()
+    debug "serialized epoch and message ", inputHex
+    # put the serialized epoch||message into a buffer
+    var inputBuffer = Buffer(`ptr`: addr(inputBytes[0]), len: 64)
 
-      # generate the proof
-      var proof: Buffer
-      let proofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr authObj, addr proof)
-      # check whether the generate_proof call is done successfully
-      doAssert(proofIsSuccessful)
-      var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
-      let proofHex = proofValue[].toHex
-      debug "proof content", proofHex
+    # generate the proof
+    var proof: Buffer
+    let proofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr authObj, addr proof)
+    # check whether the generate_proof call is done successfully
+    doAssert(proofIsSuccessful)
+    var proofValue = cast[ptr array[416,byte]] (proof.`ptr`)
+    let proofHex = proofValue[].toHex
+    debug "proof content", proofHex
 
-      # display the proof breakdown
-      var 
-        zkSNARK = proofHex[0..511]
-        proofRoot = proofHex[512..575] 
-        proofEpoch = proofHex[576..639]
-        shareX = proofHex[640..703]
-        shareY = proofHex[704..767]
-        nullifier = proofHex[768..831]
+    # display the proof breakdown
+    var 
+      zkSNARK = proofHex[0..511]
+      proofRoot = proofHex[512..575] 
+      proofEpoch = proofHex[576..639]
+      shareX = proofHex[640..703]
+      shareY = proofHex[704..767]
+      nullifier = proofHex[768..831]
 
-      doAssert(zkSNARK.len == 512)
-      doAssert(proofRoot.len == 64)
-      doAssert(proofEpoch.len == 64)
-      doAssert(epochHex == proofEpoch)
-      doAssert(shareX.len == 64)
-      doAssert(shareY.len == 64)
-      doAssert(nullifier.len == 64)
+    doAssert(zkSNARK.len == 512)
+    doAssert(proofRoot.len == 64)
+    doAssert(proofEpoch.len == 64)
+    doAssert(epochHex == proofEpoch)
+    doAssert(shareX.len == 64)
+    doAssert(shareY.len == 64)
+    doAssert(nullifier.len == 64)
 
-      debug "zkSNARK ", zkSNARK
-      debug "root ", proofRoot
-      debug "epoch ", proofEpoch
-      debug "shareX", shareX
-      debug "shareY", shareY
-      debug "nullifier", nullifier
+    debug "zkSNARK ", zkSNARK
+    debug "root ", proofRoot
+    debug "epoch ", proofEpoch
+    debug "shareX", shareX
+    debug "shareY", shareY
+    debug "nullifier", nullifier
 
-      var f = 0.uint32
-      let verifyIsSuccessful = verify(ctxPtr, addr proof, addr f)
-      doAssert(verifyIsSuccessful)
-      # f = 0 means the proof is verified
-      doAssert(f == 0)
+    var f = 0.uint32
+    let verifyIsSuccessful = verify(ctxPtr, addr proof, addr f)
+    doAssert(verifyIsSuccessful)
+    # f = 0 means the proof is verified
+    doAssert(f == 0)
 
-      # create and test a bad proof
-      # prepare a bad authentication object with a wrong peer's index
-      var badIndex = 8
-      var badAuthObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(badIndex))
-      var badProof: Buffer
-      let badProofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr badAuthObj, addr badProof)
-      # check whether the generate_proof call is done successfully
-      doAssert(badProofIsSuccessful)
+    # create and test a bad proof
+    # prepare a bad authentication object with a wrong peer's index
+    var badIndex = 8
+    var badAuthObj: Auth = Auth(secret_buffer: addr skBuffer, index: uint(badIndex))
+    var badProof: Buffer
+    let badProofIsSuccessful = generate_proof(ctxPtr, addr inputBuffer, addr badAuthObj, addr badProof)
+    # check whether the generate_proof call is done successfully
+    doAssert(badProofIsSuccessful)
 
-      var badF = 0.uint32
-      let badVerifyIsSuccessful = verify(ctxPtr, addr badProof, addr badF)
-      doAssert(badVerifyIsSuccessful)
-      # badF=1 means the proof is not verified
-      # verification of the bad proof should fail
-      doAssert(badF == 1)
+    var badF = 0.uint32
+    let badVerifyIsSuccessful = verify(ctxPtr, addr badProof, addr badF)
+    doAssert(badVerifyIsSuccessful)
+    # badF=1 means the proof is not verified
+    # verification of the bad proof should fail
+    doAssert(badF == 1)

--- a/tests/v2/test_waku_rln_relay.nim
+++ b/tests/v2/test_waku_rln_relay.nim
@@ -6,7 +6,7 @@ import
   testutils/unittests, chronos, chronicles, stint, web3,
   stew/byteutils, stew/shims/net as stewNet,
   libp2p/crypto/crypto,
-  ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils],
+  ../../waku/v2/protocol/waku_rln_relay/[rln, waku_rln_relay_utils, waku_rln_relay_types],
   ../../waku/v2/node/wakunode2,
   ../test_helpers,
   ./test_utils

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -524,61 +524,62 @@ procSuite "WakuNode":
     await node2.stop()
     await node3.stop()
   
-  asyncTest "testing rln-relay with mocked zkp":
+  when defined(rln):
+    asyncTest "testing rln-relay with mocked zkp":
     
-    let
-      # publisher node
-      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
-      # Relay node
-      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
-      # Subscriber
-      nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
-      node3 = WakuNode.init(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
+      let
+        # publisher node
+        nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+        node1 = WakuNode.init(nodeKey1, ValidIpAddress.init("0.0.0.0"), Port(60000))
+        # Relay node
+        nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+        node2 = WakuNode.init(nodeKey2, ValidIpAddress.init("0.0.0.0"), Port(60002))
+        # Subscriber
+        nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+        node3 = WakuNode.init(nodeKey3, ValidIpAddress.init("0.0.0.0"), Port(60003))
 
-      pubSubTopic = "defaultTopic"
-      contentTopic1 = ContentTopic("/waku/2/default-content/proto")
-      payload = "hello world".toBytes()
-      message1 = WakuMessage(payload: payload, contentTopic: contentTopic1)
+        pubSubTopic = "defaultTopic"
+        contentTopic1 = ContentTopic("/waku/2/default-content/proto")
+        payload = "hello world".toBytes()
+        message1 = WakuMessage(payload: payload, contentTopic: contentTopic1)
 
-    # start all the nodes
-    await node1.start()
-    node1.mountRelay(@[pubSubTopic])
+      # start all the nodes
+      await node1.start()
+      node1.mountRelay(@[pubSubTopic])
 
-    await node2.start()
-    node2.mountRelay(@[pubSubTopic])
-    node2.addRLNRelayValidator(pubSubTopic)
+      await node2.start()
+      node2.mountRelay(@[pubSubTopic])
+      node2.addRLNRelayValidator(pubSubTopic)
 
-    await node3.start()
-    node3.mountRelay(@[pubSubTopic])
+      await node3.start()
+      node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo])
-    await node3.connectToNodes(@[node2.peerInfo])
+      await node1.connectToNodes(@[node2.peerInfo])
+      await node3.connectToNodes(@[node2.peerInfo])
 
-    var completionFut = newFuture[bool]()
-    proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-      let msg = WakuMessage.init(data)
-      if msg.isOk():
-        let val = msg.value()
-        debug "The received topic:", topic
-        if topic == pubSubTopic:
-          completionFut.complete(true)
-
-
-    node3.subscribe(pubSubTopic, relayHandler)
-    await sleepAsync(2000.millis)
-
-    await node1.publish(pubSubTopic, message1, rlnRelayEnabled = true)
-    await sleepAsync(2000.millis)
+      var completionFut = newFuture[bool]()
+      proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+        let msg = WakuMessage.init(data)
+        if msg.isOk():
+          let val = msg.value()
+          debug "The received topic:", topic
+          if topic == pubSubTopic:
+            completionFut.complete(true)
 
 
-    check:
-      (await completionFut.withTimeout(10.seconds)) == true
-    
-    await node1.stop()
-    await node2.stop()
-    await node3.stop()
+      node3.subscribe(pubSubTopic, relayHandler)
+      await sleepAsync(2000.millis)
+
+      await node1.publish(pubSubTopic, message1, rlnRelayEnabled = true)
+      await sleepAsync(2000.millis)
+
+
+      check:
+        (await completionFut.withTimeout(10.seconds)) == true
+      
+      await node1.stop()
+      await node2.stop()
+      await node3.stop()
 
   asyncTest "Relay protocol is started correctly":
     let

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -304,13 +304,14 @@ proc publish*(node: WakuNode, topic: Topic, message: WakuMessage,  rlnRelayEnabl
   debug "publish", topic=topic, contentTopic=message.contentTopic
   var publishingMessage = message
 
-  if rlnRelayEnabled:
-    # if rln relay is enabled then a proof must be generated and added to the waku message
-    let 
-      proof = proofGen(message.payload)
-      ## TODO here  since the message is immutable we have to make a copy of it and then attach the proof to its duplicate 
-      ## TODO however, it might be better to change message type to mutable (i.e., var) so that we can add the proof field to the original message
-      publishingMessage = WakuMessage(payload: message.payload, contentTopic: message.contentTopic, version: message.version, proof: proof)
+  when defined(rln):
+    if rlnRelayEnabled:
+      # if rln relay is enabled then a proof must be generated and added to the waku message
+      let 
+        proof = proofGen(message.payload)
+        ## TODO here  since the message is immutable we have to make a copy of it and then attach the proof to its duplicate 
+        ## TODO however, it might be better to change message type to mutable (i.e., var) so that we can add the proof field to the original message
+        publishingMessage = WakuMessage(payload: message.payload, contentTopic: message.contentTopic, version: message.version, proof: proof)
 
   let data = message.encode().buffer
 
@@ -408,52 +409,54 @@ proc mountStore*(node: WakuNode, store: MessageStore = nil, persistMessages: boo
   if persistMessages:
     node.subscriptions.subscribe(WakuStoreCodec, node.wakuStore.subscription())
 
-proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
-  # TODO return a bool value to indicate the success of the call
-  # check whether inputs are provided
-  doAssert(ethClientAddress.isSome())
-  doAssert(ethAccountAddress.isSome())
-  doAssert(membershipContractAddress.isSome())
+when defined(rln):
+  proc mountRlnRelay*(node: WakuNode, ethClientAddress: Option[string] = none(string), ethAccountAddress: Option[Address] = none(Address), membershipContractAddress:  Option[Address] = none(Address)) {.async.} =
+    # TODO return a bool value to indicate the success of the call
+    # check whether inputs are provided
+    doAssert(ethClientAddress.isSome())
+    doAssert(ethAccountAddress.isSome())
+    doAssert(membershipContractAddress.isSome())
 
-  # create an RLN instance
-  var 
-    ctx = RLN[Bn256]()
-    ctxPtr = addr(ctx)
-  doAssert(createRLNInstance(32, ctxPtr))
+    # create an RLN instance
+    var 
+      ctx = RLN[Bn256]()
+      ctxPtr = addr(ctx)
+    doAssert(createRLNInstance(32, ctxPtr))
 
-  # generate the membership keys
-  let membershipKeyPair = membershipKeyGen(ctxPtr)
-  # check whether keys are generated
-  doAssert(membershipKeyPair.isSome())
-  debug "the membership key for the rln relay is generated"
+    # generate the membership keys
+    let membershipKeyPair = membershipKeyGen(ctxPtr)
+    # check whether keys are generated
+    doAssert(membershipKeyPair.isSome())
+    debug "the membership key for the rln relay is generated"
 
-  # initialize the WakuRLNRelay
-  var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
-    ethClientAddress: ethClientAddress.get(),
-    ethAccountAddress: ethAccountAddress.get(),
-    membershipContractAddress: membershipContractAddress.get())
-  
-  # register the rln-relay peer to the membership contract
-  let is_successful = await rlnPeer.register()
-  # check whether registration is done
-  doAssert(is_successful)
-  debug "peer is successfully registered into the membership contract"
+    # initialize the WakuRLNRelay
+    var rlnPeer = WakuRLNRelay(membershipKeyPair: membershipKeyPair.get(),
+      ethClientAddress: ethClientAddress.get(),
+      ethAccountAddress: ethAccountAddress.get(),
+      membershipContractAddress: membershipContractAddress.get())
+    
+    # register the rln-relay peer to the membership contract
+    let is_successful = await rlnPeer.register()
+    # check whether registration is done
+    doAssert(is_successful)
+    debug "peer is successfully registered into the membership contract"
 
-  node.wakuRlnRelay = rlnPeer
+    node.wakuRlnRelay = rlnPeer
 
-proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string) =
-  ## this procedure is a thin wrapper for the pubsub addValidator method
-  ## it sets message validator on the given pubsubTopic, the validator will check that
-  ## all the messages published in the pubsubTopic have a valid zero-knowledge proof 
-  proc validator(topic: string, message: messages.Message): Future[ValidationResult] {.async.} =
-    let msg = WakuMessage.init(message.data) 
-    if msg.isOk():
-      #  check the proof
-      if proofVrfy(msg.value().payload, msg.value().proof):
-        result = ValidationResult.Accept
-  # set a validator for the pubsubTopic 
-  let pb  = PubSub(node.wakuRelay)
-  pb.addValidator(pubsubTopic, validator)
+when defined(rln):
+  proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string) =
+    ## this procedure is a thin wrapper for the pubsub addValidator method
+    ## it sets message validator on the given pubsubTopic, the validator will check that
+    ## all the messages published in the pubsubTopic have a valid zero-knowledge proof 
+    proc validator(topic: string, message: messages.Message): Future[ValidationResult] {.async.} =
+      let msg = WakuMessage.init(message.data) 
+      if msg.isOk():
+        #  check the proof
+        if proofVrfy(msg.value().payload, msg.value().proof):
+          result = ValidationResult.Accept
+    # set a validator for the pubsubTopic 
+    let pb  = PubSub(node.wakuRelay)
+    pb.addValidator(pubsubTopic, validator)
 
 proc mountRelay*(node: WakuNode,
                  topics: seq[string] = newSeq[string](),
@@ -494,14 +497,14 @@ proc mountRelay*(node: WakuNode,
     # Reconnect to previous relay peers. This will respect a backoff period, if necessary
     waitFor node.peerManager.reconnectPeers(WakuRelayCodec,
                                             wakuRelay.parameters.pruneBackoff + chronos.seconds(BackoffSlackTime))
-
-  if rlnRelayEnabled:
-    # TODO pass rln relay inputs to this proc, right now it uses default values that are set in the mountRlnRelay proc
-    info "WakuRLNRelay is enabled"
-    waitFor mountRlnRelay(node)
-    # TODO currently the message validator is set for the defaultTopic, this can be configurable to accept other pubsub topics as well 
-    addRLNRelayValidator(node, defaultTopic)
-    info "WakuRLNRelay is mounted successfully"
+  when defined(rln):
+    if rlnRelayEnabled:
+      # TODO pass rln relay inputs to this proc, right now it uses default values that are set in the mountRlnRelay proc
+      info "WakuRLNRelay is enabled"
+      waitFor mountRlnRelay(node)
+      # TODO currently the message validator is set for the defaultTopic, this can be configurable to accept other pubsub topics as well 
+      addRLNRelayValidator(node, defaultTopic)
+      info "WakuRLNRelay is mounted successfully"
   
   if node.started:
     # Node has already started. Start the WakuRelay protocol

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -16,14 +16,17 @@ import
   ../protocol/waku_store/waku_store,
   ../protocol/waku_swap/waku_swap,
   ../protocol/waku_filter/waku_filter,
-  ../protocol/waku_rln_relay/[rln,waku_rln_relay_utils],
   ../protocol/waku_lightpush/waku_lightpush,
+  ../protocol/waku_rln_relay/waku_rln_relay_types,
   ../protocol/waku_keepalive/waku_keepalive,
   ../utils/peers,
   ./storage/message/message_store,
   ./storage/peer/peer_storage,
   ../utils/requests,
   ./peer_manager/peer_manager
+
+when defined(rln):
+  import ../protocol/waku_rln_relay/[rln, waku_rln_relay_utils]
 
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
 declarePublicGauge waku_node_filters, "number of content filter subscriptions"

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -2,62 +2,60 @@
 
 import os
 
-#  the following module is only available and get compiled if the compiler flag rln is passed as -d:rln 
-when defined(rln):
-  const libPath = "vendor/rln/target/debug/"
-  when defined(Windows):
-    const libName* = libPath / "rln.dll"
-  elif defined(Linux):
-    const libName* = libPath / "librln.so"
-  elif defined(MacOsX):
-    const libName* = libPath / "librln.dylib"
+const libPath = "vendor/rln/target/debug/"
+when defined(Windows):
+  const libName* = libPath / "rln.dll"
+elif defined(Linux):
+  const libName* = libPath / "librln.so"
+elif defined(MacOsX):
+  const libName* = libPath / "librln.dylib"
 
-  # all the following procedures are Nim wrappers for the functions defined in libName
-  {.push dynlib: libName, raises: [Defect].}
+# all the following procedures are Nim wrappers for the functions defined in libName
+{.push dynlib: libName, raises: [Defect].}
 
-  type RLN*[E] {.incompleteStruct.} = object
-  type Bn256* = pointer
+type RLN*[E] {.incompleteStruct.} = object
+type Bn256* = pointer
 
-  ## Buffer struct is taken from
-  # https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
-  type Buffer* = object
-    `ptr`*: ptr uint8
-    len*: uint
+## Buffer struct is taken from
+# https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
+type Buffer* = object
+  `ptr`*: ptr uint8
+  len*: uint
 
-  type Auth* = object
-    secret_buffer*: ptr Buffer
-    index*: uint
+type Auth* = object
+  secret_buffer*: ptr Buffer
+  index*: uint
 
-  #------------------------------ Merkle Tree operations -----------------------------------------
+#------------------------------ Merkle Tree operations -----------------------------------------
 
-  proc update_next_member*(ctx: ptr RLN[Bn256],
-                          input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
+proc update_next_member*(ctx: ptr RLN[Bn256],
+                        input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
 
-  proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
+proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
 
-  proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
-  #----------------------------------------------------------------------------------------------
-  #-------------------------------- zkSNARKs operations -----------------------------------------
+proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
+#----------------------------------------------------------------------------------------------
+#-------------------------------- zkSNARKs operations -----------------------------------------
 
-  proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
+proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
 
-  proc generate_proof*(ctx: ptr RLN[Bn256],
-                      input_buffer: ptr Buffer,
-                      auth: ptr Auth,
-                      output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
+proc generate_proof*(ctx: ptr RLN[Bn256],
+                    input_buffer: ptr Buffer,
+                    auth: ptr Auth,
+                    output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
 
-  proc verify*(ctx: ptr RLN[Bn256],
-              proof_buffer: ptr Buffer,
-              result_ptr: ptr uint32): bool {.importc: "verify".}
-  #----------------------------------------------------------------------------------------------
-  #-------------------------------- Common procedures -------------------------------------------
+proc verify*(ctx: ptr RLN[Bn256],
+            proof_buffer: ptr Buffer,
+            result_ptr: ptr uint32): bool {.importc: "verify".}
+#----------------------------------------------------------------------------------------------
+#-------------------------------- Common procedures -------------------------------------------
 
-  proc new_circuit_from_params*(merkle_depth: uint,
-                                parameters_buffer: ptr Buffer,
-                                ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
+proc new_circuit_from_params*(merkle_depth: uint,
+                              parameters_buffer: ptr Buffer,
+                              ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
 
-  proc hash*(ctx: ptr RLN[Bn256],
-            inputs_buffer: ptr Buffer,
-            input_len: uint,
-            output_buffer: ptr Buffer): bool {.importc: "hash".}
-  {.pop.}
+proc hash*(ctx: ptr RLN[Bn256],
+          inputs_buffer: ptr Buffer,
+          input_len: uint,
+          output_buffer: ptr Buffer): bool {.importc: "hash".}
+{.pop.}

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -2,61 +2,62 @@
 
 import os
 
+#  the following module is only available and get compiled if the compiler flag rln is passed as -d:rln 
+when defined(rln):
+  const libPath = "vendor/rln/target/debug/"
+  when defined(Windows):
+    const libName* = libPath / "rln.dll"
+  elif defined(Linux):
+    const libName* = libPath / "librln.so"
+  elif defined(MacOsX):
+    const libName* = libPath / "librln.dylib"
 
-const libPath = "vendor/rln/target/debug/"
-when defined(Windows):
-  const libName* = libPath / "rln.dll"
-elif defined(Linux):
-  const libName* = libPath / "librln.so"
-elif defined(MacOsX):
-  const libName* = libPath / "librln.dylib"
+  # all the following procedures are Nim wrappers for the functions defined in libName
+  {.push dynlib: libName, raises: [Defect].}
 
- # all the following procedures are Nim wrappers for the functions defined in libName
-{.push dynlib: libName, raises: [Defect].}
+  type RLN*[E] {.incompleteStruct.} = object
+  type Bn256* = pointer
 
-type RLN*[E] {.incompleteStruct.} = object
-type Bn256* = pointer
+  ## Buffer struct is taken from
+  # https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
+  type Buffer* = object
+    `ptr`*: ptr uint8
+    len*: uint
 
-## Buffer struct is taken from
-# https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
-type Buffer* = object
-  `ptr`*: ptr uint8
-  len*: uint
+  type Auth* = object
+    secret_buffer*: ptr Buffer
+    index*: uint
 
-type Auth* = object
-  secret_buffer*: ptr Buffer
-  index*: uint
+  #------------------------------ Merkle Tree operations -----------------------------------------
 
-#------------------------------ Merkle Tree operations -----------------------------------------
+  proc update_next_member*(ctx: ptr RLN[Bn256],
+                          input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
 
-proc update_next_member*(ctx: ptr RLN[Bn256],
-                         input_buffer: ptr Buffer): bool {.importc: "update_next_member".}
+  proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
 
-proc delete_member*(ctx: ptr RLN[Bn256], index: uint): bool {.importc: "delete_member".}
+  proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
+  #----------------------------------------------------------------------------------------------
+  #-------------------------------- zkSNARKs operations -----------------------------------------
 
-proc get_root*(ctx: ptr RLN[Bn256], output_buffer: ptr Buffer): bool {.importc: "get_root".}
-#----------------------------------------------------------------------------------------------
-#-------------------------------- zkSNARKs operations -----------------------------------------
+  proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
 
-proc key_gen*(ctx: ptr RLN[Bn256], keypair_buffer: ptr Buffer): bool {.importc: "key_gen".}
+  proc generate_proof*(ctx: ptr RLN[Bn256],
+                      input_buffer: ptr Buffer,
+                      auth: ptr Auth,
+                      output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
 
-proc generate_proof*(ctx: ptr RLN[Bn256],
-                     input_buffer: ptr Buffer,
-                     auth: ptr Auth,
-                     output_buffer: ptr Buffer): bool {.importc: "generate_proof".}
+  proc verify*(ctx: ptr RLN[Bn256],
+              proof_buffer: ptr Buffer,
+              result_ptr: ptr uint32): bool {.importc: "verify".}
+  #----------------------------------------------------------------------------------------------
+  #-------------------------------- Common procedures -------------------------------------------
 
-proc verify*(ctx: ptr RLN[Bn256],
-             proof_buffer: ptr Buffer,
-             result_ptr: ptr uint32): bool {.importc: "verify".}
-#----------------------------------------------------------------------------------------------
-#-------------------------------- Common procedures -------------------------------------------
+  proc new_circuit_from_params*(merkle_depth: uint,
+                                parameters_buffer: ptr Buffer,
+                                ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
 
-proc new_circuit_from_params*(merkle_depth: uint,
-                              parameters_buffer: ptr Buffer,
-                              ctx: ptr (ptr RLN[Bn256])): bool {.importc: "new_circuit_from_params".}
-
-proc hash*(ctx: ptr RLN[Bn256],
-           inputs_buffer: ptr Buffer,
-           input_len: uint,
-           output_buffer: ptr Buffer): bool {.importc: "hash".}
-{.pop.}
+  proc hash*(ctx: ptr RLN[Bn256],
+            inputs_buffer: ptr Buffer,
+            input_len: uint,
+            output_buffer: ptr Buffer): bool {.importc: "hash".}
+  {.pop.}

--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -1,6 +1,8 @@
 # this module contains the Nim wrappers for the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
 
-import os
+import
+  os,
+  waku_rln_relay_types
 
 const libPath = "vendor/rln/target/debug/"
 when defined(Windows):
@@ -13,8 +15,6 @@ elif defined(MacOsX):
 # all the following procedures are Nim wrappers for the functions defined in libName
 {.push dynlib: libName, raises: [Defect].}
 
-type RLN*[E] {.incompleteStruct.} = object
-type Bn256* = pointer
 
 ## Buffer struct is taken from
 # https://github.com/celo-org/celo-threshold-bls-rs/blob/master/crates/threshold-bls-ffi/src/ffi.rs
@@ -25,7 +25,7 @@ type Buffer* = object
 type Auth* = object
   secret_buffer*: ptr Buffer
   index*: uint
-
+  
 #------------------------------ Merkle Tree operations -----------------------------------------
 
 proc update_next_member*(ctx: ptr RLN[Bn256],

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -3,6 +3,14 @@ import
   web3,
   eth/keys
 
+## Bn256 and RLN are Nim wrappers for the data types defined in 
+## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
+## RLN maps to circuit::rln, public::RLN
+## Bn256 maps to bellman::pairing::bn256::Bn256
+type Bn256* = pointer
+type RLN*[E] {.incompleteStruct.} = object
+
+# Custom data types defined for waku rln relay -------------------------
 type MembershipKeyPair* = object 
   secretKey*: array[32, byte]
   publicKey*: array[32, byte]
@@ -19,7 +27,7 @@ type WakuRLNRelay* = object
 
 # inputs of the membership contract constructor
 const 
-    MembershipFee* = 5.u256
-    Depth* = 32.u256
-    # TODO the EthClient should be an input to the rln-relay
-    EthClient* = "ws://localhost:8540/"
+  MembershipFee* = 5.u256
+  Depth* = 32.u256
+  # TODO the EthClient should be an input to the rln-relay
+  EthClient* = "ws://localhost:8540/"

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -1,0 +1,31 @@
+import 
+  chronicles, options, chronos, stint,
+  web3,
+  stew/byteutils,
+  eth/keys
+  
+type MembershipKeyPair* = object 
+  secretKey*: array[32, byte]
+  publicKey*: array[32, byte]
+
+type WakuRLNRelay* = object 
+  membershipKeyPair*: MembershipKeyPair
+  ethClientAddress*: string
+  ethAccountAddress*: Address
+  # this field is required for signing transactions
+  # TODO may need to erase this ethAccountPrivateKey when is not used
+  # TODO may need to make ethAccountPrivateKey mandatory
+  ethAccountPrivateKey*: Option[PrivateKey]
+  membershipContractAddress*: Address
+
+# inputs of the membership contract constructor
+const 
+    MembershipFee* = 5.u256
+    Depth* = 32.u256
+    # TODO the EthClient should be an input to the rln-relay
+    EthClient* = "ws://localhost:8540/"
+
+# membership contract interface
+contract(MembershipContract):
+  # TODO define a return type of bool for register method to signify a successful registration
+  proc register(pubkey: Uint256) # external payable

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -3,7 +3,7 @@ import
   web3,
   eth/keys
 
-## Bn256 and RLN are Nim wrappers for the data types defined in 
+## Bn256 and RLN are Nim wrappers for the data types used in 
 ## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
 ## RLN maps to circuit::rln, public::RLN
 ## Bn256 maps to bellman::pairing::bn256::Bn256
@@ -26,6 +26,7 @@ type WakuRLNRelay* = object
   membershipContractAddress*: Address
 
 # inputs of the membership contract constructor
+# TODO may be able to make these constants private and put them inside the waku_rln_relay_utils
 const 
   MembershipFee* = 5.u256
   Depth* = 32.u256

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -5,8 +5,6 @@ import
 
 ## Bn256 and RLN are Nim wrappers for the data types used in 
 ## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
-## RLN maps to circuit::rln, public::RLN
-## Bn256 maps to bellman::pairing::bn256::Bn256
 type Bn256* = pointer
 type RLN*[E] {.incompleteStruct.} = object
 

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -1,9 +1,8 @@
 import 
   chronicles, options, chronos, stint,
   web3,
-  stew/byteutils,
   eth/keys
-  
+
 type MembershipKeyPair* = object 
   secretKey*: array[32, byte]
   publicKey*: array[32, byte]
@@ -24,8 +23,3 @@ const
     Depth* = 32.u256
     # TODO the EthClient should be an input to the rln-relay
     EthClient* = "ws://localhost:8540/"
-
-# membership contract interface
-contract(MembershipContract):
-  # TODO define a return type of bool for register method to signify a successful registration
-  proc register(pubkey: Uint256) # external payable

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -3,118 +3,96 @@ import
   web3,
   stew/byteutils,
   eth/keys,
-  rln 
-
-type MembershipKeyPair* = object 
-  secretKey*: array[32, byte]
-  publicKey*: array[32, byte]
-
-type WakuRLNRelay* = object 
-  membershipKeyPair*: MembershipKeyPair
-  ethClientAddress*: string
-  ethAccountAddress*: Address
-  # this field is required for signing transactions
-  # TODO may need to erase this ethAccountPrivateKey when is not used
-  # TODO may need to make ethAccountPrivateKey mandatory
-  ethAccountPrivateKey*: Option[PrivateKey]
-  membershipContractAddress*: Address
-
-# inputs of the membership contract constructor
-const 
-    MembershipFee* = 5.u256
-    Depth* = 32.u256
-    # TODO the EthClient should be an input to the rln-relay
-    EthClient* = "ws://localhost:8540/"
+  rln, 
+  waku_rln_relay_types
 
 # membership contract interface
 contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
+  
+proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
+  ## generates an instance of RLN 
+  ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
+  ## d indicates the depth of Merkle tree 
+  var  
+    ctxPtrPtr = addr(ctxPtr)
+    merkleDepth: csize_t = uint(d)
+    # parameters.key contains the parameters related to the Poseidon hasher
+    # to generate this file, clone this repo https://github.com/kilic/rln 
+    # and run the following command in the root directory of the cloned project
+    # cargo run --example export_test_keys
+    # the file is generated separately and copied here
+    parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+    pbytes = parameters.toBytes()
+    len : csize_t = uint(pbytes.len)
+    parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
 
-#  the following procedures are only available and get compiled if the compiler flag rln is passed as -d:rln 
-when defined(rln):
-  proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
-    ## generates an instance of RLN 
-    ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
-    ## d indicates the depth of Merkle tree 
-    var  
-      ctxPtrPtr = addr(ctxPtr)
-      merkleDepth: csize_t = uint(d)
-      # parameters.key contains the parameters related to the Poseidon hasher
-      # to generate this file, clone this repo https://github.com/kilic/rln 
-      # and run the following command in the root directory of the cloned project
-      # cargo run --example export_test_keys
-      # the file is generated separately and copied here
-      parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-      pbytes = parameters.toBytes()
-      len : csize_t = uint(pbytes.len)
-      parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
+  # check the parameters.key is not empty
+  if (pbytes.len == 0):
+    debug "error in parameters.key"
+    return false
+  
+  # create an instance of RLN
+  let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctxPtrPtr)
+  # check whether the circuit parameters are generated successfully
+  if (res == false): 
+    debug "error in parameters generation"
+    return false
+  return true
 
-    # check the parameters.key is not empty
-    if (pbytes.len == 0):
-      debug "error in parameters.key"
-      return false
+proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
+  ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
     
-    # create an instance of RLN
-    let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctxPtrPtr)
-    # check whether the circuit parameters are generated successfully
-    if (res == false): 
-      debug "error in parameters generation"
-      return false
-    return true
+  # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
+  var 
+    keysBuffer : Buffer
+    keysBufferPtr = addr(keysBuffer)
+    done = key_gen(ctxPtr, keysBufferPtr)  
 
-  proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
-    ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
-      
-    # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
-    var 
-      keysBuffer : Buffer
-      keysBufferPtr = addr(keysBuffer)
-      done = key_gen(ctxPtr, keysBufferPtr)  
-
-    # check whether the keys are generated successfully
-    if(done == false):
-      debug "error in key generation"
-      return none(MembershipKeyPair)
-      
-    var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
-    # the public and secret keys together are 64 bytes
-    if (generatedKeys.len != 64):
-      debug "the generated keys are invalid"
-      return none(MembershipKeyPair)
+  # check whether the keys are generated successfully
+  if(done == false):
+    debug "error in key generation"
+    return none(MembershipKeyPair)
     
-    # TODO define a separate proc to decode the generated keys to the secret and public components
-    var 
-      secret: array[32, byte] 
-      public: array[32, byte]
-    for (i,x) in secret.mpairs: x = generatedKeys[i]
-    for (i,x) in public.mpairs: x = generatedKeys[i+32]
-    
-    var 
-      keypair = MembershipKeyPair(secretKey: secret, publicKey: public)
+  var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
+  # the public and secret keys together are 64 bytes
+  if (generatedKeys.len != 64):
+    debug "the generated keys are invalid"
+    return none(MembershipKeyPair)
+  
+  # TODO define a separate proc to decode the generated keys to the secret and public components
+  var 
+    secret: array[32, byte] 
+    public: array[32, byte]
+  for (i,x) in secret.mpairs: x = generatedKeys[i]
+  for (i,x) in public.mpairs: x = generatedKeys[i+32]
+  
+  var 
+    keypair = MembershipKeyPair(secretKey: secret, publicKey: public)
 
 
-    return some(keypair)
+  return some(keypair)
 
-  proc register*(rlnPeer: WakuRLNRelay): Future[bool] {.async.} =
-    ## registers the public key of the rlnPeer which is rlnPeer.membershipKeyPair.publicKey
-    ## into the membership contract whose address is in rlnPeer.membershipContractAddress
-    let web3 = await newWeb3(rlnPeer.ethClientAddress)
-    web3.defaultAccount = rlnPeer.ethAccountAddress
-    # when the private key is set in a web3 instance, the send proc (sender.register(pk).send(MembershipFee))
-    # does the signing using the provided key
-    web3.privateKey = rlnPeer.ethAccountPrivateKey
-    var sender = web3.contractSender(MembershipContract, rlnPeer.membershipContractAddress) # creates a Sender object with a web3 field and contract address of type Address
-    let pk = cast[UInt256](rlnPeer.membershipKeyPair.publicKey)
-    discard await sender.register(pk).send(MembershipFee)
-    # TODO check the receipt and then return true/false
-    await web3.close()
-    return true 
+proc register*(rlnPeer: WakuRLNRelay): Future[bool] {.async.} =
+  ## registers the public key of the rlnPeer which is rlnPeer.membershipKeyPair.publicKey
+  ## into the membership contract whose address is in rlnPeer.membershipContractAddress
+  let web3 = await newWeb3(rlnPeer.ethClientAddress)
+  web3.defaultAccount = rlnPeer.ethAccountAddress
+  # when the private key is set in a web3 instance, the send proc (sender.register(pk).send(MembershipFee))
+  # does the signing using the provided key
+  web3.privateKey = rlnPeer.ethAccountPrivateKey
+  var sender = web3.contractSender(MembershipContract, rlnPeer.membershipContractAddress) # creates a Sender object with a web3 field and contract address of type Address
+  let pk = cast[UInt256](rlnPeer.membershipKeyPair.publicKey)
+  discard await sender.register(pk).send(MembershipFee)
+  # TODO check the receipt and then return true/false
+  await web3.close()
+  return true 
 
-  proc proofGen*(data: seq[byte]): seq[byte] =
-    # TODO to implement the actual proof generation logic
-    return "proof".toBytes() 
+proc proofGen*(data: seq[byte]): seq[byte] =
+  # TODO to implement the actual proof generation logic
+  return "proof".toBytes() 
 
-  proc proofVrfy*(data, proof: seq[byte]): bool =
-    # TODO to implement the actual proof verification logic
-    return true
+proc proofVrfy*(data, proof: seq[byte]): bool =
+  # TODO to implement the actual proof verification logic
+  return true

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -2,7 +2,6 @@ import
   chronicles, options, chronos, stint,
   web3,
   stew/byteutils,
-  eth/keys,
   rln, 
   waku_rln_relay_types
 
@@ -10,7 +9,7 @@ import
 contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
-  
+
 proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
   ## generates an instance of RLN 
   ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -31,88 +31,90 @@ contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
 
-proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
-  ## generates an instance of RLN 
-  ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
-  ## d indicates the depth of Merkle tree 
-  var  
-    ctxPtrPtr = addr(ctxPtr)
-    merkleDepth: csize_t = uint(d)
-    # parameters.key contains the parameters related to the Poseidon hasher
-    # to generate this file, clone this repo https://github.com/kilic/rln 
-    # and run the following command in the root directory of the cloned project
-    # cargo run --example export_test_keys
-    # the file is generated separately and copied here
-    parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
-    pbytes = parameters.toBytes()
-    len : csize_t = uint(pbytes.len)
-    parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
+#  the following procedures are only available and get compiled if the compiler flag rln is passed as -d:rln 
+when defined(rln):
+  proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
+    ## generates an instance of RLN 
+    ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
+    ## d indicates the depth of Merkle tree 
+    var  
+      ctxPtrPtr = addr(ctxPtr)
+      merkleDepth: csize_t = uint(d)
+      # parameters.key contains the parameters related to the Poseidon hasher
+      # to generate this file, clone this repo https://github.com/kilic/rln 
+      # and run the following command in the root directory of the cloned project
+      # cargo run --example export_test_keys
+      # the file is generated separately and copied here
+      parameters = readFile("waku/v2/protocol/waku_rln_relay/parameters.key")
+      pbytes = parameters.toBytes()
+      len : csize_t = uint(pbytes.len)
+      parametersBuffer = Buffer(`ptr`: addr(pbytes[0]), len: len)
 
-  # check the parameters.key is not empty
-  if (pbytes.len == 0):
-    debug "error in parameters.key"
-    return false
-  
-  # create an instance of RLN
-  let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctxPtrPtr)
-  # check whether the circuit parameters are generated successfully
-  if (res == false): 
-    debug "error in parameters generation"
-    return false
-  return true
-
-proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
-  ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
+    # check the parameters.key is not empty
+    if (pbytes.len == 0):
+      debug "error in parameters.key"
+      return false
     
-  # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
-  var 
-    keysBuffer : Buffer
-    keysBufferPtr = addr(keysBuffer)
-    done = key_gen(ctxPtr, keysBufferPtr)  
+    # create an instance of RLN
+    let res = new_circuit_from_params(merkleDepth, addr parametersBuffer, ctxPtrPtr)
+    # check whether the circuit parameters are generated successfully
+    if (res == false): 
+      debug "error in parameters generation"
+      return false
+    return true
 
-  # check whether the keys are generated successfully
-  if(done == false):
-    debug "error in key generation"
-    return none(MembershipKeyPair)
+  proc membershipKeyGen*(ctxPtr: ptr RLN[Bn256]): Option[MembershipKeyPair] =
+    ## generates a MembershipKeyPair that can be used for the registration into the rln membership contract
+      
+    # keysBufferPtr will hold the generated key pairs i.e., secret and public keys 
+    var 
+      keysBuffer : Buffer
+      keysBufferPtr = addr(keysBuffer)
+      done = key_gen(ctxPtr, keysBufferPtr)  
+
+    # check whether the keys are generated successfully
+    if(done == false):
+      debug "error in key generation"
+      return none(MembershipKeyPair)
+      
+    var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
+    # the public and secret keys together are 64 bytes
+    if (generatedKeys.len != 64):
+      debug "the generated keys are invalid"
+      return none(MembershipKeyPair)
     
-  var generatedKeys = cast[ptr array[64, byte]](keysBufferPtr.`ptr`)[]
-  # the public and secret keys together are 64 bytes
-  if (generatedKeys.len != 64):
-    debug "the generated keys are invalid"
-    return none(MembershipKeyPair)
-  
-  # TODO define a separate proc to decode the generated keys to the secret and public components
-  var 
-    secret: array[32, byte] 
-    public: array[32, byte]
-  for (i,x) in secret.mpairs: x = generatedKeys[i]
-  for (i,x) in public.mpairs: x = generatedKeys[i+32]
-  
-  var 
-    keypair = MembershipKeyPair(secretKey: secret, publicKey: public)
+    # TODO define a separate proc to decode the generated keys to the secret and public components
+    var 
+      secret: array[32, byte] 
+      public: array[32, byte]
+    for (i,x) in secret.mpairs: x = generatedKeys[i]
+    for (i,x) in public.mpairs: x = generatedKeys[i+32]
+    
+    var 
+      keypair = MembershipKeyPair(secretKey: secret, publicKey: public)
 
 
-  return some(keypair)
+    return some(keypair)
 
-proc register*(rlnPeer: WakuRLNRelay): Future[bool] {.async.} =
-  ## registers the public key of the rlnPeer which is rlnPeer.membershipKeyPair.publicKey
-  ## into the membership contract whose address is in rlnPeer.membershipContractAddress
-  let web3 = await newWeb3(rlnPeer.ethClientAddress)
-  web3.defaultAccount = rlnPeer.ethAccountAddress
-  # when the private key is set in a web3 instance, the send proc (sender.register(pk).send(MembershipFee))
-  # does the signing using the provided key
-  web3.privateKey = rlnPeer.ethAccountPrivateKey
-  var sender = web3.contractSender(MembershipContract, rlnPeer.membershipContractAddress) # creates a Sender object with a web3 field and contract address of type Address
-  let pk = cast[UInt256](rlnPeer.membershipKeyPair.publicKey)
-  discard await sender.register(pk).send(MembershipFee)
-  # TODO check the receipt and then return true/false
-  await web3.close()
-  return true 
+  proc register*(rlnPeer: WakuRLNRelay): Future[bool] {.async.} =
+    ## registers the public key of the rlnPeer which is rlnPeer.membershipKeyPair.publicKey
+    ## into the membership contract whose address is in rlnPeer.membershipContractAddress
+    let web3 = await newWeb3(rlnPeer.ethClientAddress)
+    web3.defaultAccount = rlnPeer.ethAccountAddress
+    # when the private key is set in a web3 instance, the send proc (sender.register(pk).send(MembershipFee))
+    # does the signing using the provided key
+    web3.privateKey = rlnPeer.ethAccountPrivateKey
+    var sender = web3.contractSender(MembershipContract, rlnPeer.membershipContractAddress) # creates a Sender object with a web3 field and contract address of type Address
+    let pk = cast[UInt256](rlnPeer.membershipKeyPair.publicKey)
+    discard await sender.register(pk).send(MembershipFee)
+    # TODO check the receipt and then return true/false
+    await web3.close()
+    return true 
 
-proc proofGen*(data: seq[byte]): seq[byte] =
-  # TODO to implement the actual proof generation logic
-  return "proof".toBytes() 
+  proc proofGen*(data: seq[byte]): seq[byte] =
+    # TODO to implement the actual proof generation logic
+    return "proof".toBytes() 
 
-proc proofVrfy*(data, proof: seq[byte]): bool =
-  # TODO to implement the actual proof verification logic
-  return true
+  proc proofVrfy*(data, proof: seq[byte]): bool =
+    # TODO to implement the actual proof verification logic
+    return true


### PR DESCRIPTION
# Problem
This PR isolates rln, disables it by default unless proper flags are set.
- rln-related codes and tests will not be compiled unless the `rln` flag is set (i.e., `nim c -d:rln`). 
- all of the rln-related build/dependency targets in the Make file are conditioned to the `RLN` variable being true. This variable affects two targets: namely, `rlnlib` that fetches and builds the rln dynamic library, and `installganache` that spins up ganache-cli.  When the `RLN` var also controls the rln compilation flag.
- Run `make <target> -RLN=true` to enable compilation of rln and to resolve its dependencies. 

It is also a  workaround for https://github.com/status-im/nim-waku/issues/546