### PR TITLE
fix(discv5): info print ENR containing discv5 udp port

### DIFF
--- a/waku/v2/node/wakunode2.nim
+++ b/waku/v2/node/wakunode2.nim
@@ -893,6 +893,7 @@ proc startDiscv5*(node: WakuNode): Future[bool] {.async.} =
     asyncSpawn node.runDiscv5Loop()
 
     debug "Successfully started discovery v5 service"
+    info "Discv5: discoverable ENR ", enr = node.wakuDiscV5.protocol.localNode.record.toURI()
     return true
 
   return false
@@ -928,7 +929,7 @@ proc start*(node: WakuNode) {.async.} =
                 
   ## XXX: this should be /ip4..., / stripped?
   info "Listening on", full = listenStr
-  info "Discoverable ENR ", enr = node.enr.toURI()
+  info "DNS: discoverable ENR ", enr = node.enr.toURI()
 
   ## Update switch peer info with announced addrs
   node.updateSwitchPeerInfo()


### PR DESCRIPTION
This PR addresses #906.

This is a minimal fix printing the actually discoverable ENR managed by the discv5 subsystem.

Wakunode holds another ENR that got printed before.
I will look into consolidating these two ENR instances into one in the future (not critial for now).
This PR should be a minimal fix solving this `citical` issue.

(successfully tested setting up a local fleet using the printed ENR)
