### PR TITLE
Increase rln-relay logging

### DIFF
--- a/waku/v2/node/config.nim
+++ b/waku/v2/node/config.nim
@@ -106,7 +106,7 @@ type
 
     rlnRelayContentTopic* {.
       desc: "the pubsub topic for which rln-relay gets enabled",
-      defaultValue: "/toy-chat/2/huilong/proto"
+      defaultValue: "/toy-chat/2/luzhou/proto"
       name: "rln-relay-content-topic" }: ContentTopic
     
     staticnodes* {.

--- a/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
+++ b/waku/v2/protocol/waku_rln_relay/waku_rln_relay_utils.nim
@@ -224,7 +224,7 @@ proc proofVerify*(rlnInstance: RLN[Bn256], data: openArray[byte], proof: RateLim
     proofBytes= serialize(proof, data)
     proofBuffer = proofBytes.toBuffer()
     f = 0.uint32
-  debug "serialized proof", proof=proofBytes.toHex()
+  trace "serialized proof", proof=proofBytes.toHex()
 
   let verifyIsSuccessful = verify(rlnInstance, addr proofBuffer, addr f)
   if not verifyIsSuccessful:


### PR DESCRIPTION
This PR:
- Introduces more trace level log which may be helpful for future debugging especially on fleets. 
- Converts some of the debug level logs to trace level mostly for the performance's sake, this change is important especially when the rln-relay protocol gets enabled on the fleets. 
- Changes the default rln-relay content topic.