### PR TITLE
Fix empty scripts condition. Logging.

### DIFF
--- a/waku/v2/node/storage/migration/migrations_scripts/message/00002_addSenderTimeStamp.up.sql
+++ b/waku/v2/node/storage/migration/migrations_scripts/message/00002_addSenderTimeStamp.up.sql
@@ -22,6 +22,8 @@ CREATE TABLE IF NOT EXISTS Message(
     ) WITHOUT ROWID;
 
 
-INSERT INTO Message SELECT id, timestamp, contentTopic, pubsubTopic, payload, version, 0  FROM Message_backup;
+INSERT INTO Message (id, receiverTimestamp, contentTopic, pubsubTopic, payload, version, senderTimestamp)
+    SELECT id, timestamp, contentTopic, pubsubTopic, payload, version, 0
+    FROM Message_backup;
 
 DROP TABLE Message_backup;

--- a/waku/v2/node/storage/sqlite.nim
+++ b/waku/v2/node/storage/sqlite.nim
@@ -247,6 +247,7 @@ proc migrate*(db: SqliteDatabase, path: string, targetVersion: int64 = migration
     ok(true)
   
   else:
+    info "database user_version outdated. migrating.", userVersion=userVersion, targetVersion=targetVersion
     # TODO check for the down migrations i.e., userVersion.value > tragetVersion
     # fetch migration scripts
     let migrationScriptsRes = getScripts(path)
@@ -260,6 +261,9 @@ proc migrate*(db: SqliteDatabase, path: string, targetVersion: int64 = migration
       return err("failed to filter migration scripts")
     
     let scripts = scriptsRes.value
+    if (scripts.len == 0):
+      return err("no suitable migration scripts")
+    
     debug "scripts to be run", scripts=scripts
     
     

--- a/waku/v2/node/waku_setup.nim
+++ b/waku/v2/node/waku_setup.nim
@@ -107,9 +107,9 @@ proc runMigrations*(sqliteDatabase: SqliteDatabase, conf: WakuNodeConf) =
     migrationPath = migration_types.MESSAGE_STORE_MIGRATION_PATH
 
   # run migration 
-  info "running migration ... "
+  info "running migration ...", migrationPath=migrationPath
   let migrationResult = sqliteDatabase.migrate(migrationPath)
   if migrationResult.isErr:
-    warn "migration failed"
+    warn "migration failed", error=migrationResult.error
   else:
     info "migration is done"


### PR DESCRIPTION
This PR addresses https://github.com/status-im/nim-waku/issues/791

It ensures that a DB migration fails if it finds no scripts to run for a particular migration.

In addition:
- some extra/more detailed logging, to assist with debugging
- stricter column name requirement in `Message` migration script