### PR TITLE
Adds readme for websockets

### DIFF
--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -136,21 +136,22 @@ docker run --rm -it statusteam/nim-waku:latest --help
 ```
 ## Using Websocket and secure Websockets
 
-Websocket config needs to be enabled , by default the port is 8000 for websockets.
-
+Websocket support is hidden under a feature flag and must be explicitly enabled in order to get Websockets support. The default port is 8000.
 
 ```
-# Run unsecure websockets
+# Run unsecure Websockets (doesn't require a certificate)
 ./build/wakunode2 --websocket-support=true 
-
-# Run secure websockets
-./build/wakunode2 --websocket-secure-support=true --websocket-secure-key-path="/path/to/key.pem" --websocket-secure-cert-path="/path/to/cert.pem"
 ```
 
-Self-signed ssl certificate can be used for websockets, it can be created like this:
+Running a secure websockets requires ssl certificate, we can create a self signed websocket however, it requires openssl utility. It can be acheived as:
 
 ```
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 
+mkdir -p ../ssl_dir/
+
+openssl req -x509 -newkey rsa:4096 -keyout ../ssl_dir/key.pem -out ../ssl_dir/cert.pem -sha256
+
+./build/wakunode2 --websocket-secure-support=true --websocket-secure-key-path="../ssl_dir/key.pem" --websocket-secure-cert-path="../ssl_dir/cert.pem"
 ```
+
 
 

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -134,3 +134,23 @@ You can change this to `wakunode2`, the Waku v2 node like this:
 make docker-image MAKE_TARGET=wakunode2
 docker run --rm -it statusteam/nim-waku:latest --help
 ```
+## Using Websocket and secure Websockets
+
+Websocket config needs to be enabled , by default the port is 8000 for websockets.
+
+
+```
+# Run unsecure websockets
+./build/wakunode2 --websocket-support=true 
+
+# Run secure websockets
+./build/wakunode2 --websocket-secure-support=true --websocket-secure-key-path="/path/to/key.pem" --websocket-secure-cert-path="/path/to/cert.pem"
+```
+
+Self-signed ssl certificate can be used for websockets
+
+```
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 
+```
+
+

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -143,7 +143,7 @@ Websocket support is hidden under a feature flag and must be explicitly enabled 
 ./build/wakunode2 --websocket-support=true 
 ```
 
-Running a secure websockets requires ssl certificate, we can create a self signed websocket however, it requires openssl utility. It can be acheived as:
+Running a secure websocket requires an ssl certificate. We can create a self signed websocket. However, it requires the `openssl` utility. It can be achieved as:
 
 ```
 mkdir -p ../ssl_dir/

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -143,7 +143,7 @@ Websocket support is hidden under a feature flag and must be explicitly enabled 
 ./build/wakunode2 --websocket-support=true 
 ```
 
-Running a secure websocket requires an ssl certificate. We can create a self signed websocket. However, it requires the `openssl` utility. It can be achieved as:
+Running a secure websocket requires an ssl certificate. We can create a self signed websocket. However, it requires the `openssl` utility. It can be achieved with:
 
 ```
 mkdir -p ../ssl_dir/

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -147,7 +147,7 @@ Websocket config needs to be enabled , by default the port is 8000 for websocket
 ./build/wakunode2 --websocket-secure-support=true --websocket-secure-key-path="/path/to/key.pem" --websocket-secure-cert-path="/path/to/cert.pem"
 ```
 
-Self-signed ssl certificate can be used for websockets
+Self-signed ssl certificate can be used for websockets, it can be created like this:
 
 ```
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -240,7 +240,7 @@ type
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",
-      defaultValue: false
+      defaultValue: true
       name: "websocket-support"}: bool
 
     websocketPort* {.

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -240,7 +240,7 @@ type
     ## websocket config
     websocketSupport* {.
       desc: "Enable websocket:  true|false",
-      defaultValue: true
+      defaultValue: false
       name: "websocket-support"}: bool
 
     websocketPort* {.


### PR DESCRIPTION
This PR appends to the README section of waku v2 on how to create a self signed key and enable websockets transport.

Closes issue #762 