### PR TITLE
Fix incorrect store read buffer limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This release contains the following:
 - The WakuInfo Object field of `listenStr` is deprecated and is now replaced with `listenAddresses`
 which is a sequence of string.
 
+### Fixes
+- Increased maximum length for reading from a libp2p input stream to allow largest possible protocol messages, including `HistoryResponse` messages at max size.
+
 ## 2021-11-05 v0.6
 
 Some useful features and fixes in this release, include:

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -640,7 +640,8 @@ proc mountRelay*(node: WakuNode,
     #msgIdProvider = msgIdProvider,
     triggerSelf = triggerSelf,
     sign = false,
-    verifySignature = false
+    verifySignature = false,
+    maxMessageSize = MaxWakuMessageSize
   )
   
   info "mounting relay", relayMessages=relayMessages

--- a/waku/v2/protocol/waku_filter/waku_filter.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter.nim
@@ -166,7 +166,7 @@ proc encode*(rpc: FilterRPC): ProtoBuffer =
 
 method init*(wf: WakuFilter) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
-    var message = await conn.readLp(64*1024)
+    var message = await conn.readLp(MaxRpcSize.int)
     var res = FilterRPC.init(message)
     if res.isErr:
       error "failed to decode rpc"

--- a/waku/v2/protocol/waku_filter/waku_filter_types.nim
+++ b/waku/v2/protocol/waku_filter/waku_filter_types.nim
@@ -8,6 +8,12 @@ import
 
 export waku_message
 
+const
+  # We add a 64kB safety buffer for protocol overhead.
+  # 10x-multiplier also for safety: currently we never
+  # push more than 1 message at a time.
+  MaxRpcSize* = 10 * MaxWakuMessageSize + 64*1024
+
 type
   ContentFilter* = object
     contentTopic*: ContentTopic

--- a/waku/v2/protocol/waku_lightpush/waku_lightpush.nim
+++ b/waku/v2/protocol/waku_lightpush/waku_lightpush.nim
@@ -124,7 +124,7 @@ proc setPeer*(wlp: WakuLightPush, peer: RemotePeerInfo) =
 method init*(wlp: WakuLightPush) =
   debug "init"
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
-    var message = await conn.readLp(64*1024)
+    var message = await conn.readLp(MaxRpcSize.int)
     var res = PushRPC.init(message)
     if res.isErr:
       error "failed to decode rpc"

--- a/waku/v2/protocol/waku_lightpush/waku_lightpush_types.nim
+++ b/waku/v2/protocol/waku_lightpush/waku_lightpush_types.nim
@@ -8,6 +8,9 @@ import
 
 export waku_message
 
+const
+  MaxRpcSize* = MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead
+
 type
   PushRequest* = object
     pubSubTopic*: string

--- a/waku/v2/protocol/waku_message.nim
+++ b/waku/v2/protocol/waku_message.nim
@@ -13,6 +13,9 @@ import
 when defined(rln):
   import waku_rln_relay/waku_rln_relay_types
 
+const
+  MaxWakuMessageSize* = 1024 * 1024 # In bytes. Corresponds to PubSub default
+
 type
   ContentTopic* = string
 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -413,7 +413,7 @@ proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
 proc init*(ws: WakuStore, capacity = DefaultStoreCapacity) =
 
   proc handler(conn: Connection, proto: string) {.async.} =
-    var message = await conn.readLp(64*1024)
+    var message = await conn.readLp(MaxRpcSize.int)
     var res = HistoryRPC.init(message)
     if res.isErr:
       error "failed to decode rpc"
@@ -467,8 +467,8 @@ proc init*(ws: WakuStore, capacity = DefaultStoreCapacity) =
 
 
 proc init*(T: type WakuStore, peerManager: PeerManager, rng: ref BrHmacDrbgContext,
-                   store: MessageStore = nil, wakuSwap: WakuSwap = nil, persistMessages = true,
-                   capacity = DefaultStoreCapacity): T =
+           store: MessageStore = nil, wakuSwap: WakuSwap = nil, persistMessages = true,
+           capacity = DefaultStoreCapacity): T =
   debug "init"
   var output = WakuStore(rng: rng, peerManager: peerManager, store: store, wakuSwap: wakuSwap, persistMessages: persistMessages)
   output.init(capacity)
@@ -524,7 +524,7 @@ proc query*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc) {.asyn
   await connOpt.get().writeLP(HistoryRPC(requestId: generateRequestId(w.rng),
       query: query).encode().buffer)
 
-  var message = await connOpt.get().readLp(64*1024)
+  var message = await connOpt.get().readLp(MaxRpcSize.int)
   let response = HistoryRPC.init(message)
 
   if response.isErr:
@@ -549,7 +549,7 @@ proc queryFrom*(w: WakuStore, query: HistoryQuery, handler: QueryHandlerFunc, pe
   await connOpt.get().writeLP(HistoryRPC(requestId: generateRequestId(w.rng),
       query: query).encode().buffer)
   debug "query is sent", query=query
-  var message = await connOpt.get().readLp(64*1024)
+  var message = await connOpt.get().readLp(MaxRpcSize.int)
   let response = HistoryRPC.init(message)
 
   debug "response is received"
@@ -733,7 +733,7 @@ proc queryWithAccounting*(ws: WakuStore, query: HistoryQuery, handler: QueryHand
   await connOpt.get().writeLP(HistoryRPC(requestId: generateRequestId(ws.rng),
       query: query).encode().buffer)
 
-  var message = await connOpt.get().readLp(64*1024)
+  var message = await connOpt.get().readLp(MaxRpcSize.int)
   let response = HistoryRPC.init(message)
 
   if response.isErr:

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -26,12 +26,15 @@ export
   waku_message,
   pagination
 
-# Constants required for pagination -------------------------------------------
-const MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
-# TODO the DefaultPageSize can be changed, it's current value is random
-const DefaultPageSize* = uint64(20) # A recommended default number of waku messages per page
+const
+  # Constants required for pagination -------------------------------------------
+  MaxPageSize* = uint64(100) # Maximum number of waku messages in each page
+  # TODO the DefaultPageSize can be changed, it's current value is random
+  DefaultPageSize* = uint64(20) # A recommended default number of waku messages per page
 
-const DefaultTopic* = "/waku/2/default-waku/proto"
+  MaxRpcSize* = MaxPageSize * MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead
+
+  DefaultTopic* = "/waku/2/default-waku/proto"
 
 
 type

--- a/waku/v2/protocol/waku_swap/waku_swap.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap.nim
@@ -215,7 +215,7 @@ proc init*(wakuSwap: WakuSwap) =
   info "wakuSwap init 1"
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     info "swap handle incoming connection"
-    var message = await conn.readLp(64*1024)
+    var message = await conn.readLp(MaxChequeSize.int)
     # XXX This can be handshake, etc
     var res = Cheque.init(message)
     if res.isErr:

--- a/waku/v2/protocol/waku_swap/waku_swap_types.nim
+++ b/waku/v2/protocol/waku_swap/waku_swap_types.nim
@@ -4,7 +4,10 @@ import
   std/tables,
   bearssl,
   libp2p/protocols/protocol,
-  ../../node/peer_manager/peer_manager  
+  ../../node/peer_manager/peer_manager
+
+const
+  MaxChequeSize* = 64*1024 # Used for read buffers. 64kB should be more than enough for swap cheque
 
 type
   # The Swap Mode determines the functionality available in the swap protocol.


### PR DESCRIPTION
This PR closes #787

I've decided against the initial proposed solution of varying page size based on some unrelated maximum response size.
Rather, I've explicitly set the `MaxWakuMessageSize` (corresponds to the recommended PubSub default) and derived the input stream limit by multiplying with `MaxPageSize`. A safety factor of 64kB is built in to account for protocol overhead. This seems much simpler than what I originally proposed. LMK what you think @staheri14?

I've used the same approach to find a sensible read limit for other protocols. All protocols, other than `Swap` use an RPC message for request/response, so I've adjusted the limit to whichever of the Request or Response are likely the largest, together with a significant safety factor.