### PR TITLE
feat(store): vacuum after delete

### DIFF
--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -63,6 +63,11 @@ proc deleteOldest(db: WakuMessageStore): MessageStoreResult[void] =
     let numMessages = messageCount(db.database).get() # requires another SELECT query, so only run in debug mode
     debug "Oldest messages deleted from DB due to overflow.", storeCapacity=db.storeCapacity, maxStore=db.storeMaxLoad, deleteWindow=db.deleteWindow, messagesLeft=numMessages
 
+  # reduce the size of the DB file after the delete operation. See: https://www.sqlite.org/lang_vacuum.html
+  let resVacuum = db.database.query("vacuum", proc(s: ptr sqlite3_stmt) = discard)
+  if resVacuum.isErr:
+    return err("vacuum after delete was not successful: " & resVacuum.error)
+
   ok()
 
 proc init*(T: type WakuMessageStore, db: SqliteDatabase, storeCapacity: int = 50000): MessageStoreResult[T] =


### PR DESCRIPTION
This PR addresses the vacuum part of #914

This significantly reduces the size of DB files, especially for DBs from before delete was introduced to the store.