### PR TITLE
Support for stable version of relay protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This release contains the following:
 ### Changes
 - Enables db migration for the message store.
 - The `resume` Nim API eliminates duplicates messages before storing them.
+- Support for stable version of `relay` protocol, with protocol ID `/vac/waku/relay/2.0.0`
 
 #### General refactoring
 #### Docs

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -480,7 +480,13 @@ proc mountRelay*(node: WakuNode,
   
   info "mounting relay", rlnRelayEnabled=rlnRelayEnabled, relayMessages=relayMessages
 
-  node.switch.mount(wakuRelay)
+  proc relayMatch(proto: string): bool {.gcsafe.} =
+    ## Matches the WakuRelayCodec with any postfix.
+    ## E.g. if WakuRelayCodec is `/vac/waku/relay/2.0.0` it matches:
+    ## `/vac/waku/relay/2.0.0`, `/vac/waku/relay/2.0.0-beta2`, `/vac/waku/relay/2.0.0-actualnonsense`
+    return proto.startsWith(WakuRelayCodec)
+
+  node.switch.mount(wakuRelay, relayMatch)
 
   if not relayMessages:
     ## Some nodes may choose not to have the capability to relay messages (e.g. "light" nodes).

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -15,7 +15,7 @@ logScope:
     topics = "wakurelay"
 
 const
-  WakuRelayCodec* = "/vac/waku/relay/2.0.0-beta2"
+  WakuRelayCodec* = "/vac/waku/relay/2.0.0"
 
 type
   WakuRelay* = ref object of GossipSub


### PR DESCRIPTION
This PR forms the implementation counterpart of the spec update in https://github.com/vacp2p/rfc/pull/410. Relates to https://github.com/vacp2p/rfc/issues/406.

It adds support for the `stable` version of the specified relay protocol, with protocol id `/vac/waku/relay/2.0.0`.

> **NOTE:** Once this is merged, the Waku v2 `test` fleet will be updated to support only the stable protocol id. The `prod` fleet, currently extensively used for dogfooding, and other Waku v2 clients should be updated with stable support in a coordinated manner. cc @D4nte @siphiuel @richard-ramos 