### PR TITLE
switch vendor/nim-eth branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "vendor/nim-eth"]
 	path = vendor/nim-eth
-	url = https://github.com/kaiserd/nim-eth.git
+	url = https://github.com/status-im/nim-eth.git
 	ignore = dirty
-	branch = add-selectable-protocol-id-static
+	branch = selectable-protocol-id
 [submodule "vendor/nim-secp256k1"]
 	path = vendor/nim-secp256k1
 	url = https://github.com/status-im/nim-secp256k1.git


### PR DESCRIPTION
I got write access to [status-nim/eth](https://github.com/status-im/nim-eth)  and pushed a feature branch supporting `33/WAKU-DISCV5`. 
This PR updates the nim-eth submodule switching the branch from my fork to the [status-im/nim-eth feature branch](https://github.com/status-im/nim-eth).
It also bumps to the lastest version of nim-eth.