### PR TITLE
Handles stale clients in FILTER protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ##  Next version
 
-This patch release contains the following fix:
-- This Patch introduces Filter Protocol timeout.
-- Support for full secure websockets.
+This release contains the following:
+
+### Features
+- Waku v2 node timeout for Filter nodes.
+- Waku v2 node support for secure websockets.
 
 ### Changes
 - The WakuInfo Object field of `listenStr` is deprecated and is now replaced with `listenAddresses`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This patch release contains the following fix:
 - Support for full secure websockets.
 
 ### Changes
-- The WakuInfo Object field of listenStr is depreciated and is now replaced with listenAddresses
+- The WakuInfo Object field of `listenStr` is deprecated and is now replaced with `listenAddresses`
 which is a sequence of string.
 
 ## 2021-11-05 v0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 2021-07-26 v0.6.1
+
+This patch release contains the following fix:
+- This Patch introduces Filter Protocol timeout.
+- Support for full secure websockets.
+
+### Changes
+- The WakuInfo Object field of listenStr is depreciated and is now replaced with listenAddresses
+which is a sequence of string.
+
+It supports the same [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
+| Protocol | Spec status | Protocol id |
+| ---: | :---: | :--- |
+| [`17/WAKU-RLN`](https://rfc.vac.dev/spec/17/) | `raw` | `/vac/waku/waku-rln-relay/2.0.0-alpha1` |
+| [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/) | `stable` | `/vac/waku/relay/2.0.0` |
+| [`12/WAKU2-FILTER`](https://rfc.vac.dev/spec/12/) | `draft` | `/vac/waku/filter/2.0.0-beta1` |
+| [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/) | `draft` | `/vac/waku/store/2.0.0-beta3` |
+| [`18/WAKU2-SWAP`](https://rfc.vac.dev/spec/18/) | `draft` | `/vac/waku/swap/2.0.0-beta1` |
+| [`19/WAKU2-LIGHTPUSH`](https://rfc.vac.dev/spec/19/) | `draft` | `/vac/waku/lightpush/2.0.0-beta1` |
+
+The Waku v1 implementation is stable but not under active development.
 ## 2021-11-05 v0.6
 
 Some useful features and fixes in this release, include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2021-07-26 v0.6.1
+##  Next version
 
 This patch release contains the following fix:
 - This Patch introduces Filter Protocol timeout.
@@ -8,17 +8,6 @@ This patch release contains the following fix:
 - The WakuInfo Object field of listenStr is depreciated and is now replaced with listenAddresses
 which is a sequence of string.
 
-It supports the same [libp2p protocols](https://docs.libp2p.io/concepts/protocols/):
-| Protocol | Spec status | Protocol id |
-| ---: | :---: | :--- |
-| [`17/WAKU-RLN`](https://rfc.vac.dev/spec/17/) | `raw` | `/vac/waku/waku-rln-relay/2.0.0-alpha1` |
-| [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/) | `stable` | `/vac/waku/relay/2.0.0` |
-| [`12/WAKU2-FILTER`](https://rfc.vac.dev/spec/12/) | `draft` | `/vac/waku/filter/2.0.0-beta1` |
-| [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/) | `draft` | `/vac/waku/store/2.0.0-beta3` |
-| [`18/WAKU2-SWAP`](https://rfc.vac.dev/spec/18/) | `draft` | `/vac/waku/swap/2.0.0-beta1` |
-| [`19/WAKU2-LIGHTPUSH`](https://rfc.vac.dev/spec/19/) | `draft` | `/vac/waku/lightpush/2.0.0-beta1` |
-
-The Waku v1 implementation is stable but not under active development.
 ## 2021-11-05 v0.6
 
 Some useful features and fixes in this release, include:

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -271,7 +271,9 @@ procSuite "Waku Filter":
     #Second failure should remove the subscription
     await proto2.handleMessage(defaultTopic, post)
     
-    discard responseCompletionFuture.withTimeout(3.seconds)
+    check:
+      # Check that subscription works as expected
+      (await responseCompletionFuture.withTimeout(3.seconds)) == true
   
     check:
       proto2.failedPeers.len() == 0

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -255,6 +255,8 @@ procSuite "Waku Filter":
       # Check that subscription works as expected
       (await responseCompletionFuture.withTimeout(3.seconds)) == true
     
+    responseCompletionFuture = newFuture[bool]()
+
     # Stop switch to test unsubscribe
     discard dialSwitch.stop()
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -177,7 +177,7 @@ procSuite "Waku Filter":
     proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
       discard
 
-    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 1)
+    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 1.seconds)
 
     listenSwitch.mount(proto2)
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -271,6 +271,8 @@ procSuite "Waku Filter":
     #Second failure should remove the subscription
     await proto2.handleMessage(defaultTopic, post)
     
+    discard responseCompletionFuture.withTimeout(3.seconds)
+  
     check:
       proto2.failedPeers.len() == 0
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -209,4 +209,67 @@ procSuite "Waku Filter":
     check:
       proto2.subscribers.len() == 0
   
+  asyncTest "Handles failed clients coming back up":
+    const defaultTopic = "/waku/2/default-waku/proto"
+
+    let
+      key = PrivateKey.random(ECDSA, rng[]).get()
+      peer = PeerInfo.new(key)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
+      post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
+
+    var dialSwitch = newStandardSwitch()
+    discard await dialSwitch.start()
+
+    var listenSwitch = newStandardSwitch(some(key))
+    discard await listenSwitch.start()
+
+    var responseCompletionFuture = newFuture[bool]()
+    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+      check:
+        msg.messages.len() == 1
+        msg.messages[0] == post
+      responseCompletionFuture.complete(true)
+
+    let
+      proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(contentTopic: contentTopic)], pubSubTopic: defaultTopic, subscribe: true)
+
+    dialSwitch.mount(proto)
+    proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
+
+    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+      discard
+
+    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 2.seconds)
+
+    listenSwitch.mount(proto2)
+
+    let id = (await proto.subscribe(rpc)).get()
+
+    await sleepAsync(2.seconds)
+
+    await proto2.handleMessage(defaultTopic, post)
+
+    check:
+      # Check that subscription works as expected
+      (await responseCompletionFuture.withTimeout(3.seconds)) == true
     
+    # Stop switch to test unsubscribe
+    discard dialSwitch.stop()
+
+    await sleepAsync(1.seconds)
+    
+    #First failure should add to failure list
+    await proto2.handleMessage(defaultTopic, post)
+
+    check:
+      proto2.failedPeers.len() == 1
+    
+    discard dialSwitch.start()
+    dialSwitch.mount(proto)
+    #Second failure should remove the subscription
+    await proto2.handleMessage(defaultTopic, post)
+    
+    check:
+      proto2.failedPeers.len() == 0

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -177,7 +177,7 @@ procSuite "Waku Filter":
     proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
       discard
 
-    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
+    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle, 1)
 
     listenSwitch.mount(proto2)
 

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -144,3 +144,68 @@ procSuite "Waku Filter":
 
     check:
       idOpt.isNone
+
+  asyncTest "Can subscribe and unsubscribe from content filter":
+    const defaultTopic = "/waku/2/default-waku/proto"
+
+    let
+      key = PrivateKey.random(ECDSA, rng[]).get()
+      peer = PeerInfo.new(key)
+      contentTopic = ContentTopic("/waku/2/default-content/proto")
+      post = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: contentTopic)
+
+    var dialSwitch = newStandardSwitch()
+    discard await dialSwitch.start()
+
+    var listenSwitch = newStandardSwitch(some(key))
+    discard await listenSwitch.start()
+
+    var responseCompletionFuture = newFuture[bool]()
+    proc handle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+      check:
+        msg.messages.len() == 1
+        msg.messages[0] == post
+      responseCompletionFuture.complete(true)
+
+    let
+      proto = WakuFilter.init(PeerManager.new(dialSwitch), crypto.newRng(), handle)
+      rpc = FilterRequest(contentFilters: @[ContentFilter(contentTopic: contentTopic)], pubSubTopic: defaultTopic, subscribe: true)
+
+    dialSwitch.mount(proto)
+    proto.setPeer(listenSwitch.peerInfo.toRemotePeerInfo())
+
+    proc emptyHandle(requestId: string, msg: MessagePush) {.gcsafe, closure.} =
+      discard
+
+    let proto2 = WakuFilter.init(PeerManager.new(listenSwitch), crypto.newRng(), emptyHandle)
+
+    listenSwitch.mount(proto2)
+
+    let id = (await proto.subscribe(rpc)).get()
+
+    await sleepAsync(2.seconds)
+
+    await proto2.handleMessage(defaultTopic, post)
+
+    check:
+      # Check that subscription works as expected
+      (await responseCompletionFuture.withTimeout(3.seconds)) == true
+    
+    # Reset to test unsubscribe
+    responseCompletionFuture = newFuture[bool]()
+
+    echo $proto.peerManager.peers()
+    discard dialSwitch.stop()
+    await sleepAsync(2.seconds)
+    #discard await listenSwitch.start()
+    await sleepAsync(2.seconds)
+    #listenSwitch.mount(proto2)
+    #await proto.unsubscribe(rpcU)
+    #await sleepAsync(2.seconds)
+    await proto2.handleMessage(defaultTopic, post)
+    await sleepAsync(2000.millis)
+    echo $proto.peerManager.peers()
+    await proto2.handleMessage(defaultTopic, post)
+    await sleepAsync(2000.millis)
+    echo $proto.peerManager.peers()
+    

--- a/tests/v2/test_waku_filter.nim
+++ b/tests/v2/test_waku_filter.nim
@@ -273,3 +273,6 @@ procSuite "Waku Filter":
     
     check:
       proto2.failedPeers.len() == 0
+
+    discard dialSwitch.stop()
+    discard listenSwitch.stop()

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -131,7 +131,7 @@ type
     
     filterTimeout* {.
       desc: "Timeout for filter node in seconds.",
-      defaultValue: 86400
+      defaultValue: 14400 # 4 hours
       name: "filter-timeout" }: int64
     
     ## Swap config

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -7,7 +7,7 @@ import
   nimcrypto/utils,
   eth/keys,
   ../protocol/waku_rln_relay/[waku_rln_relay_types]
-
+   
 type
   WakuNodeConf* = object
     ## General node config
@@ -128,6 +128,11 @@ type
       desc: "Peer multiaddr to request content filtering of messages.",
       defaultValue: ""
       name: "filternode" }: string
+    
+    filterTimeout* {.
+      desc: "Timeout for filter node in seconds.",
+      defaultValue: 60 * 60 * 24
+      name: "filter-timeout" }: float
     
     ## Swap config
 

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -131,8 +131,8 @@ type
     
     filterTimeout* {.
       desc: "Timeout for filter node in seconds.",
-      defaultValue: 60 * 60 * 24
-      name: "filter-timeout" }: float
+      defaultValue: 86400
+      name: "filter-timeout" }: int64
     
     ## Swap config
 

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -208,21 +208,6 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, proto: string) =
   if not pm.storage.isNil:
     pm.storage.insertOrReplace(remotePeerInfo.peerId, pm.peerStore.get(remotePeerInfo.peerId), NotConnected)
 
-# Delete peer
-proc removePeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo) =
-  # Remove peer from manager for the specified protocol
-  if remotePeerInfo.peerId == pm.switch.peerInfo.peerId:
-    # Do not attempt to manage our unmanageable self
-    return
-  debug "Removing peer from manager", peerId = remotePeerInfo.peerId, addr = remotePeerInfo.addrs[0]
-  var err = false;
-  err = pm.peerStore.addressBook.delete(remotePeerInfo.peerId) and 
-        pm.peerStore.keyBook.delete(remotePeerInfo.peerId) and
-        pm.peerStore.protoBook.delete(remotePeerInfo.peerId)
-  if err:
-    echo "everything allright"
-  return
-
 proc selectPeer*(pm: PeerManager, proto: string): Option[RemotePeerInfo] =
   # Selects the best peer for a given protocol
   let peers = pm.peers.filterIt(it.protos.contains(proto))

--- a/waku/v2/node/peer_manager/peer_manager.nim
+++ b/waku/v2/node/peer_manager/peer_manager.nim
@@ -208,6 +208,21 @@ proc addPeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo, proto: string) =
   if not pm.storage.isNil:
     pm.storage.insertOrReplace(remotePeerInfo.peerId, pm.peerStore.get(remotePeerInfo.peerId), NotConnected)
 
+# Delete peer
+proc removePeer*(pm: PeerManager, remotePeerInfo: RemotePeerInfo) =
+  # Remove peer from manager for the specified protocol
+  if remotePeerInfo.peerId == pm.switch.peerInfo.peerId:
+    # Do not attempt to manage our unmanageable self
+    return
+  debug "Removing peer from manager", peerId = remotePeerInfo.peerId, addr = remotePeerInfo.addrs[0]
+  var err = false;
+  err = pm.peerStore.addressBook.delete(remotePeerInfo.peerId) and 
+        pm.peerStore.keyBook.delete(remotePeerInfo.peerId) and
+        pm.peerStore.protoBook.delete(remotePeerInfo.peerId)
+  if err:
+    echo "everything allright"
+  return
+
 proc selectPeer*(pm: PeerManager, proto: string): Option[RemotePeerInfo] =
   # Selects the best peer for a given protocol
   let peers = pm.peers.filterIt(it.protos.contains(proto))

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -56,7 +56,7 @@ const clientId* = "Nimbus Waku v2 node"
 const defaultTopic = "/waku/2/default-waku/proto"
 
 # Default Waku Filter Timeout
-const WakuFilterTimeout: Duration = chronos.days(1)
+const WakuFilterTimeout: Duration = 1.days
 
 
 # key and crypto modules different

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -55,6 +55,9 @@ const clientId* = "Nimbus Waku v2 node"
 # Default topic
 const defaultTopic = "/waku/2/default-waku/proto"
 
+# Default Waku Filter Timeout
+const WakuFilterTimeout = 60 * 60 * 24
+
 
 # key and crypto modules different
 type
@@ -398,7 +401,7 @@ proc info*(node: WakuNode): WakuInfo =
   let wakuInfo = WakuInfo(listenStr: listenStr)
   return wakuInfo
 
-proc mountFilter*(node: WakuNode, filterTimeout: float) {.raises: [Defect, KeyError, LPError]} =
+proc mountFilter*(node: WakuNode, filterTimeout: float = WakuFilterTimeout) {.raises: [Defect, KeyError, LPError]} =
   info "mounting filter"
   proc filterHandler(requestId: string, msg: MessagePush)
     {.gcsafe, raises: [Defect, KeyError].} =

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -56,7 +56,7 @@ const clientId* = "Nimbus Waku v2 node"
 const defaultTopic = "/waku/2/default-waku/proto"
 
 # Default Waku Filter Timeout
-const WakuFilterTimeout = 60 * 60 * 24
+const WakuFilterTimeout: Duration = chronos.days(1)
 
 
 # key and crypto modules different
@@ -419,7 +419,7 @@ proc info*(node: WakuNode): WakuInfo =
   let wakuInfo = WakuInfo(listenAddresses: listenStr)
   return wakuInfo
 
-proc mountFilter*(node: WakuNode, filterTimeout: float = WakuFilterTimeout) {.raises: [Defect, KeyError, LPError]} =
+proc mountFilter*(node: WakuNode, filterTimeout: Duration = WakuFilterTimeout) {.raises: [Defect, KeyError, LPError]} =
   info "mounting filter"
   proc filterHandler(requestId: string, msg: MessagePush)
     {.gcsafe, raises: [Defect, KeyError].} =
@@ -1075,7 +1075,7 @@ when isMainModule:
     
     # Filter setup. NOTE Must be mounted after relay
     if (conf.filternode != "") or (conf.filter):
-      mountFilter(node, filterTimeout = conf.filterTimeout)
+      mountFilter(node, filterTimeout = chronos.seconds(conf.filterTimeout))
 
       if conf.filternode != "":
         setFilterPeer(node, conf.filternode)

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -217,6 +217,7 @@ proc handleClientError*(wf: WakuFilter, subscribers: seq[Subscriber]){.raises: [
     if wf.failedPeers.hasKey(subKey):
       var elapsedTime = Moment.now() - wf.failedPeers[subKey]
       if(elapsedTime > wf.timeout):
+        trace "Remove peer if timeout has reached for", peer=subscriber
         var index = wf.subscribers.find(subscriber)
         wf.subscribers.delete(index)
         wf.failedPeers.del(subKey)
@@ -253,7 +254,6 @@ proc handleMessage*(wf: WakuFilter, topic: string, msg: WakuMessage) {.async.} =
         break
   discard handleClientSuccess(wf, connectedSubscribers)
   if handleMessageFailed:
-    trace "Remove peer if timeout has reached for", peer=failedSubscriber.peer
     discard handleClientError(wf, failedSubscriber)
 
 proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[Option[string]] {.async, gcsafe.} =

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -243,7 +243,7 @@ proc handleMessage*(wf: WakuFilter, topic: string, msg: WakuMessage) {.async.} =
           waku_filter_errors.inc(labelValues = [dialFailure])
         break
   if handleMessageFailed:
-    trace "Remove peer if timeout has reached for", peer=subscriber.peer
+    trace "Remove peer if timeout has reached for", peer=failedSubscriber.peer
     discard handleClientError(wf, failedSubscriber)
 
 proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[Option[string]] {.async, gcsafe.} =

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -224,6 +224,7 @@ proc handleMessage*(wf: WakuFilter, topic: string, msg: WakuMessage) {.async.} =
     if subscriber.filter.pubSubTopic != "" and subscriber.filter.pubSubTopic != topic:
       trace "Subscriber's filter pubsubTopic does not match message topic", filter=subscriber.filter.pubSubTopic, topic=topic
       continue
+    
     for filter in subscriber.filter.contentFilters:
       if msg.contentTopic == filter.contentTopic:
         trace "Found matching contentTopic", filter=filter, msg=msg
@@ -232,6 +233,7 @@ proc handleMessage*(wf: WakuFilter, topic: string, msg: WakuMessage) {.async.} =
         if connOpt.isSome:
           await connOpt.get().writeLP(push.encode().buffer)
         else:
+          # @TODO more sophisticated error handling here
           handleMessageFailed = true
           failedSubscriber = subscriber
           error "failed to push messages to remote peer"

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -203,7 +203,7 @@ proc setPeer*(wf: WakuFilter, peer: RemotePeerInfo) =
   waku_filter_peers.inc()
 
 #clear the failed peer table if subscriber was able to connect.
-proc handleClientSuccess*(wf: WakuFilter, subscribers: seq[Subscriber]){.raises: [Defect, KeyError], async.} = 
+proc handleClientSuccess(wf: WakuFilter, subscribers: seq[Subscriber]){.raises: [Defect, KeyError].} = 
   for subscriber in subscribers:
     var subKey: string = $(subscriber)
     if wf.failedPeers.hasKey(subKey):
@@ -211,7 +211,7 @@ proc handleClientSuccess*(wf: WakuFilter, subscribers: seq[Subscriber]){.raises:
 
 # If we have already failed to send message to this peer,
 # check for elapsed time and if it's been too long, remove the peer.
-proc handleClientError*(wf: WakuFilter, subscribers: seq[Subscriber]){.raises: [Defect, KeyError], async.} = 
+proc handleClientError(wf: WakuFilter, subscribers: seq[Subscriber]){.raises: [Defect, KeyError].} = 
   for subscriber in subscribers:
     var subKey: string = $(subscriber)
     if wf.failedPeers.hasKey(subKey):
@@ -252,9 +252,9 @@ proc handleMessage*(wf: WakuFilter, topic: string, msg: WakuMessage) {.async.} =
           error "failed to push messages to remote peer"
           waku_filter_errors.inc(labelValues = [dialFailure])
         break
-  discard handleClientSuccess(wf, connectedSubscribers)
+  handleClientSuccess(wf, connectedSubscribers)
   if handleMessageFailed:
-    discard handleClientError(wf, failedSubscriber)
+    handleClientError(wf, failedSubscriber)
 
 proc subscribe*(wf: WakuFilter, request: FilterRequest): Future[Option[string]] {.async, gcsafe.} =
   let peerOpt = wf.peerManager.selectPeer(WakuFilterCodec)

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -45,3 +45,4 @@ type
     peerManager*: PeerManager
     subscribers*: seq[Subscriber]
     pushHandler*: MessagePushHandler
+    failedPeers*: Table[string, float]

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -46,3 +46,4 @@ type
     subscribers*: seq[Subscriber]
     pushHandler*: MessagePushHandler
     failedPeers*: Table[string, float]
+    timeout*: float

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -1,5 +1,6 @@
 import
   std/[tables],
+  chronos,
   bearssl,
   libp2p/protocols/protocol,
   ../../node/peer_manager/peer_manager,
@@ -45,5 +46,5 @@ type
     peerManager*: PeerManager
     subscribers*: seq[Subscriber]
     pushHandler*: MessagePushHandler
-    failedPeers*: Table[string, float]
-    timeout*: float
+    failedPeers*: Table[string, chronos.Moment]
+    timeout*: chronos.Duration


### PR DESCRIPTION
This PR closes #781

The PR deletes the peer info if after timeout period the peer is not available. We maintain a map of peerid and first unavailable time to determine its departure.

This PR achieves
- Store the map of the failed peers and its first failure epoch
- Receives the config for timeout from user in float, by default 24 hours.
- Removal of subscriber if failure continues.
- Test to check the above features.
