### PR TITLE
chore(rln): add cleanrln make rule + docu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,11 @@ clean: | clean-common
 ifneq ($(USE_LIBBACKTRACE), 0)
 	+ $(MAKE) -C vendor/nim-libbacktrace clean $(HANDLE_OUTPUT)
 endif
+	cargo clean --manifest-path vendor/rln/Cargo.toml
+
+# clean the rln build (forces recompile of old crates on next build)
+cleanrln:
+	cargo clean --manifest-path vendor/rln/Cargo.toml
 
 endif # "variables.mk" was not included
 

--- a/docs/tutorial/rln-chat2-live-testnet.md
+++ b/docs/tutorial/rln-chat2-live-testnet.md
@@ -123,3 +123,21 @@ Connecting to storenode: 16Uiu2HAmPLe7Mzm8TsYUubgCAW1aJoeFScxrLj8ppHFivPo97bUZ
 >> /exit
 quitting...
 ```
+
+# Trouble shooting
+
+## compilation error: found possibly newer version of crate
+
+
+If running `make chat2 RLN=true` yields a compile error like this
+
+```
+error[E0460]: found possibly newer version of crate `std` which `sapling_crypto_ce` depends on
+ --> src/circuit/polynomial.rs:1:5
+  |
+1 | use sapling_crypto::bellman::pairing::ff::{Field, PrimeField, PrimeFieldRepr};
+```
+
+run
+
+`make cleanrln` before running `make chat2 RLN=true` again.


### PR DESCRIPTION
During the rln test, I got a compile error due to an outdated crate that did not get recompiled.

This PR 

* adds a trouble shoot section to the docu
* adds a `cleanrln` rule to the Makefile
* adds cleaning the rln crate to the `clean` rule

Rationale for separate `cleanrln` rule:  avoid having to rebuild the whole project.
Later, this could also be added to the `update` rule.


