### PR TITLE
Update announced addrs in switch

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -125,6 +125,22 @@ proc removeContentFilters(filters: var Filters, contentFilters: seq[ContentFilte
   
   debug "filters modified", filters=filters
 
+proc updateSwitchPeerInfo(node: WakuNode) =
+  ## TODO: remove this when supported upstream
+  ## 
+  ## nim-libp2p does not yet support announcing addrs
+  ## different from bound addrs.
+  ## 
+  ## This is a temporary workaround to replace
+  ## peer info addrs in switch to announced
+  ## addresses.
+  ## 
+  ## WARNING: this should only be called once the switch
+  ## has already been started.
+  
+  if node.announcedAddresses.len > 0:
+    node.switch.peerInfo.addrs = node.announcedAddresses
+
 template tcpEndPoint(address, port): auto =
   MultiAddress.init(address, tcpProtocol, port)
 
@@ -836,6 +852,9 @@ proc start*(node: WakuNode) {.async.} =
   ## XXX: this should be /ip4..., / stripped?
   info "Listening on", full = listenStr
   info "Discoverable ENR ", enr = node.enr.toURI()
+
+  ## Update switch peer info with announced addrs
+  node.updateSwitchPeerInfo()
 
   if not node.wakuRelay.isNil:
     await node.startRelay()


### PR DESCRIPTION
This PR closes #783 

It adds a workaround for https://github.com/status-im/nim-libp2p/issues/429 where the bound addresses (instead of externally significant addresses) are announced by a `nim-libp2p` switch, specifically as part of the `identify` procedure.

This allows other clients to use the info received during `identify` to update local addresses, where necessary. One example where this is necessary is for status-go integration of Waku v2, where a table with remote peer info is populated after DNS discovery using `identify` (https://github.com/status-im/status-go/pull/2438).

cc @richard-ramos 