### PR TITLE
discv5 dns bootstrap

### DIFF
--- a/tests/v2/test_waku_discv5.nim
+++ b/tests/v2/test_waku_discv5.nim
@@ -52,7 +52,7 @@ procSuite "Waku Discovery v5":
         some(extIp), some(nodeTcpPort1), some(nodeUdpPort1),
         bindIp,
         nodeUdpPort1,
-        @[],
+        newSeq[string](),
         false,
         keys.PrivateKey(nodeKey1.skkey),
         flags,

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1263,12 +1263,12 @@ when isMainModule:
   else:
     (pStorage, mStorage) = setupStorageRes.get()
 
-  debug "2/7 Retrieve dynamic boostrap nodes"
+  debug "2/7 Retrieve dynamic bootstrap nodes"
   
   var dynamicBootstrapNodes: seq[RemotePeerInfo]
   let dynamicBootstrapNodesRes = retrieveBootstrapNodes(conf)
   if dynamicBootstrapNodesRes.isErr:
-    error "2/7 Retrieving dynamic boostrap nodes failed. Continuing without dynamic boostrap nodes."
+    error "2/7 Retrieving dynamic bootstrap nodes failed. Continuing without dynamic bootstrap nodes."
   else:
     dynamicBootstrapNodes = dynamicBootstrapNodesRes.get()
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1103,8 +1103,12 @@ when isMainModule:
       # select dynamic bootstrap nodes that have an ENR containing a udp port
       var discv5BootstrapEnrs: seq[enr.Record]
       for n in dynamicBootstrapNodes:
-        if n.enr.isSome() and n.enr.get().toTypedRecord().tryGet().udp.isSome(): # TODO: idiomatic error handling
-          discv5BootstrapEnrs.add(n.enr.get())
+        if n.enr.isSome():
+          let
+            enr = n.enr.get()
+            tenrRes = enr.toTypedRecord()
+          if tenrRes.isOk() and tenrRes.get().udp.isSome():
+            discv5BootstrapEnrs.add(enr)
     
       # parse enrURIs from the configuration and add the resulting ENRs to the discv5BootstrapEnrs seq
       for enrUri in conf.discv5BootstrapNodes:

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -17,6 +17,7 @@ type
   RemotePeerInfo* = ref object of RootObj
     peerId*: PeerID
     addrs*: seq[MultiAddress]
+    enr*: Option[enr.Record]
     protocols*: seq[string]
 
 func `$`*(remotePeerInfo: RemotePeerInfo): string =
@@ -26,11 +27,13 @@ proc init*(
   p: typedesc[RemotePeerInfo],
   peerId: PeerID,
   addrs: seq[MultiAddress] = @[],
+  enr: Option[enr.Record] = none(enr.Record),
   protocols: seq[string] = @[]): RemotePeerInfo =
 
   let remotePeerInfo = RemotePeerInfo(
     peerId: peerId,
     addrs: addrs,
+    enr: enr,
     protocols: protocols)
   
   return remotePeerInfo
@@ -38,12 +41,14 @@ proc init*(
 proc init*(p: typedesc[RemotePeerInfo],
            peerId: string,
            addrs: seq[MultiAddress] = @[],
+           enr: Option[enr.Record] = none(enr.Record),
            protocols: seq[string] = @[]): RemotePeerInfo
            {.raises: [Defect, ResultError[cstring], LPError].} =
   
   let remotePeerInfo = RemotePeerInfo(
     peerId: PeerID.init(peerId).tryGet(),
     addrs: addrs,
+    enr: enr,
     protocols: protocols)
 
   return remotePeerInfo
@@ -145,11 +150,12 @@ proc toRemotePeerInfo*(enr: enr.Record): Result[RemotePeerInfo, cstring] =
   if addrs.len == 0:
     return err("enr: no addresses in record")
 
-  return ok(RemotePeerInfo.init(peerId, addrs))
+  return ok(RemotePeerInfo.init(peerId, addrs, some(enr)))
 
 ## Converts the local peerInfo to dialable RemotePeerInfo
 ## Useful for testing or internal connections
 proc toRemotePeerInfo*(peerInfo: PeerInfo): RemotePeerInfo =
   RemotePeerInfo.init(peerInfo.peerId,
                       peerInfo.addrs,
+                      none(enr.Record), # TODO
                       peerInfo.protocols)

--- a/waku/v2/utils/peers.nim
+++ b/waku/v2/utils/peers.nim
@@ -157,5 +157,5 @@ proc toRemotePeerInfo*(enr: enr.Record): Result[RemotePeerInfo, cstring] =
 proc toRemotePeerInfo*(peerInfo: PeerInfo): RemotePeerInfo =
   RemotePeerInfo.init(peerInfo.peerId,
                       peerInfo.addrs,
-                      none(enr.Record), # TODO
+                      none(enr.Record), # we could generate an ENR from PeerInfo
                       peerInfo.protocols)


### PR DESCRIPTION
## Background

This PR addresses #880.
The current draft implementation passed a test on an experimental fleet.
This fleet server can be used for testing:
`enrtree://AKRUVB7WRORHGL5IIHKHEXGALD5IWWAL7UIVOUZ2FKE4ORV5WOX76@waku.337.ovh`
(I will keep this running during the testing phase; might be down sometimes during update phases.)

The following explains my implementation choices.
(No strong opinion on these, and happy to change if desired :))


### Introducing a separate setup phase for bootstrap nodes

Bootstrap nodes are passed to the discv5 object during the `initialize node` phase while they are dialed by Waku relay in the `start node` phase.
To avoid retrieving bootstrap nodes twice, having a separate phase for retrieving them before `initialize node` seemed like a solution with not too much restructuring.
Also, the new `retrieve dynamic bootstrap nodes` phase can be extended to retrieve dynamic bootstrap nodes from other sources, too (e.g. mDNS).

### ENR in RemotePeerInfo

This PR extends `RemotePeerInfo` storing ENRs of discovered nodes.
[DNS discovery](https://rfc.vac.dev/spec/10/#discovery-methods) retrieves ENRs anyway. While storing the ENR was not useful before because Waku only uses multiaddrs, it is now useful with the introduction of discv5, which uses the ENR format.
Storing the ENRs also avoids additional conversions.

(I am not sure if `Option` is the idiomatic Nim way for introducing an optional field. I did not find information on this in the [style guide](https://status-im.github.io/nim-style-guide/00_introduction.html). Options feel a bit clunky in Nim.)

## Todo

If the current implementation choices are fine, I would address the following

* [x] remove double conversion of ENRs from string to Record format and vice versa
* ~extend local peerInfo with ENR~ `peerInfo` is in libp2p
   - a future PR could generate an ENR [here](https://github.com/status-im/nim-waku/blob/b8da352a56b49642f198f30c45946669e055c0c1/waku/v2/utils/peers.nim#L160)




