### PR TITLE
Fix topic conversion in bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This release contains the following:
 #### API
 
 ### Fixes
+- Conversion between topics for the Waku v1 <-> v2 bridge now follows the [RFC recommendation](https://rfc.vac.dev/spec/23/)
 
 ## 2021-06-03 v0.4
 

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -50,7 +50,7 @@ procSuite "WakuBridge":
     v2NodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
     v2Node = WakuNode.new(v2NodeKey, ValidIpAddress.init("0.0.0.0"), Port(60002))
 
-    contentTopic = ContentTopic("/waku/1/1a2b3c4d/rlp")
+    contentTopic = ContentTopic("/waku/1/0x1a2b3c4d/rlp")
     topic = [byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]
     payloadV1 = "hello from V1".toBytes()
     payloadV2 = "hello from V2".toBytes()
@@ -74,13 +74,15 @@ procSuite "WakuBridge":
     # Expected cases
     
     check:
-      toV1Topic(ContentTopic("/waku/1/00000000/rlp")) == [byte 0x00, byte 0x00, byte 0x00, byte 0x00]
-      toV2ContentTopic([byte 0x00, byte 0x00, byte 0x00, byte 0x00]) == ContentTopic("/waku/1/00000000/rlp")
-      toV1Topic(ContentTopic("/waku/1/ffffffff/rlp")) == [byte 0xff, byte 0xff, byte 0xff, byte 0xff]
-      toV2ContentTopic([byte 0xff, byte 0xff, byte 0xff, byte 0xff]) == ContentTopic("/waku/1/ffffffff/rlp")
+      toV1Topic(ContentTopic("/waku/1/0x00000000/rlp")) == [byte 0x00, byte 0x00, byte 0x00, byte 0x00]
+      toV2ContentTopic([byte 0x00, byte 0x00, byte 0x00, byte 0x00]) == ContentTopic("/waku/1/0x00000000/rlp")
+      toV1Topic(ContentTopic("/waku/1/0xffffffff/rlp")) == [byte 0xff, byte 0xff, byte 0xff, byte 0xff]
+      toV2ContentTopic([byte 0xff, byte 0xff, byte 0xff, byte 0xff]) == ContentTopic("/waku/1/0xffffffff/rlp")
+      toV1Topic(ContentTopic("/waku/1/0x1a2b3c4d/rlp")) == [byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]
+      toV2ContentTopic([byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]) == ContentTopic("/waku/1/0x1a2b3c4d/rlp")
+      # Topic conversion should still work where '0x' prefix is omitted from <v1 topic byte array>
       toV1Topic(ContentTopic("/waku/1/1a2b3c4d/rlp")) == [byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]
-      toV2ContentTopic([byte 0x1a, byte 0x2b, byte 0x3c, byte 0x4d]) == ContentTopic("/waku/1/1a2b3c4d/rlp")
-    
+
     # Invalid cases
 
     expect LPError:
@@ -89,7 +91,7 @@ procSuite "WakuBridge":
     
     expect ValueError:
       # Content topic name too short
-      discard toV1Topic(ContentTopic("/waku/1/112233/rlp"))
+      discard toV1Topic(ContentTopic("/waku/1/0x112233/rlp"))
     
     expect ValueError:
       # Content topic name not hex

--- a/waku/common/wakubridge.nim
+++ b/waku/common/wakubridge.nim
@@ -66,12 +66,14 @@ proc containsOrAdd(sequence: var seq[hashes.Hash], hash: hashes.Hash): bool =
 proc toV2ContentTopic*(v1Topic: waku_protocol.Topic): ContentTopic =
   ## Convert a 4-byte array v1 topic to a namespaced content topic
   ## with format `/waku/1/<v1-topic-bytes-as-hex>/proto`
+  ## 
+  ## <v1-topic-bytes-as-hex> should be prefixed with `0x`
   
   var namespacedTopic = NamespacedTopic()
   
   namespacedTopic.application = "waku"
   namespacedTopic.version = "1"
-  namespacedTopic.topicName = v1Topic.toHex()
+  namespacedTopic.topicName = "0x" & v1Topic.toHex()
   namespacedTopic.encoding = "rlp"
 
   return ContentTopic($namespacedTopic)


### PR DESCRIPTION
This PR brings v1 <> v2 topic conversion in the `waku_bridge` in line with the [recommendations in RFC 23](https://rfc.vac.dev/spec/23/#bridging-waku-v1-and-waku-v2).

The bridge converts v1 topics (4-byte arrays) to v2 content topics using the scheme:
`/waku/1/<4bytes-waku-v1-topic>/rlp`, where `<4bytes-waku-v1-topic>` is the hex representation of the v1 topic.

This PR ensures that the `<4bytes-waku-v1-topic>` uses a `0x` prefix.

This scheme was previously supported, but not the default behaviour (in other words, `/waku/1/007f80ff/rlp` and `/waku/1/0x007f80ff/rlp` would both have been accepted as valid content topic representations of the same v1 topic, but `/waku/1/007f80ff/rlp` would have been the preferred default.)

cc @richard-ramos 