### PR TITLE
General refactoring: `nim-waku`

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -4,6 +4,8 @@
 when not(compileOption("threads")):
   {.fatal: "Please, compile this program with the --threads:on option!".}
 
+{.push raises: [Defect].}
+
 import std/[tables, strformat, strutils, times, httpclient, json, sequtils, random, options]
 import confutils, chronicles, chronos, stew/shims/net as stewNet,
        eth/keys, bearssl, stew/[byteutils, endians2],
@@ -19,10 +21,6 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                protocols/secure/secio,   # define the protocol of secure input / output, allows encrypted communication that uses public keys to validate signed messages instead of a certificate authority like in TLS
                muxers/muxer]             # define an interface for stream multiplexing, allowing peers to offer many protocols over a single connection
 import   ../../waku/v2/node/[wakunode2, waku_payload],
-         ../../waku/v2/protocol/waku_message,
-         ../../waku/v2/protocol/waku_store/waku_store,
-         ../../waku/v2/protocol/waku_filter/waku_filter,
-         ../../waku/v2/protocol/waku_lightpush/waku_lightpush,
          ../../waku/v2/utils/peers,
          ../../waku/common/utils/nat,
          ./config_chat2
@@ -119,7 +117,7 @@ proc showChatPrompt(c: Chat) =
     except IOError:
       discard
 
-proc printReceivedMessage(c: Chat, msg: WakuMessage) {.raises: [Defect].} =
+proc printReceivedMessage(c: Chat, msg: WakuMessage) =
   when PayloadV1:
       # Use Waku v1 payload encoding/encryption
       let
@@ -156,16 +154,23 @@ proc printReceivedMessage(c: Chat, msg: WakuMessage) {.raises: [Defect].} =
     trace "Printing message", topic=DefaultTopic, chatLine,
       contentTopic = msg.contentTopic
 
-proc selectRandomNode(fleetStr: string): string =
+proc selectRandomNode(fleetStr: string): Option[string] =
   randomize()
-  let
+  var
+    fleet: string
+    nodes: seq[tuple[key: string, val: JsonNode]]
+    randNode: string
+  try:
     # Get latest fleet addresses
     fleet = newHttpClient().getContent("https://fleets.status.im")
     # Select the JSONObject corresponding to the selected wakuv2 fleet and convert to seq of key-val pairs
     nodes = toSeq(fleet.parseJson(){"fleets", "wakuv2." & fleetStr, "waku"}.pairs())
-    
-  # Select a random node from the selected fleet, convert to string and return
-  return nodes[rand(nodes.len - 1)].val.getStr()
+    # Select a random node from the selected fleet, convert to string and return
+    randNode = nodes[rand(nodes.len - 1)].val.getStr()
+  except Exception: # @TODO: HttpClient raises generic Exception
+    return none(string)
+  
+  return some(randNode)
 
 proc readNick(transp: StreamTransport): Future[string] {.async.} =
   # Chat prompt
@@ -286,7 +291,7 @@ proc readWriteLoop(c: Chat) {.async.} =
   asyncSpawn c.writeAndPrint() # execute the async function but does not block
   asyncSpawn c.readAndPrint()
 
-proc readInput(wfd: AsyncFD) {.thread.} =
+proc readInput(wfd: AsyncFD) {.thread, raises: [Defect, CatchableError].} =
   ## This procedure performs reading from `stdin` and sends data over
   ## pipe to main thread.
   let transp = fromPipe(wfd)
@@ -295,6 +300,7 @@ proc readInput(wfd: AsyncFD) {.thread.} =
     let line = stdin.readLine()
     discard waitFor transp.write(line & "\r\n")
 
+{.pop.} # @TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
   let transp = fromPipe(rfd)
 
@@ -335,9 +341,12 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     
     let randNode = selectRandomNode($conf.fleet)
     
-    echo "Connecting to " & randNode
+    if randNode.isSome():
+      echo "Connecting to " & randNode.get()
 
-    await connectToNodes(chat, @[randNode])
+      await connectToNodes(chat, @[randNode.get()])
+    else:
+      echo "Couldn't select a random node to connect to. Check --fleet configuration."
 
   let peerInfo = node.peerInfo
   let listenStr = $peerInfo.addrs[0] & "/p2p/" & $peerInfo.peerId
@@ -356,12 +365,11 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
     elif conf.fleet != Fleet.none:
       echo "Store enabled, but no store nodes configured. Choosing one at random from " & $conf.fleet & " fleet..."
       
-      storenode = some(selectRandomNode($conf.fleet))
-
-      echo "Connecting to storenode: " & storenode.get()
+      storenode = selectRandomNode($conf.fleet)
     
     if storenode.isSome():
       # We have a viable storenode. Let's query it for historical messages.
+      echo "Connecting to storenode: " & storenode.get()
 
       node.wakuStore.setPeer(parsePeerInfo(storenode.get()))
 
@@ -387,7 +395,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
 
     node.wakuFilter.setPeer(parsePeerInfo(conf.filternode))
 
-    proc filterHandler(msg: WakuMessage) {.gcsafe, raises: [Defect].} =
+    proc filterHandler(msg: WakuMessage) {.gcsafe.} =
       trace "Hit filter handler", contentTopic=msg.contentTopic
 
       chat.printReceivedMessage(msg)

--- a/tests/v2/test_migration_utils.nim
+++ b/tests/v2/test_migration_utils.nim
@@ -4,7 +4,7 @@ import
   std/[unittest, tables, strutils, os, sequtils],
   chronicles,
   stew/results,
-  ../../waku/v2/node/storage/migration/[migration_types, migration_utils]
+  ../../waku/v2/node/storage/migration/migration_utils
 
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 const MIGRATION_PATH = sourceDir / "../../waku/v2/node/storage/migration/migrations_scripts/message"

--- a/tests/v2/test_namespacing_utils.nim
+++ b/tests/v2/test_namespacing_utils.nim
@@ -19,19 +19,19 @@ procSuite "Namespacing utils":
       ns.encoding == "proto"
     
     # Invalid cases
-    expect ValueError:
+    expect CatchableError:
       # Topic should be namespaced
       discard NamespacedTopic.fromString("this-is-not-namespaced").tryGet()
     
-    expect ValueError:
+    expect CatchableError:
       # Topic should start with '/'
       discard NamespacedTopic.fromString("waku/2/default-waku/proto").tryGet()
 
-    expect ValueError:
+    expect CatchableError:
       # Topic has too few parts
       discard NamespacedTopic.fromString("/waku/2/default-waku").tryGet()
 
-    expect ValueError:
+    expect CatchableError:
       # Topic has too many parts
       discard NamespacedTopic.fromString("/waku/2/default-waku/proto/2").tryGet()
 

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -14,10 +14,6 @@ import
   ../../waku/v2/node/wakunode2,
   ../../waku/v2/node/peer_manager/peer_manager,
   ../../waku/v2/node/storage/peer/waku_peer_storage,
-  ../../waku/v2/protocol/waku_relay,
-  ../../waku/v2/protocol/waku_filter/waku_filter,
-  ../../waku/v2/protocol/waku_store/waku_store,
-  ../../waku/v2/protocol/waku_swap/waku_swap,
   ../test_helpers
 
 procSuite "Peer Manager":

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -82,8 +82,8 @@ procSuite "WakuBridge":
       toV2ContentTopic([byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]) == ContentTopic("/waku/1/1a2b3c4d/rlp")
     
     # Invalid cases
-    
-    expect ValueError:
+
+    expect LPError:
       # Content topic not namespaced
       discard toV1Topic(ContentTopic("this-is-my-content"))
     

--- a/waku/v2/node/jsonrpc/admin_api.nim
+++ b/waku/v2/node/jsonrpc/admin_api.nim
@@ -5,10 +5,6 @@ import
   chronicles,
   json_rpc/rpcserver,
   libp2p/[peerinfo, switch],
-  ../../protocol/waku_store/[waku_store_types, waku_store],
-  ../../protocol/waku_swap/[waku_swap_types, waku_swap],
-  ../../protocol/waku_filter/[waku_filter_types, waku_filter],
-  ../../protocol/waku_relay,
   ../wakunode2,
   ../peer_manager/peer_manager,
   ./jsonrpc_types

--- a/waku/v2/node/jsonrpc/filter_api.nim
+++ b/waku/v2/node/jsonrpc/filter_api.nim
@@ -4,7 +4,6 @@ import
   std/[tables,sequtils],
   json_rpc/rpcserver,
   eth/[common, rlp, keys, p2p],
-  ../../protocol/waku_filter/waku_filter_types,
   ../wakunode2,
   ./jsonrpc_types
 

--- a/waku/v2/node/jsonrpc/relay_api.nim
+++ b/waku/v2/node/jsonrpc/relay_api.nim
@@ -6,8 +6,7 @@ import
   libp2p/protocols/pubsub/pubsub,
   eth/[common, rlp, keys, p2p],
   ../wakunode2,
-  ./jsonrpc_types, ./jsonrpc_utils,
-  ../../protocol/waku_message
+  ./jsonrpc_types, ./jsonrpc_utils
 
 export jsonrpc_types
 

--- a/waku/v2/node/jsonrpc/store_api.nim
+++ b/waku/v2/node/jsonrpc/store_api.nim
@@ -4,7 +4,6 @@ import
   std/options,
   chronicles,
   json_rpc/rpcserver,
-  ../../protocol/waku_store/waku_store_types,
   ../wakunode2,
   ./jsonrpc_types, ./jsonrpc_utils
 

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -6,7 +6,7 @@ import
   ./waku_peer_store,
   ../storage/peer/peer_storage
 
-export waku_peer_store
+export waku_peer_store, peer_storage
 
 declareCounter waku_peers_dials, "Number of peer dials", ["outcome"]
 declarePublicGauge waku_peers_errors, "Number of peer manager errors", ["type"]

--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -1,18 +1,14 @@
 {.push raises: [Defect].}
 
 import 
-  std/[os, algorithm, tables, strutils],
-  chronos, metrics, chronicles,
+  std/[tables, strutils],
   sqlite3_abi,
-  libp2p/crypto/crypto,
-  libp2p/protocols/protocol,
-  libp2p/protobuf/minprotobuf,
-  libp2p/stream/connection,
   stew/[byteutils, results],
   ./message_store,
   ../sqlite,
   ../../../protocol/waku_message,
-  ../../../utils/pagination 
+  ../../../utils/pagination
+
 export sqlite
 
 const TABLE_TITLE = "Message"

--- a/waku/v2/node/storage/migration/migration_types.nim
+++ b/waku/v2/node/storage/migration/migration_types.nim
@@ -1,3 +1,5 @@
+{.push raises: [Defect].}
+
 import tables, stew/results, strutils, os
 
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]

--- a/waku/v2/node/storage/migration/migration_utils.nim
+++ b/waku/v2/node/storage/migration/migration_utils.nim
@@ -1,8 +1,15 @@
+{.push raises: [Defect].}
+
 import 
   std/[os, algorithm, tables, strutils], 
   chronicles, 
   stew/results,
   migration_types
+
+export migration_types
+
+logScope:
+  topics = "migration_utils"
 
 proc getScripts*(migrationPath: string): MigrationScriptsResult[MigrationScripts] =
   ## the code in this procedure is an adaptation of https://github.com/status-im/nim-status/blob/21aebe41be03cb6450ea261793b800ed7d3e6cda/nim_status/migrations/sql_generate.nim#L4

--- a/waku/v2/node/storage/peer/peer_storage.nim
+++ b/waku/v2/node/storage/peer/peer_storage.nim
@@ -2,7 +2,6 @@
 
 import
   stew/results,
-  chronos,
   ../../peer_manager/waku_peer_store
 
 ## This module defines a peer storage interface. Implementations of

--- a/waku/v2/node/storage/peer/waku_peer_storage.nim
+++ b/waku/v2/node/storage/peer/waku_peer_storage.nim
@@ -3,7 +3,6 @@
 import
   std/sets, 
   sqlite3_abi,
-  chronos, metrics,
   libp2p/protobuf/minprotobuf,
   stew/results,
   ./peer_storage,

--- a/waku/v2/node/storage/sqlite.nim
+++ b/waku/v2/node/storage/sqlite.nim
@@ -3,17 +3,16 @@
 import 
   os,
   sqlite3_abi,
-  chronos, chronicles, metrics,
+  chronicles,
   stew/results,
-  libp2p/crypto/crypto,
-  libp2p/protocols/protocol,
-  libp2p/protobuf/minprotobuf,
-  libp2p/stream/connection,
-  migration/[migration_types,migration_utils]
+  migration/migration_utils
 # The code in this file is an adaptation of the Sqlite KV Store found in nim-eth.
 # https://github.com/status-im/nim-eth/blob/master/eth/db/kvstore_sqlite3.nim
 #
 # Most of it is a direct copy, the only unique functions being `get` and `put`.
+
+logScope:
+  topics = "sqlite"
 
 type
   DatabaseResult*[T] = Result[T, string]
@@ -233,7 +232,7 @@ proc setUserVersion*(database: SqliteDatabase, version: int64): DatabaseResult[b
   ok(true)
 
 
-proc migrate*(db: SqliteDatabase, path: string, targetVersion: int64 = migration_types.USER_VERSION): DatabaseResult[bool] = 
+proc migrate*(db: SqliteDatabase, path: string, targetVersion: int64 = migration_utils.USER_VERSION): DatabaseResult[bool] = 
   ## compares the user_version of the db with the targetVersion 
   ## runs migration scripts if the user_version is outdated (does not support down migration)
   ## path points to the directory holding the migrations scripts

--- a/waku/v2/node/waku_payload.nim
+++ b/waku/v2/node/waku_payload.nim
@@ -1,3 +1,5 @@
+{.push raises: [Defect].}
+
 import
   std/options,
   eth/keys,

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -6,7 +6,6 @@ import
   metrics/chronos_httpserver,
   stew/shims/net as stewNet,
   eth/keys,
-  web3,
   libp2p/crypto/crypto,
   libp2p/protocols/ping,
   libp2p/protocols/pubsub/gossipsub,
@@ -19,10 +18,17 @@ import
   ../protocol/waku_rln_relay/waku_rln_relay_types,
   ../utils/peers,
   ../utils/requests,
-  ./storage/message/message_store,
-  ./storage/peer/peer_storage,
   ./storage/migration/migration_types,
   ./peer_manager/peer_manager
+
+export
+  builders,
+  waku_relay, waku_message,
+  waku_store,
+  waku_swap,
+  waku_filter,
+  waku_lightpush,
+  waku_rln_relay_types
 
 when defined(rln):
   import ../protocol/waku_rln_relay/[rln, waku_rln_relay_utils]

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -18,7 +18,7 @@ import
   ../../utils/requests,
   ../../node/peer_manager/peer_manager
 
-export waku_store_types
+export waku_store_types, message_store
 
 declarePublicGauge waku_store_messages, "number of historical messages", ["type"]
 declarePublicGauge waku_store_peers, "number of store peers"


### PR DESCRIPTION
This PR refactors `nim-waku` according to [Track 1 refactoring checklist](https://hackmd.io/1imOGULZRsed2HpgmzGleA?view)

It covers all modules not addressed in the existing/closed PRs: https://github.com/status-im/nim-waku/pull/664 #667.
Not everything on the Track 1 checklist is necessary for modules in `/test`-directory, so I've mostly focused on `import` cleanup.

Once all Track 1 refactoring PRs are merged, another pass of code maintenance (especially `import` cleanups) will be necessary to account for the effect of new `export`s and other improvements.