### PR TITLE
ci: cleanup workspaces after every build to save space

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -75,6 +75,7 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
+    always { cleanWs() }
   } // post
 } // pipeline
 


### PR DESCRIPTION
Because of space issues described in https://github.com/status-im/nim-waku/pull/652#issuecomment-871205562.

The build folders take up 3.7 GB and 6.6 GB on linux and windows respectively. That's just too much to keep for multiple PR builds.