### PR TITLE
docs: added bug reporting section to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ make test
 
 Examples can be found in the examples folder. For Waku v2, there is a fully
 featured chat example.
+
+### Bugs, Questions & Features
+
+For an inquiry, or if you would like to propose new features, feel free to [open a general issue](https://github.com/status-im/nim-waku/issues/new/).
+
+For bug reports, please [tag your issue with the `bug` label](https://github.com/status-im/nim-waku/issues/new/).
+
+If you believe the reported issue requires critical attention, please [use the `critical` label](https://github.com/status-im/nim-waku/issues/new?labels=critical,bug) to assist with triaging.
+
+To get help, or participate in the conversation, join the [Vac Discord](https://discord.gg/KNj3ctuZvZ) server.


### PR DESCRIPTION
Adds a section to the `README.md` on bug reporting.

I've also added a [`critical`](https://github.com/status-im/nim-waku/labels/critical) label, which can be used on high-priority issues to assist with triaging. We could also consider adding a special column to [the project board](https://github.com/status-im/nim-waku/projects/1) to increase visibility of new critical issues/bug reports.