### PR TITLE
Remove ref to fleets.status.im

### DIFF
--- a/examples/v2/config_chat2.nim
+++ b/examples/v2/config_chat2.nim
@@ -202,7 +202,7 @@ type
     ## Chat2 configuration
     
     fleet* {.
-      desc: "Select the fleet to connect to."
+      desc: "Select the fleet to connect to. This sets the DNS discovery URL to the selected fleet."
       defaultValue: Fleet.prod
       name: "fleet" }: Fleet
 


### PR DESCRIPTION
Closes https://github.com/status-im/nim-waku/issues/850

Removes the remaining reference to _fleets.status.im_ from the `nim-waku` codebase. This was used by `chat2` to select random nodes to connect to from a configured fleet. In the new implementation, `chat2` uses DNS discovery to discover and connect to fleet nodes (or any list of nodes published to a user-configurable `--dns-discovery-url`).

From a user's perspective the behaviour is the same as before: by default a `chat2` client will attempt to connect to `prod`, although this is configurable using the `--fleet` option and can be disabled using `--fleet:none`.