### PR TITLE
Fixes getNanoSeconds() time conversion 

### DIFF
--- a/waku/v2/utils/time.nim
+++ b/waku/v2/utils/time.nim
@@ -9,11 +9,11 @@ type Timestamp* = int64
 const TIMESTAMP_TABLE_TYPE* = "INTEGER"
 
 proc getNanosecondTime*[T](timeInSeconds: T): Timestamp = 
-  var ns = Timestamp(timeInSeconds*100000000)
+  var ns = Timestamp(timeInSeconds*1000*1000*1000)
   return ns
 
 proc getMicrosecondTime*[T](timeInSeconds: T): Timestamp = 
-  var us = Timestamp(timeInSeconds*1000000)
+  var us = Timestamp(timeInSeconds*1000*1000)
   return us
 
 proc getMillisecondTime*[T](timeInSeconds: T): Timestamp = 


### PR DESCRIPTION
A fix to the conversion of seconds to nanoseconds in the `getNanoSeconds()` proc. 
The faulty version would cause messages to be timestamped (sender or receiver) with some value pointing to the past. 