### PR TITLE
Add Issuer to Cheque Object 

### DIFF
--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -148,12 +148,13 @@ proc handleCheque*(ws: WakuSwap, cheque: Cheque) =
   let peerOpt = ws.peerManager.selectPeer(WakuSwapCodec)
   let peerId = peerOpt.get().peerId
 
-    # Get the original signer using web3. Check if web3.eth.personal.ecRecover(messageHash, signature); or an equivalent function has been implemented in nim-web3
+  # Get the original signer using web3. For notw, a static value is used.
+  # Check if web3.eth.personal.ecRecover(messageHash, signature); or an equivalent function has been implemented in nim-web3
   let signer = @[byte 0, 1, 2]
 
+  # Verify that the Issuer was the signer of the signature
   if signer != cheque.issuer:
     warn "Invalid cheque: The address of the issuer is different from the signer."
-
 
   # TODO Redeem cheque here
   var signature = cast[string](cheque.signature)

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -148,7 +148,7 @@ proc handleCheque*(ws: WakuSwap, cheque: Cheque) =
   let peerOpt = ws.peerManager.selectPeer(WakuSwapCodec)
   let peerId = peerOpt.get().peerId
 
-  # Get the original signer using web3. For notw, a static value is used.
+  # Get the original signer using web3. For now, a static value (@[byte 0, 1, 2]) will be used.
   # Check if web3.eth.personal.ecRecover(messageHash, signature); or an equivalent function has been implemented in nim-web3
   let signer = @[byte 0, 1, 2]
 

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -148,6 +148,13 @@ proc handleCheque*(ws: WakuSwap, cheque: Cheque) =
   let peerOpt = ws.peerManager.selectPeer(WakuSwapCodec)
   let peerId = peerOpt.get().peerId
 
+    # Get the original signer using web3. Check if web3.eth.personal.ecRecover(messageHash, signature); or an quivalent has been implemented in nim-web3
+  let signer = @[byte 0, 1, 2]
+
+  if signer != cheque.issuer:
+    warn "Invalid cheque: The address of the issuer is different from the signer."
+
+
   # TODO Redeem cheque here
   var signature = cast[string](cheque.signature)
   # TODO Where should Alice Swap Address come from? Handshake probably?

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -148,7 +148,7 @@ proc handleCheque*(ws: WakuSwap, cheque: Cheque) =
   let peerOpt = ws.peerManager.selectPeer(WakuSwapCodec)
   let peerId = peerOpt.get().peerId
 
-    # Get the original signer using web3. Check if web3.eth.personal.ecRecover(messageHash, signature); or an quivalent has been implemented in nim-web3
+    # Get the original signer using web3. Check if web3.eth.personal.ecRecover(messageHash, signature); or an equivalent function has been implemented in nim-web3
   let signer = @[byte 0, 1, 2]
 
   if signer != cheque.issuer:

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -121,6 +121,7 @@ proc sendCheque*(ws: WakuSwap) {.async.} =
   # TODO We get this from the setup of swap setup, dynamic, should be part of setup
   # TODO Add beneficiary, etc
   var aliceSwapAddress = "0x6C3d502f1a97d4470b881015b83D9Dd1062172e1"
+  var aliceWalletAddress = "0x6C3d502f1a97d4470b881015b83D9Dd1062172e1"
   var signature: string
 
   var res = waku_swap_contracts.signCheque(aliceSwapAddress)
@@ -132,9 +133,9 @@ proc sendCheque*(ws: WakuSwap) {.async.} =
     # To test code paths, this should look different in a production setting
     warn "Something went wrong when signing cheque, sending anyway"
 
-  info "Signed Cheque", swapAddress = aliceSwapAddress, signature = signature
+  info "Signed Cheque", swapAddress = aliceSwapAddress, signature = signature, issuerAddress = aliceWalletAddress
   let sigBytes = cast[seq[byte]](signature)
-  await connOpt.get().writeLP(Cheque(amount: 1, signature: sigBytes).encode().buffer)
+  await connOpt.get().writeLP(Cheque(amount: 1, signature: sigBytes, issuerAddress: aliceWalletAddress).encode().buffer)
 
   # Set new balance
   let peerId = peer.peerId
@@ -148,12 +149,12 @@ proc handleCheque*(ws: WakuSwap, cheque: Cheque) =
   let peerOpt = ws.peerManager.selectPeer(WakuSwapCodec)
   let peerId = peerOpt.get().peerId
 
-  # Get the original signer using web3. For now, a static value (@[byte 0, 1, 2]) will be used.
+  # Get the original signer using web3. For now, a static value (0x6C3d502f1a97d4470b881015b83D9Dd1062172e1) will be used.
   # Check if web3.eth.personal.ecRecover(messageHash, signature); or an equivalent function has been implemented in nim-web3
-  let signer = @[byte 0, 1, 2]
+  let signer = "0x6C3d502f1a97d4470b881015b83D9Dd1062172e1"
 
   # Verify that the Issuer was the signer of the signature
-  if signer != cheque.issuer:
+  if signer != cheque.issuerAddress:
     warn "Invalid cheque: The address of the issuer is different from the signer."
 
   # TODO Redeem cheque here

--- a/waku/v2/protocol/waku_swap/waku_swap_types.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_types.nim
@@ -21,15 +21,14 @@ type
     disconnectThreshold* : int
 
   Beneficiary* = seq[byte]
-  Issuer* = seq[byte]
-
+  
   # TODO Consider adding payment threshhold and terms field
   Handshake* = object
     beneficiary*: Beneficiary
 
   # TODO Look over these data structures again
   Cheque* = object
-    issuer*: Issuer
+    issuerAddress*: string
     beneficiary*: Beneficiary
     date*: uint32
     amount*: uint32

--- a/waku/v2/protocol/waku_swap/waku_swap_types.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_types.nim
@@ -21,14 +21,15 @@ type
     disconnectThreshold* : int
 
   Beneficiary* = seq[byte]
+  Issuer* = seq[byte]
 
   # TODO Consider adding payment threshhold and terms field
   Handshake* = object
     beneficiary*: Beneficiary
 
-  # XXX I'm confused by lack of signature here, most important thing...
   # TODO Look over these data structures again
   Cheque* = object
+    issuer*: Issuer
     beneficiary*: Beneficiary
     date*: uint32
     amount*: uint32


### PR DESCRIPTION
closes #626

`Issuer` has been added to the cheque object. The essence Of this is to enable the signatures to be verified by the recipient using the Issuer's public key.  

