### PR TITLE
feat(noise): add support to ChaChaPoly encryption

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -2,27 +2,27 @@ import
   # Waku v2 tests
   # TODO: enable this when it is altered into a proper waku relay test
   # ./v2/test_waku,
-  #./v2/test_wakunode,
-  #./v2/test_waku_store,
-  #./v2/test_waku_filter,
-  #./v2/test_waku_pagination,
-  #./v2/test_waku_payload,
-  #./v2/test_waku_swap,
-  #./v2/test_message_store,
-  #./v2/test_jsonrpc_waku,
-  #./v2/test_peer_manager,
-  #./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  #./v2/test_waku_bridge,
-  #./v2/test_peer_storage,
-  #./v2/test_waku_keepalive,
-  #./v2/test_migration_utils,
-  #./v2/test_namespacing_utils,
-  #./v2/test_waku_dnsdisc,
-  #./v2/test_waku_discv5,
-  #./v2/test_enr_utils,
-  #./v2/test_waku_store_queue,
-  #./v2/test_pagination_utils,
-  #./v2/test_peer_exchange
+  ./v2/test_wakunode,
+  ./v2/test_waku_store,
+  ./v2/test_waku_filter,
+  ./v2/test_waku_pagination,
+  ./v2/test_waku_payload,
+  ./v2/test_waku_swap,
+  ./v2/test_message_store,
+  ./v2/test_jsonrpc_waku,
+  ./v2/test_peer_manager,
+  ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
+  ./v2/test_waku_bridge,
+  ./v2/test_peer_storage,
+  ./v2/test_waku_keepalive,
+  ./v2/test_migration_utils,
+  ./v2/test_namespacing_utils,
+  ./v2/test_waku_dnsdisc,
+  ./v2/test_waku_discv5,
+  ./v2/test_enr_utils,
+  ./v2/test_waku_store_queue,
+  ./v2/test_pagination_utils,
+  ./v2/test_peer_exchange
   ./v2/test_waku_noise
 
 when defined(rln):

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -2,27 +2,28 @@ import
   # Waku v2 tests
   # TODO: enable this when it is altered into a proper waku relay test
   # ./v2/test_waku,
-  ./v2/test_wakunode,
-  ./v2/test_waku_store,
-  ./v2/test_waku_filter,
-  ./v2/test_waku_pagination,
-  ./v2/test_waku_payload,
-  ./v2/test_waku_swap,
-  ./v2/test_message_store,
-  ./v2/test_jsonrpc_waku,
-  ./v2/test_peer_manager,
-  ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  ./v2/test_waku_bridge,
-  ./v2/test_peer_storage,
-  ./v2/test_waku_keepalive,
-  ./v2/test_migration_utils,
-  ./v2/test_namespacing_utils,
-  ./v2/test_waku_dnsdisc,
-  ./v2/test_waku_discv5,
-  ./v2/test_enr_utils,
-  ./v2/test_waku_store_queue,
-  ./v2/test_pagination_utils,
-  ./v2/test_peer_exchange
+  #./v2/test_wakunode,
+  #./v2/test_waku_store,
+  #./v2/test_waku_filter,
+  #./v2/test_waku_pagination,
+  #./v2/test_waku_payload,
+  #./v2/test_waku_swap,
+  #./v2/test_message_store,
+  #./v2/test_jsonrpc_waku,
+  #./v2/test_peer_manager,
+  #./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
+  #./v2/test_waku_bridge,
+  #./v2/test_peer_storage,
+  #./v2/test_waku_keepalive,
+  #./v2/test_migration_utils,
+  #./v2/test_namespacing_utils,
+  #./v2/test_waku_dnsdisc,
+  #./v2/test_waku_discv5,
+  #./v2/test_enr_utils,
+  #./v2/test_waku_store_queue,
+  #./v2/test_pagination_utils,
+  #./v2/test_peer_exchange
+  ./v2/test_waku_noise
 
 when defined(rln):
   import ./v2/test_waku_rln_relay

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -22,7 +22,7 @@ import
   ./v2/test_enr_utils,
   ./v2/test_waku_store_queue,
   ./v2/test_pagination_utils,
-  ./v2/test_peer_exchange
+  ./v2/test_peer_exchange,
   ./v2/test_waku_noise
 
 when defined(rln):

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -1,0 +1,6 @@
+{.used.}
+
+import
+  testutils/unittests,
+  ../../waku/v2/protocol/waku_noise/noise,
+  ../test_helpers

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -4,3 +4,20 @@ import
   testutils/unittests,
   ../../waku/v2/protocol/waku_noise/noise,
   ../test_helpers
+
+
+procSuite "Waku Noise":
+  
+  let rng = rng()
+
+  test "ChaChaPoly Encryption/Decryption":
+
+    let cipherState = randomChaChaPolyCipherState(rng[])
+
+    let
+      plaintext: seq[byte] = randomSeqByte(rng[], 128)
+      ciphertext: ChaChaPolyCiphertext = encrypt(cipherState, plaintext)
+      dec_ciphertext: seq[byte] = decrypt(cipherState, ciphertext)
+
+    check: 
+      plaintext == dec_ciphertext

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -17,7 +17,7 @@ procSuite "Waku Noise":
     let
       plaintext: seq[byte] = randomSeqByte(rng[], 128)
       ciphertext: ChaChaPolyCiphertext = encrypt(cipherState, plaintext)
-      dec_ciphertext: seq[byte] = decrypt(cipherState, ciphertext)
+      decryptedCiphertext: seq[byte] = decrypt(cipherState, ciphertext)
 
     check: 
-      plaintext == dec_ciphertext
+      plaintext == decryptedCiphertext

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -20,11 +20,8 @@ import libp2p/utility
 import libp2p/errors
 import libp2p/crypto/[crypto, chacha20poly1305]
 
-when defined(libp2p_dump):
-  import libp2p/debugutils
-
 logScope:
-  topics = "nim-waku noise"
+  topics = "wakunoise"
 
 const
   # EmptyKey is a special value which indicates a ChaChaPolyKey has not yet been initialized.

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -27,7 +27,7 @@ logScope:
   topics = "nim-waku noise"
 
 const
-  # Empty is a special value which indicates k has not yet been initialized.
+  # EmptyKey is a special value which indicates a ChaChaPolyKey has not yet been initialized.
   EmptyKey = default(ChaChaPolyKey)
 
 type

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -1,11 +1,10 @@
-## Nim-LibP2P
-## Copyright (c) 2020 Status Research & Development GmbH
-## Licensed under either of
-##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
-##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
-## at your option.
-## This file may not be copied, modified, or distributed except according to
-## those terms.
+# Waku Noise Protocols for Waku Payload Encryption
+## See spec for more details:
+## https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/35
+##
+## Implementation partially inspired by noise-libp2p:
+## https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/secure/noise.nim
+
 
 {.push raises: [Defect].}
 

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -1,0 +1,76 @@
+## Nim-LibP2P
+## Copyright (c) 2020 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+{.push raises: [Defect].}
+
+import std/[oids, options]
+import chronos
+import chronicles
+import bearssl
+import nimcrypto/[utils, sha2, hmac]
+
+import libp2p/stream/[connection]
+import libp2p/protobuf/minprotobuf
+import libp2p/utility
+import libp2p/errors
+import libp2p/crypto/[crypto, chacha20poly1305]
+
+when defined(libp2p_dump):
+  import libp2p/debugutils
+
+logScope:
+  topics = "nim-waku noise"
+
+const
+  # Empty is a special value which indicates k has not yet been initialized.
+  EmptyKey = default(ChaChaPolyKey)
+
+type
+  ChaChaPolyCiphertext* = object
+    data: seq[byte]
+    tag: ChaChaPolyTag
+
+  ChaChaPolyCipherState* = object
+    k*: ChaChaPolyKey
+    nonce*: ChaChaPolyNonce
+    ad*: seq[byte]
+
+  NoiseError* = object of LPError
+  NoiseDecryptTagError* = object of NoiseError
+
+# ChaChaPoly encryption
+proc encrypt*(
+    state: ChaChaPolyCipherState,
+    plaintext: openArray[byte]): ChaChaPolyCiphertext
+    {.noinit, raises: [Defect].} =
+  #TODO: add padding
+  result.data.add plaintext
+  ChaChaPoly.encrypt(state.k, state.nonce, result.tag, result.data, state.ad)
+
+proc decrypt*(
+    state: ChaChaPolyCipherState, 
+    ciphertext: ChaChaPolyCiphertext): seq[byte]
+    {.raises: [Defect, NoiseDecryptTagError].} =
+  var
+    tagIn = ciphertext.tag
+    tagOut: ChaChaPolyTag
+  result = ciphertext.data
+  ChaChaPoly.decrypt(state.k, state.nonce, tagOut, result, state.ad)
+  #TODO: add unpadding
+  trace "decrypt", tagIn = tagIn.shortLog, tagOut = tagOut.shortLog, nonce = state.nonce
+  if tagIn != tagOut:
+    debug "decrypt failed", result = shortLog(result)
+    raise newException(NoiseDecryptTagError, "decrypt tag authentication failed.")
+
+
+proc randomChaChaPolyCipherState*(rng: var BrHmacDrbgContext): ChaChaPolyCipherState =
+  brHmacDrbgGenerate(rng, result.k)
+  brHmacDrbgGenerate(rng, result.nonce)
+  result.ad = newSeq[byte](32)
+  brHmacDrbgGenerate(rng, result.ad)

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -43,15 +43,34 @@ type
   NoiseError* = object of LPError
   NoiseDecryptTagError* = object of NoiseError
 
+#################################################################
+
+# Utilities
+
+# Generates random byte sequences of given size
+proc randomSeqByte*(rng: var BrHmacDrbgContext, size: uint32): seq[byte] =
+  var output = newSeq[byte](size)
+  brHmacDrbgGenerate(rng, output)
+  return output
+
+#################################################################
+
+# ChaChaPoly Symmetric Cipher
+
 # ChaChaPoly encryption
+# It takes a Cipher State (with key, nonce, and associated data) and encrypts a plaintext
 proc encrypt*(
     state: ChaChaPolyCipherState,
     plaintext: openArray[byte]): ChaChaPolyCiphertext
     {.noinit, raises: [Defect].} =
   #TODO: add padding
-  result.data.add plaintext
-  ChaChaPoly.encrypt(state.k, state.nonce, result.tag, result.data, state.ad)
+  var ciphertext: ChaChaPolyCiphertext
+  ciphertext.data.add plaintext
+  ChaChaPoly.encrypt(state.k, state.nonce, ciphertext.tag, ciphertext.data, state.ad)
+  return ciphertext
 
+# ChaChaPoly decryption
+# It takes a Cipher State (with key, nonce, and associated data) and decrypts a ciphertext
 proc decrypt*(
     state: ChaChaPolyCipherState, 
     ciphertext: ChaChaPolyCiphertext): seq[byte]
@@ -59,17 +78,20 @@ proc decrypt*(
   var
     tagIn = ciphertext.tag
     tagOut: ChaChaPolyTag
-  result = ciphertext.data
-  ChaChaPoly.decrypt(state.k, state.nonce, tagOut, result, state.ad)
+  var plaintext = ciphertext.data
+  ChaChaPoly.decrypt(state.k, state.nonce, tagOut, plaintext, state.ad)
   #TODO: add unpadding
   trace "decrypt", tagIn = tagIn.shortLog, tagOut = tagOut.shortLog, nonce = state.nonce
   if tagIn != tagOut:
-    debug "decrypt failed", result = shortLog(result)
+    debug "decrypt failed", plaintext = shortLog(plaintext)
     raise newException(NoiseDecryptTagError, "decrypt tag authentication failed.")
+  return plaintext
 
-
+# Generates a random Cipher Test for testing encryption/decryption
 proc randomChaChaPolyCipherState*(rng: var BrHmacDrbgContext): ChaChaPolyCipherState =
-  brHmacDrbgGenerate(rng, result.k)
-  brHmacDrbgGenerate(rng, result.nonce)
-  result.ad = newSeq[byte](32)
-  brHmacDrbgGenerate(rng, result.ad)
+  var randomCipherState: ChaChaPolyCipherState
+  brHmacDrbgGenerate(rng, randomCipherState.k)
+  brHmacDrbgGenerate(rng, randomCipherState.nonce)
+  randomCipherState.ad = newSeq[byte](32)
+  brHmacDrbgGenerate(rng, randomCipherState.ad)
+  return randomCipherState


### PR DESCRIPTION
This PR adds support to the ChaChaPoly symmetric cipher for encrypting Waku payload message contents. 

Specifically, it adds:
- Encryption/Decryption primitives
- Some unit tests

It partially addresses https://github.com/status-im/nim-waku/issues/881.