### PR TITLE
Bridge improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Next version
+
+
+### Features
+
+### Changes
+
+- Waku v1 <> v2 bridge now supports DNS `multiaddrs`
+- Waku v1 <> v2 bridge now validates content topics before attempting to bridge a message from Waku v2 to Waku v1
+
+### Fixes
+
+### Docs
+
 ##  2021-03-03 v0.8
 
 Release highlights:
@@ -23,6 +37,7 @@ The full list of changes is below.
 - Metrics: improved default fleet monitoring dashboard
 - Introduced a `Timestamp` type (currently an alias for int64).
 - All timestamps changed to nanosecond resolution.
+- `timestamp` field number in WakuMessage object changed from `4` to `10`
 - [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/) identifier updated to `/vac/waku/store/2.0.0-beta4`
 - `toy-chat` application now uses DNS discovery to connect to existing fleets
 

--- a/tests/v2/test_waku_bridge.nim
+++ b/tests/v2/test_waku_bridge.nim
@@ -98,6 +98,19 @@ procSuite "WakuBridge":
     expect ValueError:
       # Content topic name not hex
       discard toV1Topic(ContentTopic("/waku/1/my-content/rfc26"))
+  
+  asyncTest "Verify that WakuMessages are on bridgeable content topics":
+    let
+      validCT = ContentTopic("/waku/1/my-content/rfc26")
+      unnamespacedCT = ContentTopic("just_a_bunch_of_words")
+      invalidAppCT = ContentTopic("/facebook/1/my-content/rfc26")
+      invalidVersionCT = ContentTopic("/waku/2/my-content/rfc26")
+
+    check:
+      WakuMessage(contentTopic: validCT).isBridgeable() == true
+      WakuMessage(contentTopic: unnamespacedCT).isBridgeable() == false
+      WakuMessage(contentTopic: invalidAppCT).isBridgeable() == false
+      WakuMessage(contentTopic: invalidVersionCT).isBridgeable() == false
 
   asyncTest "Messages are bridged between Waku v1 and Waku v2":
     # Setup test

--- a/waku/common/config_bridge.nim
+++ b/waku/common/config_bridge.nim
@@ -134,6 +134,16 @@ type
       defaultValue: ""
       name: "filternode" }: string
     
+    dnsAddrs* {.
+      desc: "Enable resolution of `dnsaddr`, `dns4` or `dns6` multiaddrs"
+      defaultValue: true
+      name: "dns-addrs" }: bool
+    
+    dnsAddrsNameServers* {.
+      desc: "DNS name server IPs to query for DNS multiaddrs resolution. Argument may be repeated."
+      defaultValue: @[ValidIpAddress.init("1.1.1.1"), ValidIpAddress.init("1.0.0.1")]
+      name: "dns-addrs-name-server" }: seq[ValidIpAddress]
+    
     ### Bridge options
 
     bridgePubsubTopic* {.


### PR DESCRIPTION
This PR introduces two minor improvements to the Waku v1 <> v2 bridge, that will improve its usability during the Status Waku v2 integration effort:
1. Bridge now supports resolving DNS addresses (useful for easy deployment)
2. Bridge now validates a Waku v2 message content topic before attempting to bridge the message to v1 (only messages with content topic pattern `/waku/1/*/*` are bridgeable).

(I also snuck in a single line re `timestamp` field number in the CHANGELOG that appears in the release notes for nim-waku `v0.8` but not in the CHANGELOG.)