### PR TITLE
fix: message when connecting to fleet nodes

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -378,13 +378,14 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
                   symKey: generateSymKey(conf.contentTopic))
 
   if conf.staticnodes.len > 0:
+    echo "Connecting to static peers..."
     await connectToNodes(chat, conf.staticnodes)
   
   var dnsDiscoveryUrl = none(string)
 
   if conf.fleet != Fleet.none:
     # Use DNS discovery to connect to selected fleet
-    echo "No static peers configured. Connecting to " & $conf.fleet & " fleet using DNS discovery..."
+    echo "Connecting to " & $conf.fleet & " fleet using DNS discovery..."
     
     if conf.fleet == Fleet.test:
       dnsDiscoveryUrl = some("enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im")


### PR DESCRIPTION
This PR fixes the message echoed when connecting to a fleet.
It used to say "No static peers configured [...]".
However, the corresponding branch will be executed regardless if static peers are configured or not.

This PR also adds an echo printing a message when connecting to static nodes, because a similiar messages is printed when connecting to nodes learned via other methods.