### PR TITLE
Revert "Copy rln lib into wakunode2 docker container"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,7 @@ RUN ln -s /usr/lib/libpcre.so /usr/lib/libpcre.so.3
 COPY --from=nim-build /app/build/$MAKE_TARGET /usr/local/bin/
 
 # If rln enabled: fix for 'Error loading shared library vendor/rln/target/debug/librln.so: No such file or directory'
-# It is vital to append * to the optional files, otherwise, COPY will throw an error
-# the librln.so may/may not exist depending on whether the rln compiler flag is part of NIM_PARAMS or not
-COPY --from=nim-build /app*/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
+# COPY --from=nim-build /app/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
 
 # Copy migration scripts for DB upgrades
 COPY --from=nim-build /app/waku/v2/node/storage/migration/migrations_scripts/ /app/waku/v2/node/storage/migration/migrations_scripts/


### PR DESCRIPTION
Reverts status-im/nim-waku#909 due to the error it causes on the test fleets https://ci.status.im/job/nim-waku/job/deploy-v2-test/321/execution/node/19/log/

The optional `COPY` that I added in the previous PR using `*` wildcard https://github.com/status-im/nim-waku/pull/909 works fine on my machine with Docker version 19.03.13, though it fails when building the image on the test fleets https://ci.status.im/job/nim-waku/job/deploy-v2-test/321/execution/node/19/log/
> Step 20/25 : COPY --from=nim-build /app*/vendor/rln/target/debug/librln.so vendor/rln/target/debug/librln.so
> COPY failed: no source files were specified

@jakubgs I suspect the error is due to the docker version, which docker version we are using?