### PR TITLE
add RAM requirement to README

### DIFF
--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -29,6 +29,15 @@ make wakunode2
 #./build/wakunode2 --log-level:debug --discovery:off --fleet:test --log-metrics
 ```
 
+Note: building `wakunode2` requires 2GB of RAM. The build will fail on systems not fulfilling this requirement.
+
+Setting up a `wakunode2` on the smallest [digital ocean](https://docs.digitalocean.com/products/droplets/how-to/) droplet, you can either
+
+* compile on a stronger droplet featuring the same CPU architecture and downgrade after compiling, or
+* activate swap on the smallest droplet.
+
+
+
 ### Waku v2 Protocol Test Suite
 
 ```bash

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -37,7 +37,6 @@ Setting up a `wakunode2` on the smallest [digital ocean](https://docs.digitaloce
 * activate swap on the smallest droplet.
 
 
-
 ### Waku v2 Protocol Test Suite
 
 ```bash

--- a/waku/v2/README.md
+++ b/waku/v2/README.md
@@ -34,7 +34,8 @@ Note: building `wakunode2` requires 2GB of RAM. The build will fail on systems n
 Setting up a `wakunode2` on the smallest [digital ocean](https://docs.digitalocean.com/products/droplets/how-to/) droplet, you can either
 
 * compile on a stronger droplet featuring the same CPU architecture and downgrade after compiling, or
-* activate swap on the smallest droplet.
+* activate swap on the smallest droplet, or
+* use Docker.
 
 
 ### Waku v2 Protocol Test Suite


### PR DESCRIPTION
This PR addresses #866.
I also added a short explanation on how to run wakunod2 on the smaller DO droplet.
Not sure if this is too specific for the main README, but might help folks running into the same issue.