### PR TITLE
Patch release v0.5.1 - fix multiple protocol IDs in persistent storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2021-07-26 v0.5.1
+
+This patch release contains the following fix:
+- Support for multiple protocol IDs when reconnecting to previously connected peers:
+A bug in `v0.5` caused clients using persistent peer storage to only support the mounted protocol ID.
+
+This is a patch release that is fully backwards-compatible with release `v0.5`.
+It supports the same [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
+| Protocol | Spec status | Protocol id |
+| ---: | :---: | :--- |
+| [`17/WAKU-RLN`](https://rfc.vac.dev/spec/17/) | `raw` | `/vac/waku/waku-rln-relay/2.0.0-alpha1` |
+| [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/) | `stable` | `/vac/waku/relay/2.0.0` |
+| [`12/WAKU2-FILTER`](https://rfc.vac.dev/spec/12/) | `draft` | `/vac/waku/filter/2.0.0-beta1` |
+| [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/) | `draft` | `/vac/waku/store/2.0.0-beta3` |
+| [`18/WAKU2-SWAP`](https://rfc.vac.dev/spec/18/) | `draft` | `/vac/waku/swap/2.0.0-beta1` |
+| [`19/WAKU2-LIGHTPUSH`](https://rfc.vac.dev/spec/19/) | `draft` | `/vac/waku/lightpush/2.0.0-beta1` |
+
+The Waku v1 implementation is stable but not under active development.
+
 ## 2021-07-23 v0.5
 
 This release contains the following:


### PR DESCRIPTION
This PR is a patch for [release v0.5](https://github.com/status-im/nim-waku/releases/tag/v0.5)

It adds support for multiple protocol IDs when reconnecting to previous peers in the peer manager.

Although multiple protocol IDs is supported by the protocols as per https://github.com/status-im/nim-waku/pull/652, the peer manager would only reconnect to peers that previously matched the current mounted protocol ID.

The impact is that a fleet system, being upgraded to the stable version of the `relay` protocol, will not reconnect to previously connected peers if they were not previously registered with the stable protocol ID.

This is a blocker for installing the latest v0.5 release on the `prod` fleet, an outstanding task on https://github.com/status-im/nim-waku/issues/672

The issue affects only `nim-waku` fleet clients. It is completely backwards compatible with release v0.5.