### PR TITLE
Ensure consistent resolution of receiver timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ which is a sequence of string.
 - Increased maximum length for reading from a libp2p input stream to allow largest possible protocol messages, including `HistoryResponse` messages at max size.
 - Significantly improved store node query performance
 - Added GossipSub `MessageIdProvider` for `11/WAKU2-RELAY` messages.
+- Store: timestamps of message reception, used for indexing, now have consistent millisecond resolution.
 
 ## 2021-11-05 v0.6
 


### PR DESCRIPTION
This PR provides a (very) minimal solution for https://github.com/status-im/nim-waku/issues/813

It does two things:
1. ensures that the receiver timestamp in `WakuMessage` indices are consistently millisecond resolution
2. uses stored `receiverTimestamp` when loading from persistent storage rather than system time (this keeps the index consistent after restarts)

## Longer term solution:

- Timestamps should be `int64` epoch milliseconds rather than `float64`, which is bound to lead to precision errors. Since this requires a data scheme change, protocol change and an update in other Waku v2 clients, I'll postpone this change until after the release.
- I would still propose that the index itself be a simple, time-sortable hash over receiver timestamp and message content. If prepended by the epoch received timestamp, the hash is guaranteed to be unique forever and can be reused even if the algorithm for index computation changes in future. Following this, the message index should be computed only once. Even while loading from the DB, the index should simply be read from the corresponding record and not re-computed. This will allow us to index messages in-memory in the store using a hash table (much faster to traverse), and for better uniqueness guarantee as PRIMARY KEY in the `Message` table in the DB.
