### PR TITLE
Add GH project board automation

### DIFF
--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -1,0 +1,26 @@
+name: Add new issues to nim-waku project board
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-new-issue-to-new-column:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to column "New"
+        if: ${{ !!github.event.issue }}
+        uses: alex-page/github-project-automation-plus@v0.6.0
+        with:
+          project: nim-waku
+          column: New
+          repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}
+      - name: Add pull request to column "In Progress"
+        if: ${{ !!github.event.pull_request }}
+        uses: alex-page/github-project-automation-plus@v0.6.0
+        with:
+          project: nim-waku
+          column: In Progress
+          repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}

--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -17,10 +17,10 @@ jobs:
           project: nim-waku
           column: New
           repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}
-      - name: Add pull request to column "In Progress"
+      - name: Add pull request to column "Review/QA"
         if: ${{ !!github.event.pull_request }}
         uses: alex-page/github-project-automation-plus@v0.6.0
         with:
           project: nim-waku
-          column: In Progress
+          column: Review/QA
           repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}

--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -1,4 +1,4 @@
-name: Add new issues to nim-waku project board
+name: Add new issues and PRs to nim-waku project board
 
 on:
   issues:


### PR DESCRIPTION
Now we have a project board for nim-waku, no longer cross-org, so should be simpler. Based on js-waku workflow.