### PR TITLE
Fix compilation with `rln` defined

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -33,6 +33,7 @@ export
 when defined(rln):
   import
     libp2p/protocols/pubsub/rpc/messages,
+    web3,
     ../protocol/waku_rln_relay/[rln, waku_rln_relay_utils]
 
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -31,7 +31,9 @@ export
   waku_rln_relay_types
 
 when defined(rln):
-  import ../protocol/waku_rln_relay/[rln, waku_rln_relay_utils]
+  import
+    libp2p/protocols/pubsub/rpc/messages,
+    ../protocol/waku_rln_relay/[rln, waku_rln_relay_utils]
 
 declarePublicCounter waku_node_messages, "number of messages received", ["type"]
 declarePublicGauge waku_node_filters, "number of content filter subscriptions"
@@ -462,6 +464,7 @@ when defined(rln):
     node.wakuRlnRelay = rlnPeer
 
 when defined(rln):
+
   proc addRLNRelayValidator*(node: WakuNode, pubsubTopic: string) =
     ## this procedure is a thin wrapper for the pubsub addValidator method
     ## it sets message validator on the given pubsubTopic, the validator will check that

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -3,6 +3,8 @@ import
   web3,
   eth/keys
 
+export web3
+
 ## Bn256 and RLN are Nim wrappers for the data types used in 
 ## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
 type Bn256* = pointer

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_types.nim
@@ -3,8 +3,6 @@ import
   web3,
   eth/keys
 
-export web3
-
 ## Bn256 and RLN are Nim wrappers for the data types used in 
 ## the rln library https://github.com/kilic/rln/blob/3bbec368a4adc68cd5f9bfae80b17e1bbb4ef373/src/ffi.rs
 type Bn256* = pointer

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -15,7 +15,9 @@ contract(MembershipContract):
   # TODO define a return type of bool for register method to signify a successful registration
   proc register(pubkey: Uint256) # external payable
 
-proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool = 
+proc createRLNInstance*(d: int, ctxPtr: var ptr RLN[Bn256]): bool
+  {.raises: [Defect, IOError].} =
+
   ## generates an instance of RLN 
   ## An RLN instance supports both zkSNARKs logics and Merkle tree data structure and operations
   ## d indicates the depth of Merkle tree 


### PR DESCRIPTION
Likely as a result of recent [refactoring efforts](https://hackmd.io/beMbu_fdRymYvaXDANukIw), compiling `wakunode2` with `rln` defined started failing.

This PR fixes the regression. We may want to add a CI test to avoid this from happening in future. @staheri14 