### PR TITLE
fix: release assets do not work

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Install dependencies
         run: |
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update 
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" LOG_LEVEL=TRACE wakunode1
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" LOG_LEVEL=TRACE wakunode2
-          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" LOG_LEVEL=TRACE chat2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false wakunode1
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false wakunode2
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" CI=false chat2
           tar -cvzf nim-waku-${{ matrix.platform }}.tar.gz ./build/
 
       - name: Upload asset


### PR DESCRIPTION
Fixes release assets not working.

The release asset were built using a Github Action, which sets the `CI` environment variable to `true`. This in turn enables `rln`, which causes the built release asset to require the dynamic rln library when running.

The fix sets `CI` to false.