### PR TITLE
Chat2 improvements: remove noise, set sender timestamp

### DIFF
--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -238,7 +238,7 @@ proc publish(c: Chat, line: string) =
   else:
     # No payload encoding/encryption from Waku
     var message = WakuMessage(payload: chat2pb.buffer,
-      contentTopic: c.contentTopic, version: 0, timestamp: Timestamp(time*1000*1000*1000))
+      contentTopic: c.contentTopic, version: 0, timestamp: getNanosecondTime(time))
     when defined(rln):
       if  not isNil(c.node.wakuRlnRelay):
         # for future version when we support more than one rln protected content topic, 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -216,7 +216,7 @@ proc publish(c: Chat, line: string) =
       encodedPayload = payload.encode(version, c.node.rng[])
     if encodedPayload.isOk():
       var message = WakuMessage(payload: encodedPayload.get(),
-        contentTopic: c.contentTopic, version: version, timestamp: Timestamp(time*1000*1000*1000))
+        contentTopic: c.contentTopic, version: version, timestamp: getNanosecondTime(time))
       when defined(rln):
         if  not isNil(c.node.wakuRlnRelay):
           # for future version when we support more than one rln protected content topic, 

--- a/examples/v2/chat2.nim
+++ b/examples/v2/chat2.nim
@@ -23,7 +23,7 @@ import libp2p/[switch,                   # manage transports, a single entry poi
                muxers/muxer]             # define an interface for stream multiplexing, allowing peers to offer many protocols over a single connection
 import   ../../waku/v2/node/[wakunode2, waku_payload],
          ../../waku/v2/node/./dnsdisc/waku_dnsdisc,
-         ../../waku/v2/utils/peers,
+         ../../waku/v2/utils/[peers,time],
          ../../waku/common/utils/nat,
          ./config_chat2
 
@@ -216,7 +216,7 @@ proc publish(c: Chat, line: string) =
       encodedPayload = payload.encode(version, c.node.rng[])
     if encodedPayload.isOk():
       var message = WakuMessage(payload: encodedPayload.get(),
-        contentTopic: c.contentTopic, version: version)
+        contentTopic: c.contentTopic, version: version, timestamp: Timestamp(time*1000*1000*1000))
       when defined(rln):
         if  not isNil(c.node.wakuRlnRelay):
           # for future version when we support more than one rln protected content topic, 
@@ -238,7 +238,7 @@ proc publish(c: Chat, line: string) =
   else:
     # No payload encoding/encryption from Waku
     var message = WakuMessage(payload: chat2pb.buffer,
-      contentTopic: c.contentTopic, version: 0)
+      contentTopic: c.contentTopic, version: 0, timestamp: Timestamp(time*1000*1000*1000))
     when defined(rln):
       if  not isNil(c.node.wakuRlnRelay):
         # for future version when we support more than one rln protected content topic, 
@@ -488,7 +488,8 @@ proc processInput(rfd: AsyncFD, rng: ref BrHmacDrbgContext) {.async.} =
       let decoded = WakuMessage.init(data)
       
       if decoded.isOk():
-        chat.printReceivedMessage(decoded.get())
+        if decoded.get().contentTopic == chat.contentTopic:
+          chat.printReceivedMessage(decoded.get())
       else:
         trace "Invalid encoded WakuMessage", error = decoded.error
 


### PR DESCRIPTION
Two improvements for `chat2`:
1. Do not print messages that are not on the `chat2` content topic (especially important once message rates for other applications increase).
2. Set the message `timestamp` for `store` consistency.