### PR TITLE
Fix: timestamp type could overflow before conversion

### DIFF
--- a/tests/v2/test_message_store.nim
+++ b/tests/v2/test_message_store.nim
@@ -19,7 +19,7 @@ suite "Message Store":
 
       t1 = getNanosecondTime(epochTime())
       t2 = getNanosecondTime(epochTime())
-      t3 = getNanosecondTime(high(float64))
+      t3 = high(int64)
     var msgs = @[
       WakuMessage(payload: @[byte 1, 2, 3], contentTopic: topic, version: uint32(0), timestamp: t1),
       WakuMessage(payload: @[byte 1, 2, 3, 4], contentTopic: topic, version: uint32(1), timestamp: t2),

--- a/waku/v2/utils/time.nim
+++ b/waku/v2/utils/time.nim
@@ -9,15 +9,15 @@ type Timestamp* = int64
 const TIMESTAMP_TABLE_TYPE* = "INTEGER"
 
 proc getNanosecondTime*[T](timeInSeconds: T): Timestamp = 
-  var ns = Timestamp(timeInSeconds*1000_000_000)
+  var ns = Timestamp(timeInSeconds.int64 * 1000_000_000.int64)
   return ns
 
 proc getMicrosecondTime*[T](timeInSeconds: T): Timestamp = 
-  var us = Timestamp(timeInSeconds*1000_000)
+  var us = Timestamp(timeInSeconds.int64 * 1000_000.int64)
   return us
 
 proc getMillisecondTime*[T](timeInSeconds: T): Timestamp = 
-  var ms = Timestamp(timeInSeconds*1000)
+  var ms = Timestamp(timeInSeconds.int64 * 1000.int64)
   return ms
 
 proc column_timestamp*(a1: ptr sqlite3_stmt, iCol: cint): int64 =


### PR DESCRIPTION
Fixes an issue in `time` utils, where an integer overflow could happen before converting that integer to an `int64` timestamp.
This issue causes the `wakubridge` to generate invalid Waku v2 timestamps for messages bridged from Waku v1.

cc @richard-ramos 

### What is the fix?

The `get...[T](timeInSeconds: T): Timestamp` functions should convert the integer input arguments to `int64` before multiplying, otherwise the multiplication output would still have the same width as the width of the argument. For example, if `getNanosecondTimestamp()` is called with an `int32` input of the current epoch time in seconds, the multiplication with `1000_000_000` would yield an invalid, overflowed `int32` result.