### PR TITLE
Update WakuStoreCodec string to beta4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The full list of changes is below.
 
 - A new type `Timestamp` for all timestamps is introduced (currently an alias for int64).
 - All timestamps now have nanosecond resolution.
-- `waku-store` protocol identifier is updated to `2.0.0-beta4`
+- `waku-store` protocol identifier is updated to `/vac/waku/store/2.0.0-beta4`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The full list of changes is below.
 
 - A new type `Timestamp` for all timestamps is introduced (currently an alias for int64).
 - All timestamps now have nanosecond resolution.
+- `waku-store` version updated to `2.0.0-beta3`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The full list of changes is below.
 
 - A new type `Timestamp` for all timestamps is introduced (currently an alias for int64).
 - All timestamps now have nanosecond resolution.
-- `waku-store` version updated to `2.0.0-beta4`
+- `waku-store` protocol identifier is updated to `2.0.0-beta4`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The full list of changes is below.
 
 - A new type `Timestamp` for all timestamps is introduced (currently an alias for int64).
 - All timestamps now have nanosecond resolution.
-- `waku-store` version updated to `2.0.0-beta3`
+- `waku-store` version updated to `2.0.0-beta4`
 
 ### Fixes
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -97,7 +97,7 @@ proc protocolMatcher(codec: string): Matcher =
   proc match(proto: string): bool {.gcsafe.} =
     ## Matches a proto with any postfix to the provided codec.
     ## E.g. if the codec is `/vac/waku/filter/2.0.0` it matches the protos:
-    ## `/vac/waku/filter/2.0.0`, `/vac/waku/filter/2.0.0-beta4`, `/vac/waku/filter/2.0.0-actualnonsense`
+    ## `/vac/waku/filter/2.0.0`, `/vac/waku/filter/2.0.0-beta3`, `/vac/waku/filter/2.0.0-actualnonsense`
     return proto.startsWith(codec)
 
   return match

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -97,7 +97,7 @@ proc protocolMatcher(codec: string): Matcher =
   proc match(proto: string): bool {.gcsafe.} =
     ## Matches a proto with any postfix to the provided codec.
     ## E.g. if the codec is `/vac/waku/filter/2.0.0` it matches the protos:
-    ## `/vac/waku/filter/2.0.0`, `/vac/waku/filter/2.0.0-beta3`, `/vac/waku/filter/2.0.0-actualnonsense`
+    ## `/vac/waku/filter/2.0.0`, `/vac/waku/filter/2.0.0-beta4`, `/vac/waku/filter/2.0.0-actualnonsense`
     return proto.startsWith(codec)
 
   return match

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -45,7 +45,7 @@ logScope:
   topics = "wakustore"
 
 const
-  WakuStoreCodec* = "/vac/waku/store/2.0.0-beta3"
+  WakuStoreCodec* = "/vac/waku/store/2.0.0-beta4"
   DefaultStoreCapacity* = 50000 # Default maximum of 50k messages stored
 
 # Error types (metric label values)


### PR DESCRIPTION
In light of the store protocol update provided by https://github.com/status-im/nim-waku/pull/842 (timestamps now have nanosecond resolution), the `WakuStoreCodec` string in `waku_store` needs to be updated  to the most recent version `-beta4` in order to be aligned to the corresponding RFC https://rfc.vac.dev/spec/13/.