### PR TITLE
Support for dns `multiaddrs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The full list of changes is below.
 
 - The `waku-rln-relay` now supports spam-protection for a specific combination of `pubsubTopic` and `contentTopic` (available under the `rln` compiler flag).  
 - The `waku-rln-relay` protocol in integrated into `chat2` (available under the`rln` compiler flag)
+- Added support for resolving dns-based `multiaddrs`
 
 ### Changes
 

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -64,6 +64,18 @@ type
       desc: "Enable message persistence: true|false",
       defaultValue: false
       name: "persist-messages" }: bool
+    
+    ## DNS addrs config
+    
+    dnsAddrs* {.
+      desc: "Enable resolution of `dnsaddr`, `dns4` or `dns6` multiaddrs"
+      defaultValue: true
+      name: "dns-addrs" }: bool
+    
+    dnsAddrsNameServers* {.
+      desc: "DNS name server IPs to query for DNS multiaddrs resolution. Argument may be repeated."
+      defaultValue: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")]
+      name: "dns-addrs-name-server" }: seq[ValidIpAddress]
 
     ## Relay config
     

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -10,7 +10,7 @@ import
   libp2p/crypto/crypto,
   libp2p/protocols/ping,
   libp2p/protocols/pubsub/[gossipsub, rpc/messages],
-  libp2p/nameresolving/dnsresolver,
+  libp2p/nameresolving/nameresolver,
   libp2p/[builders, multihash],
   libp2p/transports/[transport, tcptransport, wstransport],
   ../protocol/[waku_relay, waku_message],
@@ -160,7 +160,7 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
     secureKey: string = "",
     secureCert: string = "",
     wakuFlags = none(WakuEnrBitfield),
-    dnsResolver: DnsResolver = nil,
+    nameResolver: NameResolver = nil,
     ): T 
     {.raises: [Defect, LPError, IOError, TLSStreamProtocolError].} =
   ## Creates a Waku Node.
@@ -220,7 +220,7 @@ proc new*(T: type WakuNode, nodeKey: crypto.PrivateKey,
     wssEnabled = wssEnabled,
     secureKeyPath = secureKey,
     secureCertPath = secureCert,
-    nameResolver = dnsResolver)
+    nameResolver = nameResolver)
   
   let wakuNode = WakuNode(
     peerManager: PeerManager.new(switch, peerStorage),
@@ -928,6 +928,7 @@ when isMainModule:
   import
     confutils,
     system/ansi_c,
+    libp2p/nameresolving/dnsresolver,
     ../../common/utils/nat,
     ./config,
     ./waku_setup,

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -73,7 +73,8 @@ proc parseRemotePeerInfo*(address: string): RemotePeerInfo {.raises: [Defect, Va
 
   for addrPart in multiAddr.items():
     case addrPart[].protoName()[]
-    of "ip4", "ip6", "dnsaddr", "dns4", "dns6":
+    # All protocols listed here: https://github.com/multiformats/multiaddr/blob/b746a7d014e825221cc3aea6e57a92d78419990f/protocols.csv
+    of "ip4", "ip6", "dns", "dnsaddr", "dns4", "dns6":
       nwPart = addrPart.tryGet()
     of "tcp":
       tcpPart = addrPart.tryGet()

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -69,13 +69,12 @@ proc parseRemotePeerInfo*(address: string): RemotePeerInfo {.raises: [Defect, Va
   let multiAddr = MultiAddress.init(address).tryGet()
 
   var
-
-    ipPart, tcpPart, p2pPart, wsPart, wssPart: MultiAddress
+    nwPart, tcpPart, p2pPart, wsPart, wssPart: MultiAddress
 
   for addrPart in multiAddr.items():
     case addrPart[].protoName()[]
-    of "ip4", "ip6":
-      ipPart = addrPart.tryGet()
+    of "ip4", "ip6", "dnsaddr", "dns4", "dns6":
+      nwPart = addrPart.tryGet()
     of "tcp":
       tcpPart = addrPart.tryGet()
     of "p2p":
@@ -89,7 +88,7 @@ proc parseRemotePeerInfo*(address: string): RemotePeerInfo {.raises: [Defect, Va
   let
     peerIdStr = p2pPart.toString()[].split("/")[^1] 
 
-    wireAddr = ipPart & tcpPart & wsPart & wssPart
+    wireAddr = nwPart & tcpPart & wsPart & wssPart
   if (not wireAddr.validWireAddr()):
     raise newException(ValueError, "Invalid node multi-address")
 

--- a/waku/v2/utils/wakuswitch.nim
+++ b/waku/v2/utils/wakuswitch.nim
@@ -45,8 +45,6 @@ proc withWssTransport*(b: SwitchBuilder,
                   tlsCertificate = cert,
                   {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName}))
 
-
-
 proc newWakuSwitch*(
     privKey = none(crypto.PrivateKey),
     address = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),


### PR DESCRIPTION
This PR closes #521

It adds support for parsing and resolving dns-type `multiaddrs`, i.e. protocol schemes [`dns`, `dns4`, `dns6`, `dnsaddr`](https://github.com/multiformats/multiaddr/blob/b746a7d014e825221cc3aea6e57a92d78419990f/protocols.csv#L8-L11).

By default a `nwaku` node would attempt resolution against the Cloudflare name servers `1.1.1.1` and `1.0.0.1`, but this is configurable via the `dns-addrs-name-server` config option. DNS resolution can also be disabled completely by setting `dns-addrs` to `false`.

The next step would be to add a domain name config for a `nwaku` node which it can advertise. This is necessary, for example, to generate and sign a discoverable ENR containing a dns-type `multiaddr`.

cc @D4nte @dao