### PR TITLE
Fix: metrics-server use after submodule update

### DIFF
--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -1,6 +1,7 @@
 import
   std/[tables, times, strutils, hashes, sequtils],
-  chronos, confutils, chronicles, chronicles/topics_registry, metrics,
+  chronos, confutils, chronicles, chronicles/topics_registry, 
+  metrics, metrics/chronos_httpserver,
   stew/[byteutils, endians2],
   stew/shims/net as stewNet, json_rpc/rpcserver,
   # Matterbridge client imports
@@ -284,6 +285,6 @@ when isMainModule:
         address = conf.metricsServerAddress
         port = conf.metricsServerPort + conf.portsShift
       info "Starting metrics HTTP server", address, port
-      metrics.startHttpServer($address, Port(port))
+      startMetricsHttpServer($address, Port(port))
 
   runForever()

--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -279,12 +279,11 @@ when isMainModule:
 
     rpcServer.start()
 
-  when defined(insecure):
-    if conf.metricsServer:
-      let
-        address = conf.metricsServerAddress
-        port = conf.metricsServerPort + conf.portsShift
-      info "Starting metrics HTTP server", address, port
-      startMetricsHttpServer($address, Port(port))
+  if conf.metricsServer:
+    let
+      address = conf.metricsServerAddress
+      port = conf.metricsServerPort + conf.portsShift
+    info "Starting metrics HTTP server", address, port
+    startMetricsHttpServer($address, Port(port))
 
   runForever()

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -1,6 +1,7 @@
 import
   std/[tables, hashes, sequtils],
-  chronos, confutils, chronicles, chronicles/topics_registry, metrics,
+  chronos, confutils, chronicles, chronicles/topics_registry, 
+  metrics, metrics/chronos_httpserver,
   stew/[byteutils, objects],
   stew/shims/net as stewNet, json_rpc/rpcserver,
   # Waku v1 imports
@@ -290,6 +291,6 @@ when isMainModule:
         address = conf.metricsServerAddress
         port = conf.metricsServerPort + conf.portsShift
       info "Starting metrics HTTP server", address, port
-      metrics.startHttpServer($address, Port(port))
+      startMetricsHttpServer($address, Port(port))
 
   runForever()

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -285,12 +285,11 @@ when isMainModule:
 
     rpcServer.start()
 
-  when defined(insecure):
-    if conf.metricsServer:
-      let
-        address = conf.metricsServerAddress
-        port = conf.metricsServerPort + conf.portsShift
-      info "Starting metrics HTTP server", address, port
-      startMetricsHttpServer($address, Port(port))
+  if conf.metricsServer:
+    let
+      address = conf.metricsServerAddress
+      port = conf.metricsServerPort + conf.portsShift
+    info "Starting metrics HTTP server", address, port
+    startMetricsHttpServer($address, Port(port))
 
   runForever()

--- a/waku/v1/node/wakunode1.nim
+++ b/waku/v1/node/wakunode1.nim
@@ -99,13 +99,12 @@ proc run(config: WakuNodeConf, rng: ref BrHmacDrbgContext) =
       discard setTimer(Moment.fromNow(2.seconds), logPeerAccounting)
     discard setTimer(Moment.fromNow(2.seconds), logPeerAccounting)
 
-  when defined(insecure):
-    if config.metricsServer:
-      let
-        address = config.metricsServerAddress
-        port = config.metricsServerPort + config.portsShift
-      info "Starting metrics HTTP server", address, port
-      startMetricsHttpServer($address, Port(port))
+  if config.metricsServer:
+    let
+      address = config.metricsServerAddress
+      port = config.metricsServerPort + config.portsShift
+    info "Starting metrics HTTP server", address, port
+    startMetricsHttpServer($address, Port(port))
 
   if config.logMetrics:
     # https://github.com/nim-lang/Nim/issues/17369

--- a/waku/v1/node/wakunode1.nim
+++ b/waku/v1/node/wakunode1.nim
@@ -1,5 +1,6 @@
 import
-  confutils, chronos, json_rpc/rpcserver, metrics, metrics/chronicles_support,
+  confutils, chronos, json_rpc/rpcserver, 
+  metrics, metrics/chronicles_support, metrics/chronos_httpserver,
   stew/shims/net as stewNet,
   eth/[keys, p2p], eth/common/utils,
   eth/p2p/[discovery, enode, peer_pool, bootnodes, whispernodes],
@@ -104,7 +105,7 @@ proc run(config: WakuNodeConf, rng: ref BrHmacDrbgContext) =
         address = config.metricsServerAddress
         port = config.metricsServerPort + config.portsShift
       info "Starting metrics HTTP server", address, port
-      metrics.startHttpServer($address, Port(port))
+      startMetricsHttpServer($address, Port(port))
 
   if config.logMetrics:
     # https://github.com/nim-lang/Nim/issues/17369

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -781,10 +781,9 @@ when isMainModule:
   if conf.metricsLogging:
     startMetricsLog()
 
-  when defined(insecure):
-    if conf.metricsServer:
-      startMetricsServer(conf.metricsServerAddress,
-        Port(conf.metricsServerPort + conf.portsShift))
+  if conf.metricsServer:
+    startMetricsServer(conf.metricsServerAddress,
+      Port(conf.metricsServerPort + conf.portsShift))
   
   # Setup graceful shutdown
   


### PR DESCRIPTION
Fix required by changes in `metrics` submodule.

This is necessary where compiling with `-d:insecure` Nim flag, such as during deployment to fleet nodes.

For this reason the `test` deployment for Waku v1 has been [failing](https://ci.status.im/job/nim-waku/job/deploy-v1-test/162/)