### PR TITLE
Gets rln lib path at the compile time

### DIFF
--- a/waku/v2/protocol/waku_rln_relay/rln.nim
+++ b/waku/v2/protocol/waku_rln_relay/rln.nim
@@ -1,10 +1,13 @@
 # this module contains the Nim wrappers for the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
 
 import
-  os,
+  std/[os,strutils],
   waku_rln_relay_types
 
-const libPath = "vendor/rln/target/debug/"
+
+template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+
+const libPath = sourceDir / "../../../../vendor/rln/target/debug/"
 when defined(Windows):
   const libName* = libPath / "rln.dll"
 elif defined(Linux):


### PR DESCRIPTION
The path to the rln lib has been initially set relative to the nim-waku root directory. However, this path does not get recognized by the Nim compiler when nim-waku is imported as a submodule. This PR is to resolve this problem.
As the solution, the `currentSourcePath()` template is used to get the full file-system path of the `rln.nim` module at the compilation time, and then the `rln` lib path is set relative to that.

