### PR TITLE
Store timestamp validity checks

### DIFF
--- a/tests/v2/test_waku_store_queue.nim
+++ b/tests/v2/test_waku_store_queue.nim
@@ -56,7 +56,7 @@ procSuite "Sorted store queue":
   test "Sender time can't be more than MaxTimeVariance in future":
     var stQ = StoreQueueRef.new(capacity)
     let
-      receiverTime = 10*1000*1000*1000
+      receiverTime = getNanoSecondTime(10)
       senderTimeOk = receiverTime + MaxTimeVariance
       senderTimeErr = senderTimeOk + 1
       validMessage = IndexedWakuMessage(msg: WakuMessage(payload: @[byte 1], timestamp: senderTimeOk),

--- a/tests/v2/test_waku_store_queue.nim
+++ b/tests/v2/test_waku_store_queue.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import
-  std/sequtils,
+  std/[sequtils, strutils],
   testutils/unittests,
   ../../waku/v2/protocol/waku_store/waku_store_types,
   ../../waku/v2/utils/time
@@ -40,9 +40,40 @@ procSuite "Sorted store queue":
     # Add one more. Capacity should not be exceeded.
     check:
       stQ.add(genIndexedWakuMessage(capacity.int8 + 1)).isOk()
+      stQ.len == capacity
+    
+    # Attempt to add message with older value than oldest in queue should fail
+    let
+      oldestTimestamp = stQ.first().get().index.senderTime
+      addRes = stQ.add(genIndexedWakuMessage(oldestTimestamp.int8 - 1))
     
     check:
+      oldestTimestamp == 2
+      addRes.isErr()
+      ($(addRes.error())).contains("too_old")
       stQ.len == capacity
+  
+  test "Sender time can't be more than MaxTimeVariance in future":
+    var stQ = StoreQueueRef.new(capacity)
+    let
+      receiverTime = 10*1000*1000*1000
+      senderTimeOk = receiverTime + MaxTimeVariance
+      senderTimeErr = senderTimeOk + 1
+      validMessage = IndexedWakuMessage(msg: WakuMessage(payload: @[byte 1], timestamp: senderTimeOk),
+                                        index: Index(receiverTime: receiverTime, senderTime: senderTimeOk))
+      invalidMessage = IndexedWakuMessage(msg: WakuMessage(payload: @[byte 1], timestamp: senderTimeErr),
+                                          index: Index(receiverTime: receiverTime, senderTime: senderTimeErr))
+    
+    # Invalid case
+    let invalidRes = stQ.add(invalidMessage)
+    check:
+      invalidRes.isErr()
+      ($(invalidRes.error())).contains("future_sender_timestamp")
+    
+    # Valid case
+    let validRes = stQ.add(validMessage)
+    check:
+      validRes.isOk()
   
   test "Store queue sort-on-insert works":    
     # Walk forward through the set and verify ascending order

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -394,8 +394,8 @@ proc handleMessage*(w: WakuStore, topic: string, msg: WakuMessage) {.async.} =
   let addRes = w.messages.add(IndexedWakuMessage(msg: msg, index: index, pubsubTopic: topic))
   
   if addRes.isErr:
-    trace "Attempt to add message with duplicate index to store", msg=msg, index=index
-    waku_store_errors.inc(labelValues = ["duplicate"])
+    trace "Attempt to add message to store failed", msg=msg, index=index, err=addRes.error()
+    waku_store_errors.inc(labelValues = [$(addRes.error())])
     return # Do not attempt to store in persistent DB
   
   waku_store_messages.set(w.messages.len.int64, labelValues = ["stored"])

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -36,7 +36,7 @@ const
 
   MaxRpcSize* = MaxPageSize * MaxWakuMessageSize + 64*1024 # We add a 64kB safety buffer for protocol overhead
 
-  MaxTimeVariance* = (20*1000*1000*1000).int64 # 20 seconds maximum allowable sender timestamp "drift" into the future
+  MaxTimeVariance* = getNanoSecondTime(20) # 20 seconds maximum allowable sender timestamp "drift" into the future
 
   DefaultTopic* = "/waku/2/default-waku/proto"
 


### PR DESCRIPTION
Improves store integrity by adding two validity checks before storing a message:
1. The message sender timestamp may not be more than 20 seconds into the future (i.e. ahead of the receiver timestamp). This is to prevent messages from "jumping" the store queue by simply setting the `timestamp` to the future.
2. Once the store queue is at capacity, a message will not be store if its index is older than the oldest index currently in the queue.