### PR TITLE
fix: prevent empty store response due to blocked walker

### DIFF
--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -200,6 +200,7 @@ proc fwdPage(storeQueue: StoreQueueRef,
       outSeq = @[]
       outPagingInfo = PagingInfo(pageSize: 0, cursor: startCursor.get(), direction: PagingDirection.FORWARD)
       outError = HistoryResponseError.INVALID_CURSOR
+      w.destroy
       return (outSeq, outPagingInfo, outError)
     
     # Advance walker once more
@@ -271,6 +272,7 @@ proc bwdPage(storeQueue: StoreQueueRef,
       outSeq = @[]
       outPagingInfo = PagingInfo(pageSize: 0, cursor: startCursor.get(), direction: PagingDirection.BACKWARD)
       outError = HistoryResponseError.INVALID_CURSOR
+      w.destroy
       return (outSeq, outPagingInfo, outError)
 
     # Step walker one more step back


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-waku/issues/882

Previously a store node could run into a state where it would return an empty history response to each store query. This was because the walker used to populate a page of history would not get properly destroyed under certain error conditions - specifically when the node received a query with an invalid cursor. Afterwards all history responses would be empty.

Fix has been soak tested on the `prod` fleet where this issue was most observed previously.