### PR TITLE
Fixes the order of fields of History Response protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release contains the following:
 - Support for stable version of `relay` protocol, with protocol ID `/vac/waku/relay/2.0.0`
 - Support for multiple protocol IDs - now matches any protocol that adds postfix to stable ID.
 - Updates the order of fields of `HistoryResponse` protobuf message. 
-  The filed numbers are shifted up by one to match up the [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) specs. 
+  The filed numbers of `HistoryResponse` are shifted up by one to match up the [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) specs. 
 
 #### General refactoring
 #### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release contains the following:
 - Support for stable version of `relay` protocol, with protocol ID `/vac/waku/relay/2.0.0`
 - Support for multiple protocol IDs - now matches any protocol that adds postfix to stable ID.
 - Updates the order of fields of `HistoryResponse` protobuf message. 
-  The filed numbers of `HistoryResponse` are shifted up by one to match up the [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) specs. 
+  The filed numbers of the `HistoryResponse` are shifted up by one to match up the [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) specs. 
 
 #### General refactoring
 #### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This release contains the following:
 - Updates the `resume` Nim API to fetch historical messages in sequence of pages.
 - Support for stable version of `relay` protocol, with protocol ID `/vac/waku/relay/2.0.0`
 - Support for multiple protocol IDs - now matches any protocol that adds postfix to stable ID.
+- Updates the order of fields of `HistoryResponse` protobuf message. 
+  The filed numbers are shifted up by one to match up the [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) specs. 
 
 #### General refactoring
 #### Docs

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -159,17 +159,17 @@ proc init*(T: type HistoryResponse, buffer: seq[byte]): ProtoResult[T] =
   let pb = initProtoBuffer(buffer)
 
   var messages: seq[seq[byte]]
-  discard ? pb.getRepeatedField(1, messages)
+  discard ? pb.getRepeatedField(2, messages)
 
   for buf in messages:
     msg.messages.add(? WakuMessage.init(buf))
 
   var pagingInfoBuffer: seq[byte]
-  discard ? pb.getField(2,pagingInfoBuffer)
+  discard ? pb.getField(3, pagingInfoBuffer)
   msg.pagingInfo= ? PagingInfo.init(pagingInfoBuffer)
 
   var error: uint32
-  discard ? pb.getField(3, error)
+  discard ? pb.getField(4, error)
   msg.error = HistoryResponseError(error)
 
   return ok(msg)
@@ -217,11 +217,11 @@ proc encode*(response: HistoryResponse): ProtoBuffer =
   var output = initProtoBuffer()
 
   for msg in response.messages:
-    output.write(1, msg.encode())
+    output.write(2, msg.encode())
 
-  output.write(2, response.pagingInfo.encode())
+  output.write(3, response.pagingInfo.encode())
 
-  output.write(3, uint32(ord(response.error)))
+  output.write(4, uint32(ord(response.error)))
 
   return output
 


### PR DESCRIPTION
This is to fix the mismatch between the implementation and the store specs regarding the order of fields of History Response protobuf. 

The store specs indicate that the first field of `HistoryResponse` is reserved for future use (as an identifier to match up queries with their corresponding requests). However, the nim-waku implementation does not comply with this specification.