### PR TITLE
feat(noise): add support to Waku Payload V2

### DIFF
--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -2,27 +2,27 @@ import
   # Waku v2 tests
   # TODO: enable this when it is altered into a proper waku relay test
   # ./v2/test_waku,
-  #./v2/test_wakunode,
-  #./v2/test_waku_store,
-  #./v2/test_waku_filter,
-  #./v2/test_waku_pagination,
-  #./v2/test_waku_payload,
-  #./v2/test_waku_swap,
-  #./v2/test_message_store,
-  #./v2/test_jsonrpc_waku,
-  #./v2/test_peer_manager,
-  #./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  #./v2/test_waku_bridge,
-  #./v2/test_peer_storage,
-  #./v2/test_waku_keepalive,
-  #./v2/test_migration_utils,
-  #./v2/test_namespacing_utils,
-  #./v2/test_waku_dnsdisc,
-  #./v2/test_waku_discv5,
-  #./v2/test_enr_utils,
-  #./v2/test_waku_store_queue,
-  #./v2/test_pagination_utils,
-  #./v2/test_peer_exchange
+  ./v2/test_wakunode,
+  ./v2/test_waku_store,
+  ./v2/test_waku_filter,
+  ./v2/test_waku_pagination,
+  ./v2/test_waku_payload,
+  ./v2/test_waku_swap,
+  ./v2/test_message_store,
+  ./v2/test_jsonrpc_waku,
+  ./v2/test_peer_manager,
+  ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
+  ./v2/test_waku_bridge,
+  ./v2/test_peer_storage,
+  ./v2/test_waku_keepalive,
+  ./v2/test_migration_utils,
+  ./v2/test_namespacing_utils,
+  ./v2/test_waku_dnsdisc,
+  ./v2/test_waku_discv5,
+  ./v2/test_enr_utils,
+  ./v2/test_waku_store_queue,
+  ./v2/test_pagination_utils,
+  ./v2/test_peer_exchange
   ./v2/test_waku_noise
 
 when defined(rln):

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -2,27 +2,28 @@ import
   # Waku v2 tests
   # TODO: enable this when it is altered into a proper waku relay test
   # ./v2/test_waku,
-  ./v2/test_wakunode,
-  ./v2/test_waku_store,
-  ./v2/test_waku_filter,
-  ./v2/test_waku_pagination,
-  ./v2/test_waku_payload,
-  ./v2/test_waku_swap,
-  ./v2/test_message_store,
-  ./v2/test_jsonrpc_waku,
-  ./v2/test_peer_manager,
-  ./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
-  ./v2/test_waku_bridge,
-  ./v2/test_peer_storage,
-  ./v2/test_waku_keepalive,
-  ./v2/test_migration_utils,
-  ./v2/test_namespacing_utils,
-  ./v2/test_waku_dnsdisc,
-  ./v2/test_waku_discv5,
-  ./v2/test_enr_utils,
-  ./v2/test_waku_store_queue,
-  ./v2/test_pagination_utils,
-  ./v2/test_peer_exchange
+  #./v2/test_wakunode,
+  #./v2/test_waku_store,
+  #./v2/test_waku_filter,
+  #./v2/test_waku_pagination,
+  #./v2/test_waku_payload,
+  #./v2/test_waku_swap,
+  #./v2/test_message_store,
+  #./v2/test_jsonrpc_waku,
+  #./v2/test_peer_manager,
+  #./v2/test_web3, # TODO  remove it when rln-relay tests get finalized
+  #./v2/test_waku_bridge,
+  #./v2/test_peer_storage,
+  #./v2/test_waku_keepalive,
+  #./v2/test_migration_utils,
+  #./v2/test_namespacing_utils,
+  #./v2/test_waku_dnsdisc,
+  #./v2/test_waku_discv5,
+  #./v2/test_enr_utils,
+  #./v2/test_waku_store_queue,
+  #./v2/test_pagination_utils,
+  #./v2/test_peer_exchange
+  ./v2/test_waku_noise
 
 when defined(rln):
   import ./v2/test_waku_rln_relay

--- a/tests/all_tests_v2.nim
+++ b/tests/all_tests_v2.nim
@@ -22,7 +22,7 @@ import
   ./v2/test_enr_utils,
   ./v2/test_waku_store_queue,
   ./v2/test_pagination_utils,
-  ./v2/test_peer_exchange
+  ./v2/test_peer_exchange,
   ./v2/test_waku_noise
 
 when defined(rln):

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -4,7 +4,9 @@ import
   testutils/unittests,
   std/random,
   stew/byteutils,
+  ../../waku/v2/node/waku_payload,
   ../../waku/v2/protocol/waku_noise/noise,
+  ../../waku/v2/protocol/waku_message,
   ../test_helpers
 
 procSuite "Waku Noise":
@@ -43,7 +45,7 @@ procSuite "Waku Noise":
     check: 
       plaintext.toBytes() == decryptedCiphertext
 
-  test "Encrypt and decrypt Noise public keys":
+  test "Noise public keys: encrypt and decrypt a public key":
 
     let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
 
@@ -55,7 +57,7 @@ procSuite "Waku Noise":
     check: 
       noisePublicKey == decryptedPk
 
-  test "Decrypt unencrypted public key":
+  test "Noise public keys: decrypt an unencrypted public key":
 
     let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
 
@@ -66,7 +68,7 @@ procSuite "Waku Noise":
     check:
       noisePublicKey == decryptedPk
 
-  test "Encrypt encrypted public key":
+  test "Noise public keys: encrypt an encrypted public key":
 
     let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
 
@@ -78,7 +80,7 @@ procSuite "Waku Noise":
     check:
       encryptedPk == encryptedPk2
 
-  test "Encrypt, decrypt and decrypt public key":
+  test "Noise public keys: encrypt, decrypt and decrypt a public key":
 
     let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
 
@@ -91,7 +93,7 @@ procSuite "Waku Noise":
     check: 
       decryptedPk == decryptedPk2
 
-  test "Serialize and deserialize unencrypted public key":
+  test "Noise public keys: serialize and deserialize an unencrypted public key":
 
     let 
       noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
@@ -101,7 +103,7 @@ procSuite "Waku Noise":
     check:
       noisePublicKey == deserializedNoisePublicKey
 
-  test "Encrypt, serialize, deserialize and decrypt public key":
+  test "Noise public keys: encrypt, serialize, deserialize and decrypt a public key":
 
     let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
 
@@ -115,41 +117,44 @@ procSuite "Waku Noise":
     check:
       noisePublicKey == decryptedPk
 
-  test "Encode/decode PayloadV2 to byte sequence":
 
-    let 
+  test "PayloadV2: serialize/deserialize PayloadV2 to byte sequence":
+
+    let
+      payload2: PayloadV2 = randomPayloadV2(rng[])
+      serializedPayload = serializePayloadV2(payload2)
+
+    check:
+      serializedPayload.isOk()
+
+    let deserializedPayload = deserializePayloadV2(serializedPayload.get())
+
+    check:
+      deserializedPayload.isOk()
+      payload2 == deserializedPayload.get()
+
+
+  test "PayloadV2: Encode/Decode a Waku Message (version 2) to a PayloadV2":
+    
+    # We encode to a WakuMessage a random PayloadV2
+    let
       payload2 = randomPayloadV2(rng[])
-      encoded_payload = encodeV2(payload2)
-      decoded_payload = decodeV2(encoded_payload.get())
+      msg = encodePayloadV2(payload2)
 
-    check: 
-      payload2 == decoded_payload.get()
+    check:
+      msg.isOk()
 
+    # We create ProtoBuffer from WakuMessage
+    let pb = msg.get().encode()
 
-  test "Encode/Decode Waku2 payload (version 2) - ChaChaPoly Keyinfo":
-    # Encoding
-    let
-      version = 2'u32
-      payload = randomPayloadV2(rng[])
-      encodedPayload = encodePayloadV2(payload)
+    # We decode the WakuMessage from the ProtoBuffer
+    let msgFromPb = WakuMessage.init(pb.buffer)
+    
+    check:
+      msgFromPb.isOk()
 
-    check encodedPayload.isOk()
-
-    let
-      msg = WakuMessage(payload: encodedPayload.get(), version: version)
-      pb =  msg.encode()
-
-    # Decoding
-    let msgDecoded = WakuMessage.init(pb.buffer)
-    check msgDecoded.isOk()
-
-    let
-      cipherState = randomChaChaPolyCipherState(rng[])
-      keyInfo = KeyInfo(kind: ChaChaPolyEncryption, cs: cipherState)
-      decoded = decodePayloadV2(msgDecoded.get(), keyInfo)
+    let decoded = decodePayloadV2(msgFromPb.get())
 
     check:
       decoded.isOk()
-      decoded.get() == payload
-
-  #TODO: add encrypt payload with ChaChaPoly
+      payload2 == decoded.get()

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -1,0 +1,6 @@
+{.used.}
+
+import
+  testutils/unittests,
+  ../../waku/v2/protocol/waku_noise/noise,
+  ../test_helpers

--- a/tests/v2/test_waku_noise.nim
+++ b/tests/v2/test_waku_noise.nim
@@ -3,4 +3,80 @@
 import
   testutils/unittests,
   ../../waku/v2/protocol/waku_noise/noise,
-  ../test_helpers
+  ../test_helpers,
+  std/tables
+
+procSuite "Waku Noise":
+  
+  let rng = rng()
+
+  test "Encrypt -> decrypt public keys":
+
+    let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+
+    let 
+      cs: ChaChaPolyCipherState = randomChaChaPolyCipherState(rng[])
+      enc_pk: NoisePublicKey = encryptNoisePublicKey(cs, noisePublicKey)
+      dec_pk: NoisePublicKey = decryptNoisePublicKey(cs, enc_pk)
+
+    check: 
+      noisePublicKey == dec_pk
+
+  test "Decrypt unencrypted public key":
+
+    let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+
+    let 
+      cs: ChaChaPolyCipherState = randomChaChaPolyCipherState(rng[])
+      dec_pk: NoisePublicKey = decryptNoisePublicKey(cs, noisePublicKey)
+
+    check:
+      noisePublicKey == dec_pk
+
+  test "Encrypt -> encrypt public keys":
+
+    let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+
+    let
+      cs: ChaChaPolyCipherState = randomChaChaPolyCipherState(rng[])
+      enc_pk: NoisePublicKey = encryptNoisePublicKey(cs, noisePublicKey)
+      enc2_pk: NoisePublicKey = encryptNoisePublicKey(cs, enc_pk)
+    
+    check enc_pk == enc2_pk
+
+  test "Encrypt -> decrypt -> decrypt public keys":
+
+    let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+
+    let
+      cs: ChaChaPolyCipherState = randomChaChaPolyCipherState(rng[])
+      enc_pk: NoisePublicKey = encryptNoisePublicKey(cs, noisePublicKey)
+      dec_pk: NoisePublicKey = decryptNoisePublicKey(cs, enc_pk)
+      dec2_pk: NoisePublicKey = decryptNoisePublicKey(cs, dec_pk)
+
+    check: 
+      dec_pk == dec2_pk
+
+  test "Serialize -> deserialize public keys (unencrypted)":
+
+    let 
+      noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+      serializedNoisePublicKey: seq[byte] = serializeNoisePublicKey(noisePublicKey)
+      deserializedNoisePublicKey: NoisePublicKey = intoNoisePublicKey(serializedNoisePublicKey)
+
+    check:
+      noisePublicKey == deserializedNoisePublicKey
+
+  test "Encrypt -> serialize -> deserialize -> decrypt public keys":
+
+    let noisePublicKey: NoisePublicKey = genNoisePublicKey(rng[])
+
+    let 
+      cs: ChaChaPolyCipherState = randomChaChaPolyCipherState(rng[])
+      enc_pk: NoisePublicKey = encryptNoisePublicKey(cs, noisePublicKey)
+      serializedNoisePublicKey: seq[byte] = serializeNoisePublicKey(enc_pk)
+      deserializedNoisePublicKey: NoisePublicKey = intoNoisePublicKey(serializedNoisePublicKey)
+      dec_pk: NoisePublicKey = decryptNoisePublicKey(cs, deserializedNoisePublicKey)
+
+    check:
+      noisePublicKey == dec_pk

--- a/waku/v2/node/waku_payload.nim
+++ b/waku/v2/node/waku_payload.nim
@@ -7,16 +7,12 @@ import
   ../protocol/waku_message,
   ../protocol/waku_noise/noise
 
-import libp2p/crypto/[chacha20poly1305, curve25519]
-
-
 export whisper_types, keys, options
 
 type
   KeyKind* = enum
     Symmetric
     Asymmetric
-    ChaChaPolyEncryption
     None
 
   KeyInfo* = object
@@ -25,8 +21,6 @@ type
       symKey*: SymKey
     of Asymmetric:
       privKey*: PrivateKey
-    of ChaChaPolyEncryption:
-      cs*: ChaChaPolyCipherState
     of None:
       discard
 
@@ -86,27 +80,34 @@ proc encode*(payload: Payload, version: uint32, rng: var BrHmacDrbgContext):
     return err("Unsupported WakuMessage version")
 
 
-proc decodePayloadV2*(message: WakuMessage, keyInfo: KeyInfo):
-    WakuResult[PayloadV2] =
+# Decodes a WakuMessage to a PayloadV2
+# Currently, this is just a wrapper over deserializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
+proc decodePayloadV2*(message: WakuMessage): WakuResult[PayloadV2] 
+  {.raises: [Defect, NoiseMalformedHandshake, NoisePublicKeyError].} =
+  # We check message version (only 2 is supported in this proc)
   case message.version
   of 2:
-    case keyInfo.kind
-    of ChaChaPolyEncryption:
-      let decoded = decodeV2(message.payload)#, keyInfo.cs)
-      if decoded.isSome():
-        return ok(decoded.get())
-      else:
-        return err("Couldn't decrypt using ChaChaPoly Cipher State")
+    # We attempt to decode the WakuMessage payload
+    let deserializedPayload2 = deserializePayloadV2(message.payload)
+    if deserializedPayload2.isOk():
+      return ok(deserializedPayload2.get())
     else:
-      discard
+      return err("Failed to decode WakuMessage")
   else:
-    return err("Key info doesn't match v2 payloads")
+    return err("Wrong message version while decoding payload")
 
 
-proc encodePayloadV2*(payload: PayloadV2):
-    WakuResult[seq[byte]] =
-  let encoded = encodeV2(payload)
-  if encoded.isSome():
-    return ok(encoded.get())
-  else:
-    return err("Couldn't encode the payload")
+# Encodes a PayloadV2 to a WakuMessage
+# Currently, this is just a wrapper over serializePayloadV2 and encryption/decryption is done on top (no KeyInfo)
+proc encodePayloadV2*(payload2: PayloadV2): WakuResult[WakuMessage] 
+  {.raises: [Defect, NoiseMalformedHandshake, NoisePublicKeyError].} =
+
+  # We attempt to encode the PayloadV2
+  let serializedPayload2 = serializePayloadV2(payload2)
+  if not serializedPayload2.isOk():
+    return err("Failed to encode PayloadV2")
+
+  # If successful, we create and return a WakuMessage 
+  let msg = WakuMessage(payload: serializedPayload2.get(), version: 2)
+  
+  return ok(msg)

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -9,17 +9,22 @@
 
 {.push raises: [Defect].}
 
-import std/[oids, options]
+import std/[oids, options, tables]
 import chronos
 import chronicles
 import bearssl
+import strutils
+import stew/[endians2]
 import nimcrypto/[utils, sha2, hmac]
 
 import libp2p/stream/[connection]
+import libp2p/peerid
+import libp2p/peerinfo
 import libp2p/protobuf/minprotobuf
 import libp2p/utility
 import libp2p/errors
-import libp2p/crypto/[crypto, chacha20poly1305]
+import libp2p/crypto/[crypto, chacha20poly1305, curve25519]
+
 
 when defined(libp2p_dump):
   import libp2p/debugutils
@@ -30,8 +35,20 @@ logScope:
 const
   # Empty is a special value which indicates k has not yet been initialized.
   EmptyKey = default(ChaChaPolyKey)
+  NonceMax = uint64.high - 1 # max is reserved
+  NoiseSize = 32
+  MaxPlainSize = int(uint16.high - NoiseSize - ChaChaPolyTag.len)
+
 
 type
+  KeyPair* = object
+    privateKey: Curve25519Key
+    publicKey: Curve25519Key
+
+  NoisePublicKey* = object
+    flag: uint8
+    pk: seq[byte]
+
   ChaChaPolyCiphertext* = object
     data: seq[byte]
     tag: ChaChaPolyTag
@@ -42,7 +59,16 @@ type
     ad*: seq[byte]
 
   NoiseError* = object of LPError
+  NoiseHandshakeError* = object of NoiseError
   NoiseDecryptTagError* = object of NoiseError
+  NoiseNonceMaxError* = object of NoiseError # drop connection on purpose
+  NoisePublicKeyError* = object of NoiseError
+  NoiseMalformedHandshake* = object of NoiseError
+
+
+
+#################################################################
+
 
 # ChaChaPoly encryption
 proc encrypt*(
@@ -74,3 +100,71 @@ proc randomChaChaPolyCipherState*(rng: var BrHmacDrbgContext): ChaChaPolyCipherS
   brHmacDrbgGenerate(rng, result.nonce)
   result.ad = newSeq[byte](32)
   brHmacDrbgGenerate(rng, result.ad)
+
+
+#################################################################
+
+
+# Utility
+
+proc genKeyPair*(rng: var BrHmacDrbgContext): KeyPair =
+  result.privateKey = Curve25519Key.random(rng)
+  result.publicKey = result.privateKey.public()
+
+
+# Public keys serializations/encryption
+
+proc `==`(k1, k2: NoisePublicKey): bool =
+  result = (k1.flag == k2.flag) and (k1.pk == k2.pk)
+  
+
+proc keyPairToNoisePublicKey*(keyPair: KeyPair): NoisePublicKey =
+  result.flag = 0
+  result.pk = getBytes(keyPair.publicKey)
+
+
+proc genNoisePublicKey*(rng: var BrHmacDrbgContext): NoisePublicKey =
+  let keyPair: KeyPair = genKeyPair(rng)
+  result.flag = 0
+  result.pk = getBytes(keyPair.publicKey)
+
+proc serializeNoisePublicKey*(noisePublicKey: NoisePublicKey): seq[byte] =
+  result.add noisePublicKey.flag
+  result.add noisePublicKey.pk
+
+#TODO: strip pk_auth if pk not encrypted
+proc intoNoisePublicKey*(serializedNoisePublicKey: seq[byte]): NoisePublicKey =
+  result.flag = serializedNoisePublicKey[0]
+  assert result.flag == 0 or result.flag == 1
+  result.pk = serializedNoisePublicKey[1..<serializedNoisePublicKey.len]
+
+# Public keys encryption/decryption
+
+proc encryptNoisePublicKey*(cs: ChaChaPolyCipherState, noisePublicKey: NoisePublicKey): NoisePublicKey
+  {.raises: [Defect, NoiseNonceMaxError].} =
+  if cs.k != EmptyKey and noisePublicKey.flag == 0:
+    let enc_pk = encrypt(cs, noisePublicKey.pk)
+    result.flag = 1
+    result.pk = enc_pk.data
+    result.pk.add enc_pk.tag
+  else:
+    result = noisePublicKey
+
+
+proc decryptNoisePublicKey*(cs: ChaChaPolyCipherState, noisePublicKey: NoisePublicKey): NoisePublicKey
+  {.raises: [Defect, NoiseDecryptTagError].} =
+  if cs.k != EmptyKey and noisePublicKey.flag == 1:
+    #let ciphertext = ChaChaPolyCiphertext(data: noisePublicKey.pk, tag: noisePublicKey.pk_auth)
+    let pk_len = noisePublicKey.pk.len - ChaChaPolyTag.len
+    let pk = noisePublicKey.pk[0..<pk_len]
+    let pk_auth = intoChaChaPolyTag(noisePublicKey.pk[pk_len..<pk_len+ChaChaPolyTag.len])
+    let ciphertext = ChaChaPolyCiphertext(data: pk, tag: pk_auth) 
+    result.pk = decrypt(cs, ciphertext)
+    result.flag = 0
+  else:
+    if cs.k == EmptyKey:
+      debug "No key in cipher state."
+    if noisePublicKey.flag == 0:
+      debug "Public key is not encrypted."
+    debug "Public key is left unchanged"
+    result = noisePublicKey

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -1,11 +1,9 @@
-## Nim-LibP2P
-## Copyright (c) 2020 Status Research & Development GmbH
-## Licensed under either of
-##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
-##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
-## at your option.
-## This file may not be copied, modified, or distributed except according to
-## those terms.
+# Waku Noise Protocols for Waku Payload Encryption
+## See spec for more details:
+## https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/35
+##
+## Implementation partially inspired by noise-libp2p:
+## https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/secure/noise.nim
 
 {.push raises: [Defect].}
 

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -7,11 +7,10 @@
 
 {.push raises: [Defect].}
 
-import std/[options, tables]
+import std/[options, tables, strutils]
 import chronos
 import chronicles
 import bearssl
-import strutils
 import stew/[results, endians2]
 import nimcrypto/[utils, sha2, hmac]
 

--- a/waku/v2/protocol/waku_noise/noise.nim
+++ b/waku/v2/protocol/waku_noise/noise.nim
@@ -1,0 +1,76 @@
+## Nim-LibP2P
+## Copyright (c) 2020 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+{.push raises: [Defect].}
+
+import std/[oids, options]
+import chronos
+import chronicles
+import bearssl
+import nimcrypto/[utils, sha2, hmac]
+
+import libp2p/stream/[connection]
+import libp2p/protobuf/minprotobuf
+import libp2p/utility
+import libp2p/errors
+import libp2p/crypto/[crypto, chacha20poly1305]
+
+when defined(libp2p_dump):
+  import libp2p/debugutils
+
+logScope:
+  topics = "nim-waku noise"
+
+const
+  # Empty is a special value which indicates k has not yet been initialized.
+  EmptyKey = default(ChaChaPolyKey)
+
+type
+  ChaChaPolyCiphertext* = object
+    data: seq[byte]
+    tag: ChaChaPolyTag
+
+  ChaChaPolyCipherState* = object
+    k*: ChaChaPolyKey
+    nonce*: ChaChaPolyNonce
+    ad*: seq[byte]
+
+  NoiseError* = object of LPError
+  NoiseDecryptTagError* = object of NoiseError
+
+# ChaChaPoly encryption
+proc encrypt*(
+    state: ChaChaPolyCipherState,
+    plaintext: openArray[byte]): ChaChaPolyCiphertext
+    {.noinit, raises: [Defect].} =
+  #TODO: add padding
+  result.data.add plaintext
+  ChaChaPoly.encrypt(state.k, state.nonce, result.tag, result.data, state.ad)
+
+proc decrypt*(
+    state: ChaChaPolyCipherState, 
+    ciphertext: ChaChaPolyCiphertext): seq[byte]
+    {.raises: [Defect, NoiseDecryptTagError].} =
+  var
+    tagIn = ciphertext.tag
+    tagOut: ChaChaPolyTag
+  result = ciphertext.data
+  ChaChaPoly.decrypt(state.k, state.nonce, tagOut, result, state.ad)
+  #TODO: add unpadding
+  trace "decrypt", tagIn = tagIn.shortLog, tagOut = tagOut.shortLog, nonce = state.nonce
+  if tagIn != tagOut:
+    debug "decrypt failed", result = shortLog(result)
+    raise newException(NoiseDecryptTagError, "decrypt tag authentication failed.")
+
+
+proc randomChaChaPolyCipherState*(rng: var BrHmacDrbgContext): ChaChaPolyCipherState =
+  brHmacDrbgGenerate(rng, result.k)
+  brHmacDrbgGenerate(rng, result.nonce)
+  result.ad = newSeq[byte](32)
+  brHmacDrbgGenerate(rng, result.ad)


### PR DESCRIPTION
This PR introduces data structures and procedures to process Waku Message Payload with version 2. 

Specifically, it adds:
- Encode/decode payload functions
- Some unit tests

Implementation of Waku Payload with version 2 partially follows [35/WAKU2-NOISE](https://rfc.vac.dev/spec/35/#specification) (RFC will be updated accordingly once this PR is merged).

This PR extends https://github.com/status-im/nim-waku/pull/931 (which in turn extends https://github.com/status-im/nim-waku/pull/930) and partially addresses https://github.com/status-im/nim-waku/issues/881.