### PR TITLE
Remove node peerInfo copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This release contains the following:
 ### Changes
 - The WakuInfo Object field of `listenStr` is deprecated and is now replaced with `listenAddresses`
 which is a sequence of string.
+- Removed cached `peerInfo` on local node. Rely on underlying libp2p switch instead.
 
 ## 2021-11-05 v0.6
 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -387,7 +387,7 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
       echo "Couldn't select a random node to connect to. Check --fleet configuration."
       echo randNode.error()
 
-  let peerInfo = node.peerInfo
+  let peerInfo = node.switch.peerInfo
   let listenStr = $peerInfo.addrs[0] & "/p2p/" & $peerInfo.peerId
   echo &"Listening on\n {listenStr}"
 

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -63,7 +63,7 @@ procSuite "Waku v2 JSON-RPC API":
     let response = await client.get_waku_v2_debug_v1_info()
 
     check:
-      response.listenAddresses == @[$node.peerInfo.addrs[^1] & "/p2p/" & $node.peerInfo.peerId]
+      response.listenAddresses == @[$node.switch.peerInfo.addrs[^1] & "/p2p/" & $node.switch.peerInfo.peerId]
 
     server.stop()
     server.close()
@@ -140,8 +140,8 @@ procSuite "Waku v2 JSON-RPC API":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     # RPC server setup
     let
@@ -395,11 +395,11 @@ procSuite "Waku v2 JSON-RPC API":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"),
         Port(60004))
-      peerInfo3 = node3.peerInfo
+      peerInfo3 = node3.switch.peerInfo
     
     await allFutures([node1.start(), node2.start(), node3.start()])
 
@@ -451,11 +451,11 @@ procSuite "Waku v2 JSON-RPC API":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
       nodeKey3 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node3 = WakuNode.new(nodeKey3, ValidIpAddress.init("0.0.0.0"),
         Port(60004))
-      peerInfo3 = node3.peerInfo
+      peerInfo3 = node3.switch.peerInfo
     
     await allFutures([node1.start(), node2.start(), node3.start()])
 
@@ -573,8 +573,8 @@ procSuite "Waku v2 JSON-RPC API":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     # Setup two servers so we can see both sides of encrypted communication
     let
@@ -663,8 +663,8 @@ procSuite "Waku v2 JSON-RPC API":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     # Setup two servers so we can see both sides of encrypted communication
     let

--- a/tests/v2/test_peer_manager.nim
+++ b/tests/v2/test_peer_manager.nim
@@ -26,7 +26,7 @@ procSuite "Peer Manager":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
     
     await allFutures([node1.start(), node2.start()])
 
@@ -59,7 +59,7 @@ procSuite "Peer Manager":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
     
     await node1.start()
     # Purposefully don't start node2
@@ -128,7 +128,7 @@ procSuite "Peer Manager":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
     
     await node1.start()
 
@@ -173,7 +173,7 @@ procSuite "Peer Manager":
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
     
     await node1.start()
     await node2.start()
@@ -221,7 +221,7 @@ asyncTest "Peer manager support multiple protocol IDs when reconnecting to peers
       nodeKey2 = crypto.PrivateKey.random(Secp256k1, rng[])[]
       node2 = WakuNode.new(nodeKey2, ValidIpAddress.init("0.0.0.0"),
         Port(60002))
-      peerInfo2 = node2.peerInfo
+      peerInfo2 = node2.switch.peerInfo
       betaCodec = "/vac/waku/relay/2.0.0-beta2"
       stableCodec = "/vac/waku/relay/2.0.0"
     

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -108,7 +108,7 @@ procSuite "WakuBridge":
     v2Node.mountRelay(@[DefaultBridgeTopic], triggerSelf = false)
 
     discard waitFor v1Node.rlpxConnect(newNode(bridge.nodev1.toENode()))
-    waitFor v2Node.connectToNodes(@[bridge.nodev2.peerInfo.toRemotePeerInfo()])
+    waitFor v2Node.connectToNodes(@[bridge.nodev2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
 

--- a/tests/v2/test_waku_dnsdisc.nim
+++ b/tests/v2/test_waku_dnsdisc.nim
@@ -77,20 +77,20 @@ procSuite "Waku DNS Discovery":
       # We have discovered all three nodes
       res.isOk()
       res[].len == 3
-      res[].mapIt(it.peerId).contains(node1.peerInfo.peerId)
-      res[].mapIt(it.peerId).contains(node2.peerInfo.peerId)
-      res[].mapIt(it.peerId).contains(node3.peerInfo.peerId)
+      res[].mapIt(it.peerId).contains(node1.switch.peerInfo.peerId)
+      res[].mapIt(it.peerId).contains(node2.switch.peerInfo.peerId)
+      res[].mapIt(it.peerId).contains(node3.switch.peerInfo.peerId)
     
     # Connect to discovered nodes
     await node4.connectToNodes(res[])
 
     check:
       # We have successfully connected to all discovered nodes
-      node4.peerManager.peers().anyIt(it.peerId == node1.peerInfo.peerId)
-      node4.peerManager.connectedness(node1.peerInfo.peerId) == Connected
-      node4.peerManager.peers().anyIt(it.peerId == node2.peerInfo.peerId)
-      node4.peerManager.connectedness(node2.peerInfo.peerId) == Connected
-      node4.peerManager.peers().anyIt(it.peerId == node3.peerInfo.peerId)
-      node4.peerManager.connectedness(node3.peerInfo.peerId) == Connected
+      node4.peerManager.peers().anyIt(it.peerId == node1.switch.peerInfo.peerId)
+      node4.peerManager.connectedness(node1.switch.peerInfo.peerId) == Connected
+      node4.peerManager.peers().anyIt(it.peerId == node2.switch.peerInfo.peerId)
+      node4.peerManager.connectedness(node2.switch.peerInfo.peerId) == Connected
+      node4.peerManager.peers().anyIt(it.peerId == node3.switch.peerInfo.peerId)
+      node4.peerManager.connectedness(node3.switch.peerInfo.peerId) == Connected
 
     await allFutures([node1.stop(), node2.stop(), node3.stop(), node4.stop()])

--- a/tests/v2/test_waku_keepalive.nim
+++ b/tests/v2/test_waku_keepalive.nim
@@ -41,7 +41,7 @@ procSuite "Waku Keepalive":
     node2.mountRelay()
     node2.switch.mount(Ping.new(handler = pingHandler))
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     node1.startKeepalive()
 

--- a/tests/v2/test_waku_swap.nim
+++ b/tests/v2/test_waku_swap.nim
@@ -72,9 +72,9 @@ procSuite "Waku SWAP Accounting":
 
     await sleepAsync(2000.millis)
 
-    node1.wakuStore.setPeer(node2.peerInfo.toRemotePeerInfo())
-    node1.wakuSwap.setPeer(node2.peerInfo.toRemotePeerInfo())
-    node2.wakuSwap.setPeer(node1.peerInfo.toRemotePeerInfo())
+    node1.wakuStore.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
+    node1.wakuSwap.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
+    node2.wakuSwap.setPeer(node1.switch.peerInfo.toRemotePeerInfo())
 
     proc storeHandler(response: HistoryResponse) {.gcsafe, closure.} =
       debug "storeHandler hit"
@@ -87,8 +87,8 @@ procSuite "Waku SWAP Accounting":
     check:
       (await completionFut.withTimeout(5.seconds)) == true
       # Accounting table updated with credit and debit, respectively
-      node1.wakuSwap.accounting[node2.peerInfo.peerId] == 1
-      node2.wakuSwap.accounting[node1.peerInfo.peerId] == -1
+      node1.wakuSwap.accounting[node2.switch.peerInfo.peerId] == 1
+      node2.wakuSwap.accounting[node1.switch.peerInfo.peerId] == -1
     await node1.stop()
     await node2.stop()
 
@@ -122,9 +122,9 @@ procSuite "Waku SWAP Accounting":
 
     await sleepAsync(2000.millis)
 
-    node1.wakuStore.setPeer(node2.peerInfo.toRemotePeerInfo())
-    node1.wakuSwap.setPeer(node2.peerInfo.toRemotePeerInfo())
-    node2.wakuSwap.setPeer(node1.peerInfo.toRemotePeerInfo())
+    node1.wakuStore.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
+    node1.wakuSwap.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
+    node2.wakuSwap.setPeer(node1.switch.peerInfo.toRemotePeerInfo())
 
     proc handler1(response: HistoryResponse) {.gcsafe, closure.} =
       futures[0].complete(true)
@@ -139,7 +139,7 @@ procSuite "Waku SWAP Accounting":
       (await allFutures(futures).withTimeout(5.seconds)) == true
       # Accounting table updated with credit and debit, respectively
       # After sending a cheque the balance is partially adjusted
-      node1.wakuSwap.accounting[node2.peerInfo.peerId] == 1
-      node2.wakuSwap.accounting[node1.peerInfo.peerId] == -1
+      node1.wakuSwap.accounting[node2.switch.peerInfo.peerId] == 1
+      node2.wakuSwap.accounting[node1.switch.peerInfo.peerId] == -1
     await node1.stop()
     await node2.stop()

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -129,12 +129,12 @@ procSuite "WakuNode":
     node1.subscribe(pubSubTopic, relayHandler)
     # Subscribe a contentFilter to trigger a specific application handler when
     # WakuMessages with that content are received
-    node1.wakuFilter.setPeer(node2.peerInfo.toRemotePeerInfo())
+    node1.wakuFilter.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
     await node1.subscribe(filterRequest, contentHandler)
     await sleepAsync(2000.millis)
 
     # Connect peers by dialing from node2 to node1
-    let conn = await node2.switch.dial(node1.peerInfo.peerId, node1.peerInfo.addrs, WakuRelayCodec)
+    let conn = await node2.switch.dial(node1.switch.peerInfo.peerId, node1.switch.peerInfo.addrs, WakuRelayCodec)
 
     # We need to sleep to allow the subscription to go through
     info "Going to sleep to allow subscribe to go through"
@@ -172,7 +172,7 @@ procSuite "WakuNode":
     await node2.start()
     node2.mountRelay()
     node2.mountFilter()
-    node2.wakuFilter.setPeer(node1.peerInfo.toRemotePeerInfo())
+    node2.wakuFilter.setPeer(node1.switch.peerInfo.toRemotePeerInfo())
 
     var defaultComplete = newFuture[bool]()
     var otherComplete = newFuture[bool]()
@@ -243,7 +243,7 @@ procSuite "WakuNode":
     await node2.start()
     node2.mountRelay(relayMessages=false) # Do not start WakuRelay or subscribe to any topics
     node2.mountFilter()
-    node2.wakuFilter.setPeer(node1.peerInfo.toRemotePeerInfo())
+    node2.wakuFilter.setPeer(node1.switch.peerInfo.toRemotePeerInfo())
 
     check:
       node1.wakuRelay.isNil == false # Node1 is a full node
@@ -294,7 +294,7 @@ procSuite "WakuNode":
 
     await sleepAsync(2000.millis)
 
-    node1.wakuStore.setPeer(node2.peerInfo.toRemotePeerInfo())
+    node1.wakuStore.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
 
     proc storeHandler(response: HistoryResponse) {.gcsafe, closure.} =
       check:
@@ -326,7 +326,7 @@ procSuite "WakuNode":
     await node2.start()
     node2.mountFilter()
 
-    node1.wakuFilter.setPeer(node2.peerInfo.toRemotePeerInfo())
+    node1.wakuFilter.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
 
     proc handler(msg: WakuMessage) {.gcsafe, closure.} =
       check:
@@ -371,8 +371,8 @@ procSuite "WakuNode":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -429,7 +429,7 @@ procSuite "WakuNode":
 
     # Now verify that protocol matcher returns `true` and relay works
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -530,8 +530,8 @@ procSuite "WakuNode":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
 
     var completionFutValidatorAcc = newFuture[bool]()
@@ -643,8 +643,8 @@ procSuite "WakuNode":
       await node3.start()
 
       # connect them together
-      await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-      await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+      await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+      await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
       
       var completionFut = newFuture[bool]()
       proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -741,8 +741,8 @@ procSuite "WakuNode":
       await node3.start()
 
       # connect them together
-      await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-      await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+      await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+      await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
       
       # define a custom relay handler
       var completionFut = newFuture[bool]()
@@ -843,8 +843,8 @@ procSuite "WakuNode":
       await node3.start()
 
       # connect the nodes together node1 <-> node2 <-> node3
-      await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
-      await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+      await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
+      await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
       # get the current epoch time 
       let time = epochTime()
@@ -983,9 +983,9 @@ procSuite "WakuNode":
     await node3.start()
     node3.mountRelay(@[pubSubTopic])
 
-    discard await node1.peerManager.dialPeer(node2.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
+    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuLightPushCodec)
     await sleepAsync(5.seconds)
-    await node3.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node3.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFutLightPush = newFuture[bool]()
     var completionFutRelay = newFuture[bool]()
@@ -1044,7 +1044,7 @@ procSuite "WakuNode":
 
     await sleepAsync(2000.millis)
 
-    node1.wakuStore.setPeer(node2.peerInfo.toRemotePeerInfo())
+    node1.wakuStore.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
 
     await node1.resume()
 
@@ -1085,7 +1085,7 @@ procSuite "WakuNode":
 
     await sleepAsync(2000.millis)
 
-    node1.wakuStore.setPeer(node2.peerInfo.toRemotePeerInfo())
+    node1.wakuStore.setPeer(node2.switch.peerInfo.toRemotePeerInfo())
     
 
     # populate db with msg1 to be a duplicate
@@ -1145,14 +1145,14 @@ procSuite "WakuNode":
     await node3.start()
     node3.mountRelay()
 
-    discard await node1.peerManager.dialPeer(node2.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+    discard await node1.peerManager.dialPeer(node2.switch.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
     await sleepAsync(3.seconds)
-    discard await node1.peerManager.dialPeer(node3.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
+    discard await node1.peerManager.dialPeer(node3.switch.peerInfo.toRemotePeerInfo(), WakuRelayCodec)
 
     check:
       # Verify that only the first connection succeeded
-      node1.switch.isConnected(node2.peerInfo.peerId)
-      node1.switch.isConnected(node3.peerInfo.peerId) == false
+      node1.switch.isConnected(node2.switch.peerInfo.peerId)
+      node1.switch.isConnected(node3.switch.peerInfo.peerId) == false
 
     await allFutures([node1.stop(), node2.stop(), node3.stop()])
 
@@ -1176,7 +1176,7 @@ asyncTest "Messages are relayed between two websocket nodes":
     await node2.start()
     node2.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -1221,7 +1221,7 @@ asyncTest "Messages are relayed between nodes with multiple transports (TCP and 
     await node2.start()
     node2.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -1267,9 +1267,9 @@ asyncTest "Messages relaying fails with non-overlapping transports (TCP or Webso
 
     #delete websocket peer address
     # TODO: a better way to find the index - this is too brittle
-    node2.peerInfo.addrs.delete(0)
+    node2.switch.peerInfo.addrs.delete(0)
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -1313,7 +1313,7 @@ asyncTest "Messages are relayed between nodes with multiple transports (TCP and 
     await node2.start()
     node2.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -1366,7 +1366,7 @@ asyncTest "Messages are relayed between nodes with multiple transports (websocke
     await node2.start()
     node2.mountRelay(@[pubSubTopic])
 
-    await node1.connectToNodes(@[node2.peerInfo.toRemotePeerInfo()])
+    await node1.connectToNodes(@[node2.switch.peerInfo.toRemotePeerInfo()])
 
     var completionFut = newFuture[bool]()
     proc relayHandler(topic: string, data: seq[byte]) {.async, gcsafe.} =

--- a/tests/v2/utils.nim
+++ b/tests/v2/utils.nim
@@ -44,8 +44,8 @@ proc subscribeNodes*(nodes: seq[PubSub]) {.async.} =
   for dialer in nodes:
     for node in nodes:
       if dialer.switch.peerInfo.peerId != node.switch.peerInfo.peerId:
-        await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
-        dialer.subscribePeer(node.peerInfo.peerId)
+        await dialer.switch.connect(node.switch.peerInfo.peerId, node.switch.peerInfo.addrs)
+        dialer.subscribePeer(node.switch.peerInfo.peerId)
 
 proc subscribeSparseNodes*(nodes: seq[PubSub], degree: int = 2) {.async.} =
   if nodes.len < degree:
@@ -56,17 +56,17 @@ proc subscribeSparseNodes*(nodes: seq[PubSub], degree: int = 2) {.async.} =
       continue
 
     for node in nodes:
-      if dialer.switch.peerInfo.peerId != node.peerInfo.peerId:
-        await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
-        dialer.subscribePeer(node.peerInfo.peerId)
+      if dialer.switch.peerInfo.peerId != node.switch.peerInfo.peerId:
+        await dialer.switch.connect(node.switch.peerInfo.peerId, node.switch.peerInfo.addrs)
+        dialer.subscribePeer(node.switch.peerInfo.peerId)
 
 proc subscribeRandom*(nodes: seq[PubSub]) {.async.} =
   for dialer in nodes:
     var dialed: seq[PeerID]
     while dialed.len < nodes.len - 1:
       let node = sample(nodes)
-      if node.peerInfo.peerId notin dialed:
-        if dialer.peerInfo.peerId != node.peerInfo.peerId:
-          await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
-          dialer.subscribePeer(node.peerInfo.peerId)
-          dialed.add(node.peerInfo.peerId)
+      if node.switch.peerInfo.peerId notin dialed:
+        if dialer.switch.peerInfo.peerId != node.switch.peerInfo.peerId:
+          await dialer.switch.connect(node.switch.peerInfo.peerId, node.switch.peerInfo.addrs)
+          dialer.subscribePeer(node.switch.peerInfo.peerId)
+          dialed.add(node.switch.peerInfo.peerId)

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -82,7 +82,6 @@ type
     wakuSwap*: WakuSwap
     wakuRlnRelay*: WakuRLNRelay
     wakuLightPush*: WakuLightPush
-    peerInfo*: PeerInfo
     enr*: enr.Record
     libp2pPing*: Ping
     libp2pTransportLoops*: seq[Future[void]]
@@ -195,7 +194,6 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
   ## Initialize peer
   let
     rng = crypto.newRng()
-    peerInfo = PeerInfo.new(nodekey)
     enrIp = if extIp.isSome(): extIp
             else: some(bindIp)
     enrTcpPort = if extPort.isSome(): extPort
@@ -209,12 +207,8 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
                   wakuFlags,
                   enrMultiaddrs)
   
-  # TODO: local peerInfo should be removed
-  for multiaddr in announcedAddresses:
-    peerInfo.addrs.add(multiaddr) 
+  info "Initializing networking", addrs=announcedAddresses
 
-  info "Initializing networking", addrs=peerInfo.addrs
-  
   var switch = newWakuSwitch(some(nodekey),
     hostAddress,
     wsHostAddress,
@@ -228,8 +222,7 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
   let wakuNode = WakuNode(
     peerManager: PeerManager.new(switch, peerStorage),
     switch: switch,
-    rng: rng, 
-    peerInfo: peerInfo,
+    rng: rng,
     enr: enr,
     filters: initTable[string, Filter](),
     announcedAddresses: announcedAddresses
@@ -423,8 +416,7 @@ proc info*(node: WakuNode): WakuInfo =
   ## Status: Implemented.
   ##
 
-  let
-    peerInfo = node.peerInfo
+  let peerInfo = node.switch.peerInfo
   
   var listenStr : seq[string]
   for address in node.announcedAddresses:
@@ -861,7 +853,7 @@ proc start*(node: WakuNode) {.async.} =
   node.libp2pTransportLoops = await node.switch.start()
   
   # TODO Get this from WakuNode obj
-  let peerInfo = node.peerInfo
+  let peerInfo = node.switch.peerInfo
   info "PeerInfo", peerId = peerInfo.peerId, addrs = peerInfo.addrs
   var listenStr = ""
   for address in node.announcedAddresses:


### PR DESCRIPTION
Closes #744

Removes the local `peerInfo` instance/node property and replaces all uses of this copy with the underlying libp2p `switch.peerInfo`.

A local copy on the node is a bad idea, as the underlying addresses may be manipulated by the `switch` under certain circumstances. The `wakunode2` is not the authority on local peer information.