### PR TITLE
Copy rln lib into wakunode2 docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
 # It is vital to append * to the optional files, otherwise, COPY will throw an error
 # the librln.so may/may not exist depending on whether the rln compiler flag is part of NIM_PARAMS or not
-COPY --from=nim-build /app/vendor/rln/target/debug/librln.so* vendor/rln/target/debug/librln.so
+COPY --from=nim-build /app*/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
 # It is vital to append * to the optional files, otherwise, COPY will throw an error
+# the librln.so may/may not exist depending on whether the rln compiler flag is part of NIM_PARAMS or not
 COPY --from=nim-build /app/vendor/rln/target/debug/librln.so* vendor/rln/target/debug/librln.so
 
 # Copy migration scripts for DB upgrades

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-# COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+# It is vital to append * to the optional files, otherwise, COPY will throw an error
+COPY --from=nim-build /app/vendor/rln/target/debug/librln.so* vendor/rln/target/debug/librln.so
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/


### PR DESCRIPTION
This change is needed to enable rln-relay protocol (which relies on rln lib) on waku test fleets. The rln lib is dynamically linked hence needs to be loaded separately. 

The `Copy` operation for the rln lib is made optional (by appending the `*` at the end of the source file) to account for the cases that the rln lib does not exist e.g., in waku prod fleets which are built with the rln compiler flag turned off hence the rln lib `librln.so` never gets produced. 