### PR TITLE
ci: add architecture specification to agent label

### DIFF
--- a/ci/Jenkinsfile.prs
+++ b/ci/Jenkinsfile.prs
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
-  agent { label getAgentLabel() }
+  agent { label "${getAgentLabel()} && x86_64" }
 
   parameters {
     string(


### PR DESCRIPTION
Should fix errors like:
```
clang: error: the clang compiler does not support '-march=native'
```
Caused by hitting the Apple M1 `arm64` host.