### PR TITLE
chore: bumps up the alpine version to 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BUILD IMAGE --------------------------------------------------------
 
-FROM alpine:3.12 AS nim-build
+FROM alpine:3.15 AS nim-build
 
 ARG NIM_PARAMS
 ARG MAKE_TARGET=wakunode2
@@ -22,7 +22,7 @@ RUN make -j$(nproc) $MAKE_TARGET NIM_PARAMS="$NIM_PARAMS"
 
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM alpine:3.12
+FROM alpine:3.15
 
 ARG MAKE_TARGET=wakunode2
 


### PR DESCRIPTION
The cargo version in alpine 3.12 is old and causes some compile-time errors for the rln lib.  This PR is to bump the version up to 3.15.


Would there be any issue if we use the `latest` tag for the alpine image so that we always use the latest version? @jakubgs 