### PR TITLE
Fix: Remove rln file from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 # Copy to separate location to accomodate different MAKE_TARGET values
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
-# Fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+# If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
+# COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
 
 # Symlink the correct wakunode binary
 RUN ln -sv /usr/local/bin/$MAKE_TARGET /usr/bin/wakunode


### PR DESCRIPTION
Since 2fe53c3, the Jenkins [deployment job](https://ci.status.im/job/nim-waku/job/deploy-v2-test/) has been failing with error log:

```
21:10:26  Step 19/22 : COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
21:10:26  COPY failed: stat app/vendor/rln/target/debug/librln.so: file does not exist
```

This PR fixes that by removing the librln file copy from the `Dockerfile`.