### PR TITLE
Ensure store response never exceeds `MaxPageSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ which is a sequence of string.
 - Metrics: added counters for protocol messages
 
 ### Fixes
-- `HistoryResponse` messages now auto-paginated to a maximum of 100 messages per page
+- All `HistoryResponse` messages are now auto-paginated to a maximum of 100 messages per response
 - Increased maximum length for reading from a libp2p input stream to allow largest possible protocol messages, including `HistoryResponse` messages at max size.
 
 ## 2021-11-05 v0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ which is a sequence of string.
 - Metrics: added counters for protocol messages
 
 ### Fixes
+- `HistoryResponse` messages now auto-paginated to a maximum of 100 messages per page
 - Increased maximum length for reading from a libp2p input stream to allow largest possible protocol messages, including `HistoryResponse` messages at max size.
 
 ## 2021-11-05 v0.6

--- a/tests/v2/test_jsonrpc_waku.nim
+++ b/tests/v2/test_jsonrpc_waku.nim
@@ -257,7 +257,7 @@ procSuite "Waku v2 JSON-RPC API":
     let response = await client.get_waku_v2_store_v1_messages(some(defaultTopic), some(@[HistoryContentFilter(contentTopic: defaultContentTopic)]), some(0.float64), some(9.float64), some(StorePagingOptions()))
     check:
       response.messages.len() == 8
-      response.pagingOptions.isNone
+      response.pagingOptions.isSome()
       
     server.stop()
     server.close()

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -190,8 +190,8 @@ procSuite "Waku Store":
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.new(key)
       msg1 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: defaultContentTopic)
-      msg2 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: defaultContentTopic)
-      msg3 = WakuMessage(payload: @[byte 1, 2, 3], contentTopic: defaultContentTopic)
+      msg2 = WakuMessage(payload: @[byte 4, 5, 6], contentTopic: defaultContentTopic)
+      msg3 = WakuMessage(payload: @[byte 7, 8, 9,], contentTopic: defaultContentTopic)
 
     var dialSwitch = newStandardSwitch()
     discard await dialSwitch.start()

--- a/tests/v2/test_waku_store.nim
+++ b/tests/v2/test_waku_store.nim
@@ -389,7 +389,7 @@ procSuite "Waku Store":
     check:
       (await completionFut.withTimeout(5.seconds)) == true
 
-  asyncTest "handle queries with no pagination":
+  asyncTest "handle queries with no paging info (auto-paginate)":
     let
       key = PrivateKey.random(ECDSA, rng[]).get()
       peer = PeerInfo.new(key)
@@ -424,8 +424,12 @@ procSuite "Waku Store":
 
     proc handler(response: HistoryResponse) {.gcsafe, closure.} =
       check:
+        ## No pagination specified. Response will be auto-paginated with
+        ## up to MaxPageSize messages per page.
         response.messages.len() == 8
-        response.pagingInfo == PagingInfo()
+        response.pagingInfo.pageSize == 8
+        response.pagingInfo.direction == PagingDirection.BACKWARD
+        response.pagingInfo.cursor != Index()
       completionFut.complete(true)
 
     let rpc = HistoryQuery(contentFilters: @[HistoryContentFilter(contentTopic: defaultContentTopic)] )


### PR DESCRIPTION
Small but significant change.

It ensures that, even with no paging info specified in the store query, the store will never return a response that exceeds the specified `MaxPageSize`. In other words, _all HistoryResponses will now be auto-paginated_.

This is necessary, because:
- https://github.com/status-im/nim-waku/pull/800 will not work properly if we don't limit _all_ response sizes
- at least some of the performance issues on the fleet is caused by un-paginated query responses attempting to stream the entire history in a single HistoryResponse (https://github.com/status-im/nim-waku/issues/736)

More store changes coming up: https://github.com/status-im/nim-waku/issues/805

@staheri14, keen to know what you think and if there are any gotchas that I've missed. LMK if you think this should be a provision in the spec as well?