### PR TITLE
feat(store): info message after delete

### DIFF
--- a/waku/v2/node/storage/message/waku_message_store.nim
+++ b/waku/v2/node/storage/message/waku_message_store.nim
@@ -59,9 +59,10 @@ proc deleteOldest(db: WakuMessageStore): MessageStoreResult[void] =
     return err(res.error)
   db.numMessages = db.storeCapacity + db.deleteWindow # sqlite3 DELETE does not return the number of deleted rows; Ideally we would subtract the number of actually deleted messages. We could run a separate COUNT.
 
+  info "Oldest messages deleted from DB due to overflow.", storeCapacity=db.storeCapacity, maxStore=db.storeMaxLoad, deleteWindow=db.deleteWindow
   when defined(debug):
     let numMessages = messageCount(db.database).get() # requires another SELECT query, so only run in debug mode
-    debug "Oldest messages deleted from DB due to overflow.", storeCapacity=db.storeCapacity, maxStore=db.storeMaxLoad, deleteWindow=db.deleteWindow, messagesLeft=numMessages
+    debug "Number of messages left after delete operation.", messagesLeft=numMessages
 
   ok()
 


### PR DESCRIPTION
This PR prints an info message after a delete operation containing related info that is not costly to retrieve.
The number of messages left is still only printed in a debug message, because it takes a additional query to retrieve.