### PR TITLE
Remove unnecessary ENR caching

### DIFF
--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -65,12 +65,11 @@ procSuite "Waku DNS Discovery":
     let
       nodeKey4 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node4 = WakuNode.new(nodeKey4, bindIp, Port(60004))
-      enr4 = node4.enr
     
     node4.mountRelay()
     await node4.start()
     
-    var wakuDnsDisc = WakuDnsDiscovery.init(enr4, location, resolver).get()
+    var wakuDnsDisc = WakuDnsDiscovery.init(location, resolver).get()
 
     let res = wakuDnsDisc.findPeers()
 

--- a/waku/v2/node/dnsdisc/waku_dnsdisc.nim
+++ b/waku/v2/node/dnsdisc/waku_dnsdisc.nim
@@ -29,7 +29,6 @@ logScope:
 
 type
   WakuDnsDiscovery* = object
-    enr*: enr.Record
     client*: Client
     resolver*: Resolver
 
@@ -158,16 +157,15 @@ proc findPeers*(wdd: var WakuDnsDiscovery): Result[seq[PeerInfo], cstring] =
   return ok(discoveredNodes)
 
 proc init*(T: type WakuDnsDiscovery,
-           enr: enr.Record,
            locationUrl: string,
            resolver: Resolver): Result[T, cstring] =
   ## Initialise Waku peer discovery via DNS
   
-  debug "init WakuDnsDiscovery", enr=enr, locationUrl=locationUrl
+  debug "init WakuDnsDiscovery", locationUrl=locationUrl
   
   let
     client = ? Client.init(locationUrl)
-    wakuDnsDisc = WakuDnsDiscovery(enr: enr, client: client, resolver: resolver)
+    wakuDnsDisc = WakuDnsDiscovery(client: client, resolver: resolver)
 
   debug "init success"
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -855,8 +855,7 @@ when isMainModule:
       # @ TODO: this is merely POC integration with an empty resolver
       debug "Waku DNS Discovery enabled. Using empty resolver."
       
-      var wakuDnsDiscovery = WakuDnsDiscovery.init(node.enr,
-                                                   conf.dnsDiscoveryUrl,
+      var wakuDnsDiscovery = WakuDnsDiscovery.init(conf.dnsDiscoveryUrl,
                                                    emptyResolver)  # TODO: Add DNS resolver
       if wakuDnsDiscovery.isOk:
         let discoveredPeers = wakuDnsDiscovery.get().findPeers()


### PR DESCRIPTION
Minor improvement:

There's no reason for a Waku DNS discovery client to cache its own ENR (yet), so I've removed it. It is still cached and logged by the `wakunode2`.