### PR TITLE
Improved `store` query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ which is a sequence of string.
 ### Fixes
 - All `HistoryResponse` messages are now auto-paginated to a maximum of 100 messages per response
 - Increased maximum length for reading from a libp2p input stream to allow largest possible protocol messages, including `HistoryResponse` messages at max size.
+- Significantly improved store node query performance
 
 ## 2021-11-05 v0.6
 

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -278,8 +278,8 @@ proc findIndex*(msgList: seq[IndexedWakuMessage], index: Index): Option[int] =
       return some(i)
   return none(int)
 
-proc paginate*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[IndexedWakuMessage], PagingInfo, HistoryResponseError) =
-  ## takes list, and performs paging based on pinfo 
+proc paginate*(msgList: var seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[IndexedWakuMessage], PagingInfo, HistoryResponseError) =
+  ## takes a message list, and performs paging based on pinfo 
   ## returns the page i.e, a sequence of IndexedWakuMessage and the new paging info to be used for the next paging request
   var
     cursor = pinfo.cursor
@@ -288,11 +288,11 @@ proc paginate*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[IndexedWa
     output: (seq[IndexedWakuMessage], PagingInfo, HistoryResponseError) 
 
   if pageSize == uint64(0): # pageSize being zero indicates that no pagination is required
-    let output = (list, pinfo, HistoryResponseError.NONE)
+    let output = (msgList, pinfo, HistoryResponseError.NONE)
     return output
 
-  if list.len == 0: # no pagination is needed for an empty list
-    output = (list, PagingInfo(pageSize: 0, cursor:pinfo.cursor, direction: pinfo.direction), HistoryResponseError.NONE)
+  if msgList.len == 0: # no pagination is needed for an empty list
+    output = (msgList, PagingInfo(pageSize: 0, cursor:pinfo.cursor, direction: pinfo.direction), HistoryResponseError.NONE)
     return output
   
   # adjust pageSize
@@ -300,27 +300,30 @@ proc paginate*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[IndexedWa
     pageSize = MaxPageSize
 
   # sort the existing messages
-  var 
-    msgList = list # makes a copy of the list
-    total = uint64(msgList.len)
-  # sorts msgList based on the custom comparison proc indexedWakuMessageComparison
-  msgList.sort(indexedWakuMessageComparison)  
+  let total = uint64(msgList.len)
+
+  # sorts list based on the custom comparison proc indexedWakuMessageComparison
+  # TODO: we can gain a lot by rather sorting on insert. Perhaps use a nim-stew sorted set?
+  msgList.sort(indexedWakuMessageComparison)
   
   # set the cursor of the initial paging request
   var isInitialQuery = false
+  var cursorIndex: uint64
   if cursor == Index(): # an empty cursor means it is an initial query
     isInitialQuery = true
     case dir
-      of PagingDirection.FORWARD: 
-        cursor = msgList[0].index # set the cursor to the beginning of the list
-      of PagingDirection.BACKWARD: 
-        cursor = msgList[list.len - 1].index # set the cursor to the end of the list
-    
-  var cursorIndexOption = msgList.findIndex(cursor) 
-  if cursorIndexOption.isNone: # the cursor is not valid
-    output = (@[], PagingInfo(pageSize: 0, cursor:pinfo.cursor, direction: pinfo.direction), HistoryResponseError.INVALID_CURSOR)
-    return output
-  var cursorIndex = uint64(cursorIndexOption.get()) 
+      of PagingDirection.FORWARD:
+        cursorIndex = 0 
+        cursor = msgList[cursorIndex].index # set the cursor to the beginning of the list
+      of PagingDirection.BACKWARD:
+        cursorIndex =  total - 1
+        cursor = msgList[cursorIndex].index # set the cursor to the end of the list
+  else:
+    var cursorIndexOption = msgList.findIndex(cursor) 
+    if cursorIndexOption.isNone: # the cursor is not valid
+      output = (@[], PagingInfo(pageSize: 0, cursor:pinfo.cursor, direction: pinfo.direction), HistoryResponseError.INVALID_CURSOR)
+      return output
+    cursorIndex = uint64(cursorIndexOption.get()) 
     
   case dir
     of PagingDirection.FORWARD: # forward pagination
@@ -375,41 +378,53 @@ proc paginate*(list: seq[IndexedWakuMessage], pinfo: PagingInfo): (seq[IndexedWa
 
 
 proc findMessages(w: WakuStore, query: HistoryQuery): HistoryResponse =
-  var data : seq[IndexedWakuMessage] = w.messages.allItems()
-
-  # filter based on content filters
-  # an empty list of contentFilters means no content filter is requested
-  if ((query.contentFilters).len != 0):
-    # matchedMessages holds IndexedWakuMessage whose content topics match the queried Content filters
-    var matchedMessages : seq[IndexedWakuMessage] = @[]
-    for filter in query.contentFilters:
-      var matched = w.messages.filterIt(it.msg.contentTopic  == filter.contentTopic)  
-      matchedMessages.add(matched)
-    # remove duplicates 
-    # duplicates may exist if two content filters target the same content topic, then the matched message gets added more than once
-    data = matchedMessages.deduplicate()
-
-  # filter based on pubsub topic
-  # an empty pubsub topic means no pubsub topic filter is requested
-  if ((query.pubsubTopic).len != 0):
-    data = data.filterIt(it.pubsubTopic == query.pubsubTopic)
-
-  # temporal filtering   
-  # check whether the history query contains a time filter
-  if (query.endTime != float64(0) and query.startTime != float64(0)):
-    # for a valid time query, select messages whose sender generated timestamps fall bw the queried start time and end time
-    data = data.filterIt(it.msg.timestamp <= query.endTime and it.msg.timestamp >= query.startTime)
-
+  ## Extract query criteria
+  ## All query criteria are optional
+  let
+    qContentTopics = if (query.contentFilters.len != 0): some(query.contentFilters.mapIt(it.contentTopic))
+                     else: none(seq[ContentTopic])
+    qPubSubTopic = if (query.pubsubTopic != ""): some(query.pubsubTopic)
+                   else: none(string)
+    qStartTime = if query.startTime != float64(0): some(query.startTime)
+                 else: none(float64)
+    qEndTime = if query.endTime != float64(0): some(query.endTime)
+               else: none(float64)
   
-  # perform pagination
-  var (indexedWakuMsgList, updatedPagingInfo, error) = paginate(data, query.pagingInfo)
+  ## Compose filter predicate for message from query criteria
+  proc matchesQuery(indMsg: IndexedWakuMessage): bool =
+    if qPubSubTopic.isSome():
+      # filter on pubsub topic
+      if indMsg.pubsubTopic != qPubSubTopic.get():
+        return false
+    
+    if qStartTime.isSome() and qEndTime.isSome():
+      # temporal filtering
+      # select only messages whose sender generated timestamps fall bw the queried start time and end time
+      if indMsg.msg.timestamp > qEndTime.get() or indMsg.msg.timestamp < qStartTime.get():
+        return false
+    
+    if qContentTopics.isSome():
+      # filter on content
+      if indMsg.msg.contentTopic notin qContentTopics.get():
+        return false
+    
+    return true
 
-  # extract waku messages
-  var wakuMsgList = indexedWakuMsgList.mapIt(it.msg)
+  ## Filter history using predicate
+  ## TODO: since MaxPageSize is likely much smaller than w.messages.len,
+  ## we could optimise here by only filtering a portion of w.messages,
+  ## and repeat until we have populated a full page.
+  var filteredMsgs = w.messages.filterIt(it.matchesQuery)
+  
+  ## Paginate the filtered messages
+  let (indexedWakuMsgList, updatedPagingInfo, error) = paginate(filteredMsgs, query.pagingInfo)
 
-  let historyRes = HistoryResponse(messages: wakuMsgList, pagingInfo: updatedPagingInfo, error: error)
+  ## Extract and return response
+  let
+    wakuMsgList = indexedWakuMsgList.mapIt(it.msg)
+    historyRes = HistoryResponse(messages: wakuMsgList, pagingInfo: updatedPagingInfo, error: error)
+  
   return historyRes
-
 
 proc init*(ws: WakuStore, capacity = DefaultStoreCapacity) =
 


### PR DESCRIPTION
## Background

This closes https://github.com/status-im/nim-waku/issues/805 (albeit using a slightly different approach than envisioned in that issue).
It is a prerequisite for the release (https://github.com/status-im/nim-waku/issues/808) and likely addresses https://github.com/status-im/nim-waku/issues/736 as well, though longer term testing will be required to confirm.

It significantly decreases store query times, especially for large message stores as in our fleets.
Recently fleet performance has deteriorated resulting in unusably slow response times.
In local tests query response time improved from >10min to under 100ms.

## What does it change?

- tries to limit calls to more computationally expensive procs (such as `findIndex`)
- extracts all query criteria before filtering, and then filters only once as a single predicate (this saves as from making multiple copies of the in-memory messages)
- pre-sorts messages before pagination (saves us from making another copy)

## What can we still improve?

Changing the underlying data structure (`WakuStore.messages`) to one that sorts on insert will save us from having to sort for each query.  This would also mean that we would only have to find/filter messages until we have populated one full page of history - currently we filter and sort the entire history for every query, and then extract only a single page to respond to the querying node. I don't believe this is urgent yet, as query times seems to be acceptable for now.

cc @D4nte 