### PR TITLE
feat(jsonrpc): add call returning git version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ endif
 # use a separate waku discv5 network with `protocol-id="d5waku"`
 NIM_PARAMS := $(NIM_PARAMS) -d:discv5_protocol_id:d5waku
 
+# git version for JSON RPC call
+GIT_VERSION := "$(shell git describe --abbrev=6 --always --tags)"
+NIM_PARAMS := $(NIM_PARAMS) -d:git_version:\"$(GIT_VERSION)\"
+
 deps: | deps-common nat-libs waku.nims rlnlib
 ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace

--- a/waku/v2/node/jsonrpc/debug_api.nim
+++ b/waku/v2/node/jsonrpc/debug_api.nim
@@ -8,6 +8,9 @@ import
 logScope:
   topics = "debug api"
 
+const 
+  git_version {.strdefine.} = "n/a"
+
 proc installDebugApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
 
   ## Debug API version 1 definitions
@@ -17,3 +20,10 @@ proc installDebugApiHandlers*(node: WakuNode, rpcsrv: RpcServer) =
     debug "get_waku_v2_debug_v1_info"
 
     return node.info()
+
+  rpcsrv.rpc("get_waku_v2_debug_v1_version") do() -> string:
+    ## Returns information about WakuNode
+    debug "get_waku_v2_debug_v1_version"
+
+    return git_version
+


### PR DESCRIPTION
This PR addresses #859.

There are other ways of getting access to the git version number from within Nim.
This requires minimal changes and no further build deps.

The current format is simple, just returing a single string of the form `<tag>-<commit-hash>` if there is a tag for the respective commit hash. (See output of `git describe --abbrev=6 --always --tags`).
If desired, I could split it into the format that is given as an example in the issue.
Either by

* calling `git describe` twice during `make`
* splitting the string in Nim

Alternatively, we could also print the most recent tag on any branch (this would require calling `git describe` twice).
Right now, this might be confusing, because we only have tags up to v0.6.

I chose to introduce a new call `get_waku_v2_debug_v1_version`, because `get_waku_v2_debug_v1_info` returns `node.info()` and making the git-version part of `WakuInfo` felt off.

If you agree with this implementation, I will add the call to the docs.

## TODO:

- [ ] add docs