### PR TITLE
Fix `chat2bridge` announced addresses

### DIFF
--- a/examples/v2/matterbridge/chat2bridge.nim
+++ b/examples/v2/matterbridge/chat2bridge.nim
@@ -243,6 +243,12 @@ when isMainModule:
     (nodev2ExtIp, nodev2ExtPort, _) = setupNat(conf.nat, clientId,
                                                Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
                                                Port(uint16(conf.udpPort) + conf.portsShift))
+    ## The following heuristic assumes that, in absence of manual
+    ## config, the external port is the same as the bind port.
+    extPort = if nodev2ExtIp.isSome() and nodev2ExtPort.isNone():
+                some(Port(uint16(conf.libp2pTcpPort) + conf.portsShift))
+              else:
+                nodev2ExtPort
 
   let
     bridge = Chat2Matterbridge.new(
@@ -250,7 +256,7 @@ when isMainModule:
                             mbGateway = conf.mbGateway,
                             nodev2Key = conf.nodekey,
                             nodev2BindIp = conf.listenAddress, nodev2BindPort = Port(uint16(conf.libp2pTcpPort) + conf.portsShift),
-                            nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = nodev2ExtPort,
+                            nodev2ExtIp = nodev2ExtIp, nodev2ExtPort = extPort,
                             contentTopic = conf.contentTopic)
   
   waitFor bridge.start()


### PR DESCRIPTION
Fix to ensure `chat2bridge` adds external IP and port to its announced addresses, if NAT is configured.

The ext IP will also be populated in the
```
 INF Listening on     topics="wakunode" tid=23616 file=wakunode2.nim:672 full=/ip4/0.0.0.0/tcp/9000/xxx
```
log, which currently only populates the bind IP (generally `0.0.0.0`).

cc @arthurk 