### PR TITLE
Revert PRUNE backoff period to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Next version
+
+This release contains the following:
+
+### Features
+
+### Changes
+
+- GossipSub [prune backoff period](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange) is now the recommended 1 minute
+
+#### General refactoring
+
+#### Docs
+
+#### Schema
+
+#### API
+
+
+### Fixes
+
 ## 2021-07-26 v0.5.1
 
 This patch release contains the following fix:

--- a/waku/v2/protocol/waku_relay.nim
+++ b/waku/v2/protocol/waku_relay.nim
@@ -54,11 +54,6 @@ method initPubSub*(w: WakuRelay) {.raises: [Defect, InitializationError].} =
   w.verifySignature = false
   w.sign = false
 
-  # Here we can fine-tune GossipSub params for our purposes
-  w.parameters = GossipSubParams.init()
-  # Setting pruneBackoff allows us to restart nodes and trigger a re-subscribe within reasonable time.
-  w.parameters.pruneBackoff = 30.seconds
-
   procCall GossipSub(w).initPubSub()
 
   w.init()


### PR DESCRIPTION
Relates to https://github.com/vacp2p/rfc/pull/451

It reverts a `nim-waku`-specific change to GossipSub parameters that were made earlier.
Specifically, the PRUNE backoff period was set to 30 seconds (50% of the default 1 minute). Although this theoretically shortens the restart-and-reconnect time for clients implementing peer persistence, this is not a good enough reason to deviate from the recommended default and may result in inconsistencies between client implementations.

This PR ensures the `nim-waku` implementation follows the recommendations set out in `29/WAKU2-CONFIG`.

cc @richard-ramos @D4nte to confirm that prune backoff is set to `1 min` in `go` and `js` implementations respectively