### PR TITLE
Make maximum connections configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release contains the following:
 - GossipSub [prune backoff period](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange) is now the recommended 1 minute
 - Bridge now uses content topic format according to [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/)
 - Better internal differentiation between local and remote peer info
+- Maximum number of libp2p connections is now configurable
 
 #### General refactoring
 

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -835,3 +835,43 @@ procSuite "WakuNode":
 
     await node1.stop()
     await node2.stop()
+
+  asyncTest "Maximum connections can be configured":
+    let
+      maxConnections = 1
+      nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
+        Port(60010), maxConnections = maxConnections)
+      nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
+        Port(60012))
+      nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"),
+        Port(60013))
+    
+    check:
+      # Sanity check, to verify config was applied
+      node1.switch.connManager.inSema.size == maxConnections
+
+    # Node with connection limit set to 1
+    await node1.start()
+    node1.mountRelay() 
+
+    # Remote node 1
+    await node2.start()
+    node2.mountRelay()
+
+    # Remote node 2
+    await node3.start()
+    node3.mountRelay()
+
+    discard await node1.peerManager.dialPeer(node2.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+    await sleepAsync(3.seconds)
+    discard await node1.peerManager.dialPeer(node3.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+
+    check:
+      # Verify that only the first connection succeeded
+      node1.switch.isConnected(node2.peerInfo.peerId)
+      node1.switch.isConnected(node3.peerInfo.peerId) == false
+
+    await allFutures([node1.stop(), node2.stop(), node3.stop()])

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -838,7 +838,7 @@ procSuite "WakuNode":
 
   asyncTest "Maximum connections can be configured":
     let
-      maxConnections = 1
+      maxConnections = 2
       nodeKey1 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node1 = WakuNode.new(nodeKey1, ValidIpAddress.init("0.0.0.0"),
         Port(60010), maxConnections = maxConnections)

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -46,6 +46,11 @@ type
       desc: "Specify method to use for determining public address. " &
             "Must be one of: any, none, upnp, pmp, extip:<IP>."
       defaultValue: "any" }: string
+
+    maxConnections* {.
+      desc: "Maximum allowed number of libp2p connections."
+      defaultValue: 50
+      name: "max-connections" }: uint16
     
     ## Persistence config
     

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -128,7 +128,8 @@ template tcpEndPoint(address, port): auto =
 proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
     bindIp: ValidIpAddress, bindPort: Port,
     extIp = none[ValidIpAddress](), extPort = none[Port](),
-    peerStorage: PeerStorage = nil): T 
+    peerStorage: PeerStorage = nil,
+    maxConnections = MaxConnections): T 
     {.raises: [Defect, LPError].} =
   ## Creates a Waku Node.
   ##
@@ -153,15 +154,13 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
   for multiaddr in announcedAddresses:
     peerInfo.addrs.add(multiaddr) # Announced addresses in index > 0
   
-  var switch = newStandardSwitch(some(nodekey), hostAddress,
-    transportFlags = {ServerFlags.ReuseAddr}, rng = rng)
-  # TODO Untested - verify behavior after switch interface change
-  # More like this:
-  # let pubsub = GossipSub.init(
-  #    switch = switch,
-  #    msgIdProvider = msgIdProvider,
-  #    triggerSelf = true, sign = false,
-  #    verifySignature = false).PubSub
+  var switch = newStandardSwitch(
+    some(nodekey),
+    hostAddress,
+    transportFlags = {ServerFlags.ReuseAddr},
+    rng = rng,
+    maxConnections = maxConnections)
+
   let wakuNode = WakuNode(
     peerManager: PeerManager.new(switch, peerStorage),
     switch: switch,
@@ -838,7 +837,8 @@ when isMainModule:
       node = WakuNode.new(conf.nodekey,
                           conf.listenAddress, Port(uint16(conf.tcpPort) + conf.portsShift), 
                           extIp, extPort,
-                          pStorage)
+                          pStorage,
+                          conf.maxConnections)
     
     ok(node)
 


### PR DESCRIPTION
This PR partly addresses https://github.com/status-im/nim-waku/issues/721 and is a prerequisite vir the upcoming [`v0.6` release]()

It makes the max allowed libp2p connections per `wakunode2` configurable.
Once this change is released, it will be installed on the `wakuv2.prod` fleet, after which the `prod` fleet connection limit can be increased from the hardcoded `50`.