### PR TITLE
ci(windows): disable windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,60 +53,60 @@ jobs:
       - name: Run V2 Tests
         run: make test2
 
-  windows:
-    strategy:
-      matrix:
-        env:
-          - NPROC: 2
-            MAKEFLAGS: "-j${NPROC}"
-            ARCH_OVERRIDE: "%PLATFORM%"
-    runs-on: windows-latest
-    env: ${{ matrix.env }}
-    timeout-minutes: 90
+  # windows:
+  #   strategy:
+  #     matrix:
+  #       env:
+  #         - NPROC: 2
+  #           MAKEFLAGS: "-j${NPROC}"
+  #           ARCH_OVERRIDE: "%PLATFORM%"
+  #   runs-on: windows-latest
+  #   env: ${{ matrix.env }}
+  #   timeout-minutes: 90
 
-    name: windows - ${{ matrix.env.NPROC }} processes
+  #   name: windows - ${{ matrix.env.NPROC }} processes
 
-    steps:
-      - uses: eine/setup-msys2@v2
-        with:
-            msystem: MSYS
-            update: true
+  #   steps:
+  #     - uses: eine/setup-msys2@v2
+  #       with:
+  #           msystem: MSYS
+  #           update: true
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-        # We need to do this because of how github cache works
-        # I am not sure we can move the cache file, so if we do not do this
-        # make update breaks because the cached compiler is there where the submodules
-        # are meant to go.
-      - name: Submodules
-        run: git submodule update --init --recursive
+  #       # We need to do this because of how github cache works
+  #       # I am not sure we can move the cache file, so if we do not do this
+  #       # make update breaks because the cached compiler is there where the submodules
+  #       # are meant to go.
+  #     - name: Submodules
+  #       run: git submodule update --init --recursive
 
-      - name: Cache nim
-        uses: actions/cache@v1
-        with:
-          path: vendor/nimbus-build-system/vendor/Nim/bin
-          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
+  #     - name: Cache nim
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: vendor/nimbus-build-system/vendor/Nim/bin
+  #         key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
 
-      - name: Update dependencies
-        run: mingw32-make CI_CACHE=NimBinaries update
+  #     - name: Update dependencies
+  #       run: mingw32-make CI_CACHE=NimBinaries update
 
-      - name: Fetch DLLs
-        run: mingw32-make fetch-dlls
+  #     - name: Fetch DLLs
+  #       run: mingw32-make fetch-dlls
 
-      - name: Build V1 Binaries
-        run: mingw32-make LOG_LEVEL=TRACE v1
+  #     - name: Build V1 Binaries
+  #       run: mingw32-make LOG_LEVEL=TRACE v1
 
-      - name: Build V2 Binaries
-        run: mingw32-make LOG_LEVEL=TRACE v2
+  #     - name: Build V2 Binaries
+  #       run: mingw32-make LOG_LEVEL=TRACE v2
 
-      - name: Test Binaries
-        run: |
-          build\wakunode1.exe --help
-          build\wakunode2.exe --help
+  #     - name: Test Binaries
+  #       run: |
+  #         build\wakunode1.exe --help
+  #         build\wakunode2.exe --help
 
-      - name: Run V1 Tests
-        run: mingw32-make test1
+  #     - name: Run V1 Tests
+  #       run: mingw32-make test1
 
-      - name: Run V2 Tests
-        run: mingw32-make test2
+  #     - name: Run V2 Tests
+  #       run: mingw32-make test2


### PR DESCRIPTION
Disable Windows CI for now, as it is currently failing on both Jenkins and as a Github workflow for reasons unrelated to the code.

This PR disables Windows CI in Github. It's also been manually [disabled in Jenkins](https://ci.status.im/job/nim-waku/job/prs/job/windows/configure).

This issue tracks re-enabling Windows CI: https://github.com/status-im/nim-waku/issues/896

> Note: let's use [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) from now on.