### PR TITLE
Domain name config for `nwaku` node

### DIFF
--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -1481,3 +1481,22 @@ procSuite "WakuNode":
       node.switch.peerInfo.addrs.contains(announcedEndpoint)
 
     await node.stop()
+
+  asyncTest "Node can use dns4 in announced addresses":
+    let
+      nodeKey = crypto.PrivateKey.random(Secp256k1, rng[])[]
+      bindIp = ValidIpAddress.init("0.0.0.0")
+      bindPort = Port(60000)
+      extIp = some(ValidIpAddress.init("127.0.0.1"))
+      extPort = some(Port(60002))
+      domainName = "example.com"
+      expectedDns4Addr = MultiAddress.init("/dns4" & domainName & "/tcp/" & $bindPort).get()
+      node = WakuNode.new(
+        nodeKey,
+        bindIp, bindPort,
+        extIp, extPort,
+        dns4DomainName = some(domainName))
+    
+    check:
+      node.announcedAddresses.len == 1
+      node.announcedAddresses.contains(expectedDns4Addr)

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -1490,7 +1490,7 @@ procSuite "WakuNode":
       extIp = some(ValidIpAddress.init("127.0.0.1"))
       extPort = some(Port(60002))
       domainName = "example.com"
-      expectedDns4Addr = MultiAddress.init("/dns4" & domainName & "/tcp/" & $bindPort).get()
+      expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $bindPort).get()
       node = WakuNode.new(
         nodeKey,
         bindIp, bindPort,

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -1490,7 +1490,7 @@ procSuite "WakuNode":
       extIp = some(ValidIpAddress.init("127.0.0.1"))
       extPort = some(Port(60002))
       domainName = "example.com"
-      expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $extPort).get()
+      expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $(extPort.get())).get()
       node = WakuNode.new(
         nodeKey,
         bindIp, bindPort,

--- a/tests/v2/test_wakunode.nim
+++ b/tests/v2/test_wakunode.nim
@@ -1490,7 +1490,7 @@ procSuite "WakuNode":
       extIp = some(ValidIpAddress.init("127.0.0.1"))
       extPort = some(Port(60002))
       domainName = "example.com"
-      expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $bindPort).get()
+      expectedDns4Addr = MultiAddress.init("/dns4/" & domainName & "/tcp/" & $extPort).get()
       node = WakuNode.new(
         nodeKey,
         bindIp, bindPort,

--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -76,6 +76,11 @@ type
       desc: "DNS name server IPs to query for DNS multiaddrs resolution. Argument may be repeated."
       defaultValue: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")]
       name: "dns-addrs-name-server" }: seq[ValidIpAddress]
+    
+    dns4DomainName* {.
+      desc: "The domain name resolving to the node's public IPv4 address",
+      defaultValue: ""
+      name: "dns4-domain-name" }: string
 
     ## Relay config
     


### PR DESCRIPTION
This PR introduces the ability to configure a `nwaku` node with an (ipv4) domain name.

This allows for the node's publically announced `multiaddrs` to use the `/dns4/` scheme. In addition, nodes with domain name and secure websocket configured, will generate a discoverable ENR containing the `wss` `multiaddr` with `/dns4/` domain name. This is necessary to verify domain certificates when connecting to this node over secure websocket. 

Related issues: https://github.com/status-im/nim-waku/pull/848 https://github.com/status-im/nim-waku/issues/845