### PR TITLE
fix(store): capacity limit for persistent message store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Waku v1 <> v2 bridge now supports DNS `multiaddrs`
 - Waku v1 <> v2 bridge now validates content topics before attempting to bridge a message from Waku v2 to Waku v1
+- Message store now auto deletes messages once over specified `--store-capacity`. This can significantly improve node start-up times.
 
 ### Fixes
 

--- a/waku/v2/node/storage/message/message_store.nim
+++ b/waku/v2/node/storage/message/message_store.nim
@@ -20,5 +20,5 @@ type
 
 # MessageStore interface
 method put*(db: MessageStore, cursor: Index, message: WakuMessage, pubsubTopic: string): MessageStoreResult[void] {.base.} = discard
-method getAll*(db: MessageStore, onData: DataProc, limit = none(int)): MessageStoreResult[bool] {.base.} = discard
+method getAll*(db: MessageStore, onData: DataProc): MessageStoreResult[bool] {.base.} = discard
 

--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -1018,7 +1018,7 @@ when isMainModule:
       
       if conf.persistMessages:
         # Historical message persistence enable. Set up Message table in storage
-        let res = WakuMessageStore.init(sqliteDatabase)
+        let res = WakuMessageStore.init(sqliteDatabase, conf.storeCapacity)
 
         if res.isErr:
           warn "failed to init WakuMessageStore", err = res.error

--- a/waku/v2/protocol/waku_store/waku_store.nim
+++ b/waku/v2/protocol/waku_store/waku_store.nim
@@ -369,7 +369,7 @@ proc init*(ws: WakuStore, capacity = DefaultStoreCapacity) =
 
   info "attempting to load messages from persistent storage"
 
-  let res = ws.store.getAll(onData, some(capacity))
+  let res = ws.store.getAll(onData)
   if res.isErr:
     warn "failed to load messages from store", err = res.error
     waku_store_errors.inc(labelValues = ["store_load_failure"])

--- a/waku/v2/protocol/waku_store/waku_store_types.nim
+++ b/waku/v2/protocol/waku_store/waku_store_types.nim
@@ -110,8 +110,8 @@ type
   WakuStore* = ref object of LPProtocol
     peerManager*: PeerManager
     rng*: ref BrHmacDrbgContext
-    messages*: StoreQueueRef
-    store*: MessageStore
+    messages*: StoreQueueRef # in-memory message store
+    store*: MessageStore  # sqlite DB handle
     wakuSwap*: WakuSwap
     persistMessages*: bool
 


### PR DESCRIPTION
This PR provides a simple solution to https://github.com/status-im/infra-status/issues/5 and https://github.com/status-im/nim-waku/issues/767

Currently, the DB grows boundless, and, while only a subset of messages is loaded into the in-memory store, an `ORDER-BY` operation is run on the whole DB.
This might lead to very long loading times https://github.com/status-im/infra-status/issues/5 

This PR adds `numMessages` (a message counter) and `maxMessages` (max number of messages to be held in the sqlite DB) to the `WakuMessageStore`.
When `put`ting a message into the store, it checks if `maxMessages` is reached and if so, deletes a configurable percentage of oldest messages.

This PR introduces two new config options:

* `--db-capacity` the maximum number of messages stored in the DB
* `--db-truncate-percentage` the percentage of messages to be deleted once the max is reached

These are added for flexibility when testing on the test fleet and might be removed in the future.

This PR further changes the first part of the sqlite primary key from `senderTimestamp` to `receiverTimestamp`.
Rationale: Most costly sort operations are on `receiverTimestamp`, so this change increases performance.
I would suggest, building a dedicated index on `receiverTimestamp` as even with this change, sqlite has to build a temporary B-tree when ordering by `receiverTimestamp`.
(For this, I could introduce another issue. As we plan to update to a more efficient DB structure anyway, we might wait for the respective issue.)

## Alternatives

These are alternatives to solving the issues mentioned above:

* don't change the implementation but simply run a chron job truncating the DB from time to time
* trigger the `trunctate` proc introduced by this PR within a timer instead of on `put`.

We are planning to update the DB structure to make it more efficient, which will solve these issues, too.
So this PR is more of a quick fix.

cc @jakubgs 

## Todo

These todo's should be completed before making the PR mergeable / "ready for review".

* [x] fix test error : reverted the primary key change for now
* [x] add tests
* ~adapt the migration test to the new primary key~ no primary key update in this PR
* [ ] update documentation
